### PR TITLE
Fix indentation on ‘Get Started’ code sample

### DIFF
--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -48,16 +48,15 @@ You'll need to either create a new colony or talk to an existing one.
 ```js
 // To create a new cool colony:
 const colonyData = {
-    name: 'MyCoolColony', // Unique name for the colony
-    tokenAddress: '0xf000000000000000000000000000000000000000', // Address of the colony's native token
-  };
+  name: 'MyCoolColony', // Unique name for the colony
+  tokenAddress: '0xf000000000000000000000000000000000000000', // Address of the colony's native token
+};
 
-  // Create a cool Colony!
-  const { eventData: { colonyId }} = await networkClient.createColony.send(colonyData);
+// Create a cool Colony!
+const { eventData: { colonyId }} = await networkClient.createColony.send(colonyData);
 
-  // Congrats, you've created a Colony!
-  console.log(colonyId);
-
+// Congrats, you've created a Colony!
+console.log(colonyId);
 ```
 
 ```js


### PR DESCRIPTION
## Description

The Colony creation code sample has been partially indented one level too much.
