### PR TITLE
Add 'bignumber' parameter type

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -146,7 +146,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|amount|number|Amount of specified tokens to payout for that task and a role|
+|amount|BigNumber|Amount of specified tokens to payout for that task and a role|
 
 ### `getTaskRole.call({ taskId, role })`
 
@@ -224,7 +224,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|balance|number|Balance for token `token` in pot `potId`|
+|balance|BigNumber|Balance for token `token` in pot `potId`|
 
 ### `getNonRewardPotsTotal.call({ address })`
 
@@ -242,7 +242,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|total|number|All tokens that are not within the colony's `rewards` pot.|
+|total|BigNumber|All tokens that are not within the colony's `rewards` pot.|
 
 ### `getRewardPayoutInfo.call({ payoutId })`
 
@@ -261,11 +261,11 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |blockNumber|number|Block number at the time of creation|
-|remainingTokenAmount|number|Remaining (unclaimed) amount of tokens|
+|remainingTokenAmount|BigNumber|Remaining (unclaimed) amount of tokens|
 |reputationRootHash|string|Reputation root hash at the time of creation|
 |tokenAddress|Address|Token address|
-|totalTokenAmountForRewardPayout|number|Total amount of tokens taken aside for reward payout|
-|totalTokens|number|Total colony tokens at the time of creation|
+|totalTokenAmountForRewardPayout|BigNumber|Total amount of tokens taken aside for reward payout|
+|totalTokens|BigNumber|Total colony tokens at the time of creation|
 
 ### `getToken.call()`
 
@@ -567,7 +567,7 @@ Move a given amount of `token` funds from one pot to another
 |---|---|---|
 |fromPot|number|Origin pot Id|
 |toPot|number|Destination pot Id|
-|amount|number|Amount of funds to move|
+|amount|BigNumber|Amount of funds to move|
 |address|Address|Address of the token contract|
 
 **Returns**
@@ -687,7 +687,7 @@ Sets the payout given to the EVALUATOR role when the task is finalized.
 |---|---|---|
 |taskId|number|Integer taskId|
 |token|Address|Address of the token's ERC20 contract.|
-|amount|number|Amount to be paid.|
+|amount|BigNumber|Amount to be paid.|
 
 **Returns**
 
@@ -705,7 +705,7 @@ Sets the payout given to the MANAGER role when the task is finalized.
 |---|---|---|
 |taskId|number|Integer taskId|
 |token|Address|Address of the token's ERC20 contract.|
-|amount|number|Amount to be paid.|
+|amount|BigNumber|Amount to be paid.|
 
 **Returns**
 
@@ -723,7 +723,7 @@ Sets the payout given to the WORKER role when the task is finalized.
 |---|---|---|
 |taskId|number|Integer taskId|
 |token|Address|Address of the token's ERC20 contract.|
-|amount|number|Amount to be paid.|
+|amount|BigNumber|Amount to be paid.|
 
 **Returns**
 

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -209,7 +209,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|amount|number|amount|
+|amount|BigNumber|amount|
 |colony|Address|Address of the colony|
 |nPreviousUpdates|number|number of previous updates|
 |nUpdates|number|number of updates|
@@ -277,7 +277,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|balance|number|Amount of staked CLNY|
+|balance|BigNumber|Amount of staked CLNY|
 
 ## Senders
 
@@ -309,7 +309,7 @@ Allow a reputation miner to stake an amount of CLNY tokens, which is required be
 
 |Argument|Type|Description|
 |---|---|---|
-|amount|number|Amount of CLNY to stake|
+|amount|BigNumber|Amount of CLNY to stake|
 
 **Returns**
 
@@ -362,7 +362,7 @@ Allow a user who has staked CLNY to withdraw their stake
 
 |Argument|Type|Description|
 |---|---|---|
