### PR TITLE
Fix ColonyClient params

### DIFF
--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -232,10 +232,11 @@ export default class ColonyNetworkClient extends ContractClient {
     return contractAddress;
   }
   async getColonyClientByAddress(contractAddress: string) {
-    const colonyClient = new this.constructor.ColonyClient(
-      { adapter: this.adapter, networkClient: this },
-      { contractAddress },
-    );
+    const colonyClient = new this.constructor.ColonyClient({
+      adapter: this.adapter,
+      networkClient: this,
+      query: { contractAddress },
+    });
     return colonyClient.init();
   }
   async getColonyClient({ key, id }: { key?: string, id?: number } = {}) {

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -161,15 +161,13 @@ describe('ColonyNetworkClient', () => {
 
     expect(colonyClientSpy).toHaveBeenCalled();
     expect(colonyClient).toBeInstanceOf(ColonyClient);
-    expect(Mock).toHaveBeenCalledWith(
-      {
-        adapter: networkClient.adapter,
-        networkClient,
-      },
-      {
+    expect(Mock).toHaveBeenCalledWith({
+      adapter: networkClient.adapter,
+      networkClient,
+      query: {
         contractAddress: colonyAddress,
       },
-    );
+    });
     expect(colonyClient.init).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Description

There was another bug introduced in #95 which I (and Flow, and the tests) didn't catch 🙈

The `ContractClient` class constructor (which `ColonyClient` is derived from) accepts one object parameter, not two; the query to load the contract was being passed in as a second query, instead of as a property of the object.

This PR fixes that and amends the tests.
