### PR TITLE
Add `isomorphic-fetch` package

### DIFF
--- a/packages/colony-js-contract-loader-http/package.json
+++ b/packages/colony-js-contract-loader-http/package.json
@@ -31,7 +31,10 @@
         "type": "git",
         "url": "git+https://github.com/JoinColony/colonyJS.git"
     },
-    "contributors": ["Christian Maniewski <chris@colony.io>", "James Lefrère <james@colony.io>"],
+    "contributors": [
+        "Christian Maniewski <chris@colony.io>",
+        "James Lefrère <james@colony.io>"
+    ],
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/JoinColony/colonyJS/issues"
@@ -39,7 +42,8 @@
     "homepage": "https://github.com/JoinColony/colonyJS#readme",
     "dependencies": {
         "@colony/colony-js-contract-loader": "^1.0.0",
-        "browser-assert": "^1.2.1"
+        "browser-assert": "^1.2.1",
+        "isomorphic-fetch": "^2.2.1"
     },
     "devDependencies": {
         "babel-cli": "^6.26.0",

--- a/packages/colony-js-contract-loader-http/src/loaders/ContractHttpLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/ContractHttpLoader.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import assert from 'browser-assert';
+import 'isomorphic-fetch';
 
 import type {
   ContractDefinition,

--- a/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import 'isomorphic-fetch';
 import type { Query } from '@colony/colony-js-contract-loader';
 
 import ContractHttpLoader from './ContractHttpLoader';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,6 +4837,10 @@ lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
## Description

This PR simply adds `isomorphic-fetch` so that the library works with node. This has been tested locally (node 9.5.0) and seems to work fine 🙂 

## Deps

**New dependencies**:

- `isomorphic-fetch` : https://github.com/matthew-andrews/isomorphic-fetch

Resolves #85 