-|amount|number|Amount of CLNY to withdraw from stake|
+|amount|BigNumber|Amount of CLNY to withdraw from stake|
 
 **Returns**
 

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -11,6 +11,7 @@ const TYPES = {
   NumberTypeAnnotation: 'number',
   Date: 'Date',
   Address: 'Address',
+  BigNumber: 'BigNumber',
 };
 
 const ast = parser.parse(

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -101,7 +101,7 @@ export default class ColonyClient extends ContractClient {
       token: Address, // Address of the token's contract
     },
     {
-      amount: number, // Amount of specified tokens to payout for that task and a role
+      amount: BigNumber, // Amount of specified tokens to payout for that task and a role
     },
     ColonyClient,
   >;
@@ -155,7 +155,7 @@ export default class ColonyClient extends ContractClient {
       token: Address, // Address of the token's contract
     },
     {
-      balance: number, // Balance for token `token` in pot `potId`
+      balance: BigNumber, // Balance for token `token` in pot `potId`
     },
     ColonyClient,
   >;
@@ -167,7 +167,7 @@ export default class ColonyClient extends ContractClient {
       address: Address, // Address of the token's contract (token in question)
     },
     {
-      total: number, // All tokens that are not within the colony's `rewards` pot.
+      total: BigNumber, // All tokens that are not within the colony's `rewards` pot.
     },
     ColonyClient,
   >;
@@ -180,11 +180,11 @@ export default class ColonyClient extends ContractClient {
     },
     {
       blockNumber: number, // Block number at the time of creation
-      remainingTokenAmount: number, // Remaining (unclaimed) amount of tokens
+      remainingTokenAmount: BigNumber, // Remaining (unclaimed) amount of tokens
       reputationRootHash: string, // Reputation root hash at the time of creation
       tokenAddress: Address, // Token address
-      totalTokenAmountForRewardPayout: number, // Total amount of tokens taken aside for reward payout
-      totalTokens: number, // Total colony tokens at the time of creation
+      totalTokenAmountForRewardPayout: BigNumber, // Total amount of tokens taken aside for reward payout
+      totalTokens: BigNumber, // Total colony tokens at the time of creation
     },
     ColonyClient,
   >;
@@ -284,7 +284,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
       token: Address, // Address of the token's ERC20 contract.
-      amount: number, // Amount to be paid.
+      amount: BigNumber, // Amount to be paid.
     },
     {},
     ColonyClient,
@@ -296,7 +296,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
       token: Address, // Address of the token's ERC20 contract.
-      amount: number, // Amount to be paid.
+      amount: BigNumber, // Amount to be paid.
     },
     {},
     ColonyClient,
@@ -308,7 +308,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
       token: Address, // Address of the token's ERC20 contract.
-      amount: number, // Amount to be paid.
+      amount: BigNumber, // Amount to be paid.
     },
     {},
     ColonyClient,
