### PR TITLE
Update ColonyNetworkClient for recent contract changes

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -642,7 +642,7 @@ An instance of a `ContractResponse`
 
 ## Task MultiSig
 
-**All MultiSig functions return an instance of a `MultiSigOperation`.** For a reference please check [here](/colonyjs/docs-multisignature).
+**All MultiSig functions return an instance of a `MultiSigOperation`.** For a reference please check [here](/colonyjs/docs-multisignature-transactions/).
 ### `setTaskBrief.startOperation({ taskId, specificationHash })`
 
 The task brief, or specification, is a description of the tasks work specification. The description is hashed and stored with the task for future reference in ratings or in the event of a dispute.

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -57,9 +57,9 @@ Returns an initialized ColonyClient for the contract at address `contractAddress
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
-### `getColonyClient({ key?, id? })`
+### `getColonyClient(id)`
 
-Returns an initialized ColonyClient for the specified key (the name) or id of a deployed colony contract. It is crucial that you define exactly one of the arguments.
+Returns an initialized ColonyClient for the specified id of a deployed colony contract.
 
 **Arguments**
 
@@ -72,9 +72,9 @@ Returns an initialized ColonyClient for the specified key (the name) or id of a 
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
-### `getColonyAddress({ key?, id? })`
+### `getColonyAddress(id)`
 
-Get the address of a Colony for the specified key (the name) or id of a deployed colony contract. It is crucial that you define exactly one of the arguments.
+Get the address of a Colony for the specified id of a deployed colony contract.
 
 **Arguments**
 
@@ -87,19 +87,27 @@ Get the address of a Colony for the specified key (the name) or id of a deployed
 
 `Promise<Address>`. The address of the given Colony contract
 
+### `getMetaColonyClient()`
+
+Gets the Meta Colony as an initialized ColonyClient
+
+**Returns**
+
+`Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the MetaColony contract
+
 ## Callers
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
 
-### `getColonyById.call({ id })`
+### `getColony.call({ id })`
 
-Returns the address of a colony when given the colonyId
+Returns the address of a colony when given the ID
 
 **Arguments**
 
 |Argument|Type|Description|
 |---|---|---|
-|id|number|Integer colonyId|
+|id|number|Integer colony ID|
 
 **Returns**
 
@@ -109,15 +117,10 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|Address of the colony contract|
 
-### `getColonyByKey.call({ key })`
+### `getMetaColonyAddress.call()`
 
-Returns the address of a colony when given the colony's name (a.k.a its unique "key")
+Returns the address of the Meta Colony
 
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|key|string|The colony's unique key|
 
 **Returns**
 
@@ -125,7 +128,7 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|address|Address|Address of the colony contract|
+|address|Address|Address of the Meta Colony contract|
 
 ### `getColonyCount.call()`
 
@@ -279,7 +282,7 @@ A promise which resolves to an object containing the following properties:
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).
-### `createColony.send({ name, tokenAddress }, options)`
+### `createColony.send({ tokenAddress }, options)`
 
 Creates a new colony on the network.
 
@@ -287,8 +290,7 @@ Creates a new colony on the network.
 
 |Argument|Type|Description|
 |---|---|---|
-|name|string|Unique name for the colony. Will return an error if there already exists a colony with the specified name|
-|tokenAddress|Address|Token to import. Note: the ownership of the token contract must be transferred to the newly created colony.|
+|tokenAddress|Address|Token to import. Note: the ownership of the token contract must be transferred to the newly-created Colony.|
 
 **Returns**
 
@@ -296,7 +298,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Event data|Type|Description|
 |---|---|---|
-|colonyId|number|Id of the newly created colony|
+|colonyId|number|ID of the newly-created Colony|
+|colonyAddress|Address|Address of the newly-created Colony|
 
 ### `deposit.send({ amount }, options)`
 
@@ -334,7 +337,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|Address|The address of the token being auctioned|
 |quantity|number|The amount of available tokens for auction|
 
-### `upgradeColony.send({ key, newVersion }, options)`
+### `upgradeColony.send({ id, newVersion }, options)`
 
 Upgrades a colony to a new Colony contract version.
 
@@ -342,7 +345,7 @@ Upgrades a colony to a new Colony contract version.
 
 |Argument|Type|Description|
 |---|---|---|
