### PR TITLE
Prepend HTTP protocol to default Trufflepig endpoint

### DIFF
--- a/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
@@ -7,7 +7,7 @@ import ContractHttpLoader from './ContractHttpLoader';
 import type { TruffleArtifact, ConstructorArgs } from '../flowtypes';
 
 const DEFAULT_ENDPOINT =
-  '//127.0.0.1:3030/contracts?name=%%NAME%%&address=%%ADDRESS%%&version=%%VERSION%%'; // eslint-disable-line max-len
+  'http://127.0.0.1:3030/contracts?name=%%NAME%%&address=%%ADDRESS%%&version=%%VERSION%%'; // eslint-disable-line max-len
 
 function trufflepigParse(
   { abi = [], bytecode, networks = {} }: TruffleArtifact = {},


### PR DESCRIPTION
## Description

This is a fix that addresses #85. When using `TrufflepigLoader` with `node-fetch` on Node (`9.11.1`), the `DEFAULT_ENDPOINT` URL will cause an error due to the missing protocol. Prepending `http:` to that fixed it.

Contributes to #85.