@@ -444,7 +444,7 @@ export default class ColonyClient extends ContractClient {
     {
       fromPot: number, // Origin pot Id
       toPot: number, // Destination pot Id
-      amount: number, // Amount of funds to move
+      amount: BigNumber, // Amount of funds to move
       address: Address, // Address of the token contract
     },
     {},
@@ -519,7 +519,7 @@ export default class ColonyClient extends ContractClient {
 
     // Callers
     this.addCaller('generateSecret', {
-      input: [['salt', 'string'], ['value', 'number']],
+      input: [['salt', 'string'], ['value', 'bignumber']],
       output: [['secret', 'string']],
     });
     this.addCaller('getDomainCount', {
@@ -534,19 +534,19 @@ export default class ColonyClient extends ContractClient {
     });
     this.addCaller('getNonRewardPotsTotal', {
       input: [['address', 'address']],
-      output: [['total', 'number']],
+      output: [['total', 'bignumber']],
     });
     this.addCaller('getPotBalance', {
       input: [['potId', 'number'], ['token', 'address']],
-      output: [['balance', 'number']],
+      output: [['balance', 'bignumber']],
     });
     this.addCaller('getRewardPayoutInfo', {
       input: [['payoutId'], 'number'],
       output: [
         ['reputationRootHash', 'string'],
-        ['totalTokens', 'number'],
-        ['totalTokenAmountForRewardPayout', 'number'],
-        ['remainingTokenAmount', 'number'],
+        ['totalTokens', 'bignumber'],
+        ['totalTokenAmountForRewardPayout', 'bignumber'],
+        ['remainingTokenAmount', 'bignumber'],
         ['tokenAddress', 'address'],
         ['blockNumber', 'number'],
       ],
@@ -556,7 +556,7 @@ export default class ColonyClient extends ContractClient {
     });
     this.addCaller('getTaskPayout', {
       input: [['taskId', 'number'], ['role', 'number'], ['token', 'address']],
-      output: [['amount', 'number']],
+      output: [['amount', 'bignumber']],
     });
     this.addCaller('getTaskRole', {
       input: [['taskId', 'number'], ['role', 'number']],
@@ -641,16 +641,16 @@ export default class ColonyClient extends ContractClient {
       input: [['payoutId', 'number']],
     });
     this.addSender('mintTokens', {
-      input: [['amount', 'number']],
+      input: [['amount', 'bignumber']],
     });
     this.addSender('mintTokensForColonyNetwork', {
-      input: [['amount', 'number']],
+      input: [['amount', 'bignumber']],
     });
     this.addSender('moveFundsBetweenPots', {
       input: [
         ['fromPot', 'number'],
         ['toPot', 'number'],
-        ['amount', 'number'],
+        ['amount', 'bignumber'],
         ['address', 'address'],
       ],
     });
@@ -708,15 +708,15 @@ export default class ColonyClient extends ContractClient {
     makeExecuteTaskChange('setTaskDueDate', [['dueDate', 'number']]);
     makeExecuteTaskChange('setTaskWorkerPayout', [
       ['token', 'address'],
-      ['amount', 'number'],
+      ['amount', 'bignumber'],
     ]);
     makeExecuteTaskChange('setTaskManagerPayout', [
       ['token', 'address'],
-      ['amount', 'number'],
+      ['amount', 'nubignumbermber'],
     ]);
     makeExecuteTaskChange('setTaskEvaluatorPayout', [
       ['token', 'address'],
-      ['amount', 'number'],
+      ['amount', 'bignumber'],
     ]);
   }
 }

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -88,7 +88,7 @@ export default class ColonyNetworkClient extends ContractClient {
       id: number, // The reputation log members array index of the entry to get
     },
     {
-      amount: number, // amount
+      amount: BigNumber, // amount
       colony: Address, // Address of the colony
       nPreviousUpdates: number, // number of previous updates
       nUpdates: number, // number of updates
@@ -138,7 +138,7 @@ export default class ColonyNetworkClient extends ContractClient {
       user: Address, // Address of the user
     },
     {
-      balance: number, // Amount of staked CLNY
+      balance: BigNumber, // Amount of staked CLNY
     },
     ColonyNetworkClient,
   >;
@@ -160,7 +160,7 @@ export default class ColonyNetworkClient extends ContractClient {
   */
   deposit: ColonyNetworkClient.Sender<
     {
-      amount: number, // Amount of CLNY to stake
+      amount: BigNumber, // Amount of CLNY to stake
     },
     {},
     ColonyNetworkClient,
@@ -195,7 +195,7 @@ export default class ColonyNetworkClient extends ContractClient {
   */
   withdraw: ColonyNetworkClient.Sender<
     {
-      amount: number, // Amount of CLNY to withdraw from stake
+      amount: BigNumber, // Amount of CLNY to withdraw from stake
     },
     {},
     ColonyNetworkClient,
@@ -294,7 +294,7 @@ export default class ColonyNetworkClient extends ContractClient {
     });
     this.addCaller('getStakedBalance', {
       input: [['user', 'address']],
-      output: [['balance', 'number']],
+      output: [['balance', 'bignumber']],
     });
     this.addCaller('getParentSkillId', {
       input: [['skillId', 'number'], ['parentSkillIndex', 'number']],
@@ -304,7 +304,7 @@ export default class ColonyNetworkClient extends ContractClient {
       input: [['id', 'number']],
       output: [
         ['user', 'string'],
-        ['amount', 'number'],
+        ['amount', 'bignumber'],
         ['skillId', 'number'],
         ['colony', 'string'],
         ['nUpdates', 'number'],
@@ -347,7 +347,7 @@ export default class ColonyNetworkClient extends ContractClient {
       },
     });
     this.addSender('deposit', {
-      input: [['amount', 'number']],
+      input: [['amount', 'bignumber']],
     });
     this.addSender('startTokenAuction', {
       input: [['tokenAddress', 'address']],
@@ -378,7 +378,7 @@ export default class ColonyNetworkClient extends ContractClient {
       input: [['key', 'string'], ['newVersion', 'number']],
     });
     this.addSender('withdraw', {
-      input: [['amount', 'number']],
+      input: [['amount', 'bignumber']],
     });
   }
 }

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -51,6 +51,25 @@ describe('Parameter types', () => {
     expect(convertInputValue('0x123', 'address')).toBe('0x123');
   });
 
+  test('BigNumbers are handled properly', () => {
+    const bn = new BigNumber(1);
+
+    // Validation
+    expect(validateValue(bn, 'bignumber')).toBe(true);
+    expect(isBigNumber).toHaveBeenCalledWith(bn);
+    isBigNumber.mockClear();
+
+    // Cleaning
+    expect(convertOutputValue(bn, 'bignumber')).toBe(bn);
+    expect(isBigNumber).toHaveBeenCalledWith(bn);
+
+    isBigNumber.mockReturnValueOnce(false);
+    expect(convertOutputValue(null, 'bignumber')).toBe(null);
+
+    // Conversion
+    expect(convertInputValue(bn, 'bignumber')).toBe(bn);
+  });
+
   test('Booleans are handled properly', () => {
     // Validation
     expect(validateValue(false, 'boolean')).toBe(true);

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -15,7 +15,12 @@ import type { Query } from '@colony/colony-js-contract-loader';
 import ContractClient from './classes/ContractClient';
 import { SIGNING_MODES } from './constants';
 
-export type ParamTypes = 'number' | 'string' | 'address' | 'boolean';
+export type ParamTypes =
+  | 'address'
+  | 'bignumber'
+  | 'boolean'
+  | 'number'
+  | 'string';
 
 export type ParamTypePair = [string, ParamTypes];
 

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import BigNumber from 'bn.js';
 import { isHex, utf8ToHex } from 'web3-utils';
 import { isValidAddress, isBigNumber } from '@colony/colony-js-utils';
 
@@ -20,6 +21,18 @@ const PARAM_TYPE_MAP: {
     validate: isValidAddress,
     convertOutput(value) {
       return isValidAddress(value) ? value : null;
+    },
+    convertInput: passThrough,
+  },
+  bignumber: {
+    validate: isBigNumber,
+    convertOutput(value: any) {
+      if (isBigNumber(value)) {
+        return value;
+      } else if (Number.isFinite(value)) {
+        return new BigNumber(value);
+      }
+      return null;
     },
     convertInput: passThrough,
   },

--- a/packages/colony-js-utils/src/isBigNumber.js
+++ b/packages/colony-js-utils/src/isBigNumber.js
@@ -7,7 +7,9 @@ export default function isBigNumber(value: any) {
     BigNumber.isBN(value) ||
     // XXX Some libraries (cough *ethers* cough) wrap BigNumbers in a way
     // that breaks `isBN`; this is a workaround for that issue:
-    // eslint-disable-next-line no-underscore-dangle
-    (typeof value === 'object' && value._bn && BigNumber.isBN(value._bn))
+    (value != null &&
+      Object.hasOwnProperty.call(value, 'bn') &&
+      // eslint-disable-next-line no-underscore-dangle
+      BigNumber.isBN(value._bn))
   );
 }


### PR DESCRIPTION
## Description

Adds a new parameter type 'bignumber' and implements this in the client for Callers/Senders that use amounts.

The idea is that the 'number' type is good for IDs and integers (it automatically converts BigNumbers from the contract responses to numbers), but less useful for amounts, where we need accuracy.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Fixes `isBigNumber` function's handling of null values
* Will affect the documentation!


Resolves #113
