### PR TITLE
Reinstate correct param name for addDomain

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -595,7 +595,7 @@ export default class ColonyClient extends ContractClient {
       },
     };
     this.addSender('addDomain', {
-      input: [['domainId', 'number']],
+      input: [['parentSkillId', 'number']],
       eventHandlers: {
         success: { SkillAdded },
       },


### PR DESCRIPTION
## Description

`ColonyClient.addDomain` has the correct parameter name in the flow typing, but not in the `input` property when declaring it. This change was made in a previous PR but somehow it got removed (probably a bad rebase, probably a late night mistake). 