-|key|string|Unique colony 'key' to be upgraded|
+|id|number|Colony ID to be upgraded|
 |newVersion|number|The target version for the upgrade|
 
 **Returns**

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -117,9 +117,9 @@ ${printProps('Event data', sender.events)}
 function printMultiSig() {
   if (!multisig.length) return '';
   // TODO: use templates to properly place this text into the file
-  return `'## Task MultiSig
+  return `## Task MultiSig
 
-**All MultiSig functions return an instance of a \`MultiSigOperation\`.** For a reference please check [here](/colonyjs/docs-contract-client/#task-multisig).` +
+**All MultiSig functions return an instance of a \`MultiSigOperation\`.** For a reference please check [here](/colonyjs/docs-multisignature-transactions/).` +
     multisig
       .map(
         ms => `

--- a/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
+++ b/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
@@ -58,7 +58,7 @@ export default class GetTask extends ContractClient.Caller<
       domainId,
       skillIds,
     ]: CallResult,
-    { taskId }: InputValues,
+    { taskId }: *,
   ) {
     const task: OutputValues = {
       cancelled: !!cancelled,

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -33,7 +33,7 @@ export default class ColonyClient extends ContractClient {
     Gets the total number of domains in a Colony. This number equals the last `domainId` created.
   */
   getDomainCount: ColonyClient.Caller<
-    null,
+    {},
     {
       count: number, // Number of all domain in this Colony; == the last added domainId
     },
@@ -43,7 +43,7 @@ export default class ColonyClient extends ContractClient {
     Gets the total number of reward payout cycles.
   */
   getGlobalRewardPayoutCount: ColonyClient.Caller<
-    null,
+    {},
     {
       count: number, // Number of reward payout cycles
     },
@@ -65,7 +65,7 @@ export default class ColonyClient extends ContractClient {
     Gets the total number of tasks in a Colony. This number equals the last `taskId` created.
   */
   getTaskCount: ColonyClient.Caller<
-    null,
+    {},
     {
       count: number, // Total number of tasks in this Colony
     },
@@ -192,7 +192,7 @@ export default class ColonyClient extends ContractClient {
     Gets the address of the colony's official token contract
   */
   getToken: ColonyClient.Caller<
-    null,
+    {},
     {
       address: Address, // The address of the colony's official deployed token contract
     },
@@ -202,7 +202,7 @@ export default class ColonyClient extends ContractClient {
     Returns the total number of transactions the colony has made, == the `transactionId` of the last added transaction to the Colony.
   */
   getTransactionCount: ColonyClient.Caller<
-    null,
+    {},
     {
       count: number, // Number of all transactions in this Colony; == the last added transactionId
     },
@@ -229,7 +229,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId
       specificationHash: string, // digest of the task's hashed specification.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -240,7 +240,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId
       domainId: number, // Integer domainId
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -251,7 +251,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId
       dueDate: Date, // Due date
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -263,7 +263,7 @@ export default class ColonyClient extends ContractClient {
       role: number, // MANAGER (`0`), EVALUATOR (`1`), or WORKER (`2`)
       user: Address, // address of the user
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -274,7 +274,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId
       skillId: number, // Integer skillId
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -286,7 +286,7 @@ export default class ColonyClient extends ContractClient {
       token: Address, // Address of the token's ERC20 contract.
       amount: number, // Amount to be paid.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -298,7 +298,7 @@ export default class ColonyClient extends ContractClient {
       token: Address, // Address of the token's ERC20 contract.
       amount: number, // Amount to be paid.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -310,7 +310,7 @@ export default class ColonyClient extends ContractClient {
       token: Address, // Address of the token's ERC20 contract.
       amount: number, // Amount to be paid.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -321,7 +321,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId
       deliverableHash: string, // Hash of the work performed
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -333,7 +333,7 @@ export default class ColonyClient extends ContractClient {
       role: number, // The role submitting their rating, either EVALUATOR (`1`) or WORKER (`2`)
       ratingSecret: string, // hidden work rating, generated as the output of `generateSecret(_salt, _rating)`, where `_rating` is a score from 0-50 (in increments of 10).
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -346,7 +346,7 @@ export default class ColonyClient extends ContractClient {
       rating: number, // Rating scored 0-50 in increments of 10 (e.g. 10, 20, 30, 40 or 50).
       salt: string, // `_salt` value to be used in `generateSecret`. A correct value will result in the same `ratingSecret` submitted during the work rating submission period.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -356,7 +356,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -366,7 +366,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -376,7 +376,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -388,7 +388,7 @@ export default class ColonyClient extends ContractClient {
       role: number, // Role of the contributor claiming the payout.
       token: Address, // Address of the token contract
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -424,7 +424,7 @@ export default class ColonyClient extends ContractClient {
     {
       token: Address, // Address of the token contract. `0x0` value indicates Ether.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -434,7 +434,7 @@ export default class ColonyClient extends ContractClient {
     {
       payoutId: number, // Id of the reward payout.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -447,7 +447,7 @@ export default class ColonyClient extends ContractClient {
       amount: number, // Amount of funds to move
       address: Address, // Address of the token contract
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -457,7 +457,7 @@ export default class ColonyClient extends ContractClient {
     {
       amount: number, // Amount of new tokens to be minted
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -467,7 +467,7 @@ export default class ColonyClient extends ContractClient {
     {
       amount: number, // Amount of new tokens to be minted
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -477,7 +477,7 @@ export default class ColonyClient extends ContractClient {
     {
       token: Address, // Address of token used for reward payout.
     },
-    null,
+    {},
     ColonyClient,
   >;
   /*
@@ -487,7 +487,7 @@ export default class ColonyClient extends ContractClient {
     {
       numPayouts: number, // Number of payouts to waive
     },
-    null,
+    {},
     ColonyClient,
   >;
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -28,7 +28,7 @@ export default class ColonyNetworkClient extends ContractClient {
   /*
   Returns the address of the Meta Colony
   */
-  getMetaColony: ColonyNetworkClient.Caller<
+  getMetaColonyAddress: ColonyNetworkClient.Caller<
     null,
     {
       address: Address, // Address of the Meta Colony contract
@@ -265,13 +265,21 @@ export default class ColonyNetworkClient extends ContractClient {
 
     return address;
   }
+  /*
+  Gets the Meta Colony as an initialized ColonyClient
+   */
+  async getMetaColonyClient() {
+    const { address } = await this.getMetaColonyAddress.call();
+    return this.getColonyClientByAddress(address);
+  }
   initializeContractMethods() {
     // Callers
     this.addCaller('getColony', {
       input: [['id', 'number']],
       output: [['address', 'address']],
     });
-    this.addCaller('getMetaColony', {
+    this.addCaller('getMetaColonyAddress', {
+      functionName: 'getMetaColony',
       output: [['address', 'address']],
     });
     this.addCaller('getColonyCount', {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -29,7 +29,7 @@ export default class ColonyNetworkClient extends ContractClient {
   Returns the address of the Meta Colony
   */
   getMetaColonyAddress: ColonyNetworkClient.Caller<
-    null,
+    {},
     {
       address: Address, // Address of the Meta Colony contract
     },
@@ -39,7 +39,7 @@ export default class ColonyNetworkClient extends ContractClient {
   Returns the number of colonies created on the Colony Network, i.e. the colonyId of the most recently created colony.
   */
   getColonyCount: ColonyNetworkClient.Caller<
-    null,
+    {},
     {
       count: number, // colonyId of the most recently created colony
     },
@@ -61,7 +61,7 @@ export default class ColonyNetworkClient extends ContractClient {
   Returns the latest Colony contract version. This is the version used to create all new colonies.
   */
   getCurrentColonyVersion: ColonyNetworkClient.Caller<
-    null,
+    {},
     {
       version: number, // The current / latest Colony contract version
     },
@@ -101,7 +101,7 @@ export default class ColonyNetworkClient extends ContractClient {
   Gets the length of the reputation update log for either the current active or inactive log
   */
   getReputationUpdateLogLength: ColonyNetworkClient.Caller<
-    null,
+    {},
     {
       count: number, // Length of Reputation update log array
     },
@@ -124,7 +124,7 @@ export default class ColonyNetworkClient extends ContractClient {
   Get the total number of skills in the network (both global and local skills)
   */
   getSkillCount: ColonyNetworkClient.Caller<
-    null,
+    {},
     {
       count: number, // The number of skills on the network
     },
@@ -162,7 +162,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       amount: number, // Amount of CLNY to stake
     },
-    null,
+    {},
     ColonyNetworkClient,
   >;
   /*
@@ -187,7 +187,7 @@ export default class ColonyNetworkClient extends ContractClient {
       id: number, // Colony ID to be upgraded
       newVersion: number, // The target version for the upgrade
     },
-    null,
+    {},
     ColonyNetworkClient,
   >;
   /*
@@ -197,7 +197,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       amount: number, // Amount of CLNY to withdraw from stake
     },
-    null,
+    {},
     ColonyNetworkClient,
   >;
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -323,14 +323,14 @@ export default class ColonyNetworkClient extends ContractClient {
           ColonyAdded: {
             contract: this.contract,
             handler({
-              id,
+              colonyId,
               colonyAddress,
             }: {
-              id: BigNumber,
+              colonyId: BigNumber,
               colonyAddress: Address,
             }) {
               return {
-                colonyId: id.toNumber(),
+                colonyId: colonyId.toNumber(),
                 colonyAddress,
               };
             },

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -194,4 +194,26 @@ describe('ColonyNetworkClient', () => {
     expect(await networkClient.getColonyAddress(id)).toBe(colonyAddress);
     expect(getColonySpy).toHaveBeenCalledWith({ id });
   });
+
+  test('Getting the Meta Colony as a ColonyClient', async () => {
+    const networkClient = new ColonyNetworkClient({ adapter });
+    await networkClient.init();
+
+    const metaColonyAddress = 'The Meta Colony lives here';
+    const metaColonyClient = {
+      contract: {
+        address: metaColonyAddress,
+      },
+    };
+
+    sandbox
+      .spyOn(networkClient.getMetaColonyAddress, 'call')
+      .mockImplementation(async () => ({ address: metaColonyAddress }));
+    sandbox
+      .spyOn(networkClient, 'getColonyClientByAddress')
+      .mockImplementation(async () => metaColonyClient);
+
+    expect(await networkClient.getMetaColonyClient()).toBe(metaColonyClient);
+    expect(networkClient.getMetaColonyAddress.call).toHaveBeenCalled();
+  });
 });

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -91,9 +91,10 @@ describe('ColonyNetworkClient', () => {
     ]);
     expect(
       networkClient.createColony.eventHandlers.success.ColonyAdded.handler({
-        id: new BigNumber(100),
+        colonyId: new BigNumber(100),
+        colonyAddress: 'colony address',
       }),
-    ).toEqual({ colonyId: 100 });
+    ).toEqual({ colonyId: 100, colonyAddress: 'colony address' });
 
     const response = {
       eventData: {

--- a/packages/colony-js-contract-client/src/classes/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethod.js
@@ -40,14 +40,14 @@ export default class ContractMethod<
    * Given named input values, validate them against the expected parameters
    * for this method, throwing errors if validation fails.
    */
-  validate(inputValues: InputValues) {
+  validate(inputValues?: InputValues) {
     return this._validate(inputValues, this.input);
   }
   /**
    * Given named input values, transform these with the expected parameters
    * in order to get an array of arguments expected by the contract function.
    */
-  getMethodArgs(inputValues: InputValues) {
+  getMethodArgs(inputValues?: InputValues) {
     return this._getMethodArgs(inputValues, this.input);
   }
   /**
@@ -56,7 +56,7 @@ export default class ContractMethod<
    * order to get named output values as the method's `ReturnValues`
    */
   // eslint-disable-next-line no-unused-vars
-  getOutputValues(callResult: any, inputValues: InputValues): OutputValues {
+  getOutputValues(callResult: any, inputValues?: InputValues): OutputValues {
     return this._getMethodReturnValue(callResult, this.output);
   }
   /**

--- a/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
@@ -12,7 +12,7 @@ export default class ContractMethodCaller<
    * Given named input values, perform a call on the method's
    * contract function, and get named output values from the result.
    */
-  async call(inputValues: InputValues) {
+  async call(inputValues?: InputValues) {
     this.validate(inputValues);
     const args = this.getMethodArgs(inputValues);
     const result = await this.client.call(this.functionName, args);

--- a/packages/colony-js-contract-client/src/modules/getMethodArgs.js
+++ b/packages/colony-js-contract-client/src/modules/getMethodArgs.js
@@ -7,12 +7,12 @@ import type { ParamTypePairs, ParamTypes } from '../flowtypes';
 const parseParamsValue = (value: any, type: ParamTypes) =>
   type === 'string' ? utf8ToHex(value) : value;
 
-const parseParams = <Params: {}, MethodParams: ParamTypePairs>(
-  params: Params,
+const parseParams = <Params: Object, MethodParams: ParamTypePairs>(
+  params?: Params,
   methodParams: MethodParams,
 ) =>
   methodParams.map(([paramName, paramType]) =>
-    parseParamsValue(params[paramName], paramType),
+    parseParamsValue(params && params[paramName], paramType),
   );
 
 /**
@@ -23,7 +23,7 @@ const parseParams = <Params: {}, MethodParams: ParamTypePairs>(
 export default function getMethodArgs<
   Params: Object,
   MethodParams: ParamTypePairs,
->(params: Params, methodParams: MethodParams): Array<any> {
+>(params?: Params, methodParams: MethodParams): Array<any> {
   let args = [];
 
   if (methodParams && methodParams.length) {


### PR DESCRIPTION
## Description

Updates the network client so that it supports the recent changes to the contracts: JoinColony/colonyNetwork#207

* Remove `getColonyByKey`
* Removed key option for `getColonyAddress`/`getColonyClient`
* Rename `getColonyById` -> `getColony`
* Removes `name` parameter from `createColony`
* Adds `colonyAddress` event parameter for `createColony`
* Replace `key` with `id` parameter for `upgradeColony`
* Adds `getMetaColonyAddress` Caller
* Adds `getMetaColonyClient` method

These changes will need to be made to the colonyDapp integration tests once merged.

## Other changes

* Changes flow typings in `ContractMethod`/`ContractMethodCaller`. By adding `getMetaColonyClient` and calling a Caller without arguments, flow determined that the `null` typing for the `InputValues` generic conflicted with the expectation. Now it's possible to call Callers without arguments (without flow complaining).

Resolves #119 

