### PR TITLE
Remove errant `events` property in `SendOptions` flow type

### DIFF
--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -22,7 +22,6 @@ export type ParamTypePair = [string, ParamTypes];
 export type ParamTypePairs = Array<ParamTypePair>;
 
 export type SendOptions = {
-  events?: EventHandlers,
   estimate: boolean,
   timeoutMs: number,
   waitForMining: boolean,


### PR DESCRIPTION
## Description (Required)

Removes the `events` property in the `SendOptions` flow type. I'm not sure how this property ended up here, but it doesn't belong in the send options. It is probably ignored by the underlying adapter, but let's remove it anyway.
