### PR TITLE
Remove separate success/error event handling

### DIFF
--- a/packages/colony-js-adapter-ethers/src/EthersAdapter.js
+++ b/packages/colony-js-adapter-ethers/src/EthersAdapter.js
@@ -97,17 +97,11 @@ export default class EthersAdapter implements IAdapter {
     });
     try {
       // Wait for all success events to resolve, or reject on any error event
-      return Object.assign(
-        {},
-        ...(await Promise.all(eventPromises)
-        ),
-      );
+      return Object.assign({}, ...(await Promise.all(eventPromises)));
     } finally {
-      Object.entries(events).forEach(
-        ([eventName, { contract }]) => {
-          contract.removeListener(eventName, transactionHash);
-        },
-      );
+      Object.entries(events).forEach(([eventName, { contract }]) => {
+        contract.removeListener(eventName, transactionHash);
+      });
     }
   }
   async getTransactionReceipt(transactionHash: string) {

--- a/packages/colony-js-adapter/interface/EventHandlers.js
+++ b/packages/colony-js-adapter/interface/EventHandlers.js
@@ -10,10 +10,5 @@ export type EventHandler = {
 };
 
 export type EventHandlers = {
-  success?: {
-    [eventName: string]: EventHandler,
-  },
-  error?: {
-    [eventName: string]: EventHandler,
-  },
+  [eventName: string]: EventHandler,
 };

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -598,13 +598,13 @@ export default class ColonyClient extends ContractClient {
     this.addSender('addDomain', {
       input: [['parentSkillId', 'number']],
       eventHandlers: {
-        success: { SkillAdded },
+        SkillAdded,
       },
     });
     this.addSender('addGlobalSkill', {
       input: [['parentSkillId', 'number']],
       eventHandlers: {
-        success: { SkillAdded },
+        SkillAdded,
       },
     });
     this.addSender('assignWorkRating', {
@@ -623,14 +623,12 @@ export default class ColonyClient extends ContractClient {
       functionName: 'makeTask',
       input: [['specificationHash', 'string'], ['domainId', 'number']],
       eventHandlers: {
-        success: {
-          TaskAdded: {
-            contract: this.contract,
-            handler({ id }: { id: BigNumber }) {
-              return {
-                taskId: id.toNumber(),
-              };
-            },
+        TaskAdded: {
+          contract: this.contract,
+          handler({ id }: { id: BigNumber }) {
+            return {
+              taskId: id.toNumber(),
+            };
           },
         },
       },

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -327,21 +327,19 @@ export default class ColonyNetworkClient extends ContractClient {
       input: [['tokenAddress', 'address']],
       defaultGasLimit: new BigNumber(2500000),
       eventHandlers: {
-        success: {
-          ColonyAdded: {
-            contract: this.contract,
-            handler({
-              colonyId,
+        ColonyAdded: {
+          contract: this.contract,
+          handler({
+            colonyId,
+            colonyAddress,
+          }: {
+            colonyId: BigNumber,
+            colonyAddress: Address,
+          }) {
+            return {
+              colonyId: colonyId.toNumber(),
               colonyAddress,
-            }: {
-              colonyId: BigNumber,
-              colonyAddress: Address,
-            }) {
-              return {
-                colonyId: colonyId.toNumber(),
-                colonyAddress,
-              };
-            },
+            };
           },
         },
       },
@@ -352,24 +350,22 @@ export default class ColonyNetworkClient extends ContractClient {
     this.addSender('startTokenAuction', {
       input: [['tokenAddress', 'address']],
       eventHandlers: {
-        success: {
-          AuctionCreated: {
-            contract: this.contract,
-            handler({
+        AuctionCreated: {
+          contract: this.contract,
+          handler({
+            auction,
+            token,
+            quantity,
+          }: {
+            auction: string,
+            token: string,
+            quantity: BigNumber,
+          }) {
+            return {
               auction,
               token,
-              quantity,
-            }: {
-              auction: string,
-              token: string,
-              quantity: BigNumber,
-            }) {
-              return {
-                auction,
-                token,
-                quantity: quantity.toNumber(),
-              };
-            },
+              quantity: quantity.toNumber(),
+            };
           },
         },
       },

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -80,18 +80,16 @@ describe('ColonyNetworkClient', () => {
     );
     expect(networkClient.createColony).toHaveProperty('_defaultGasLimit');
     expect(networkClient.createColony.eventHandlers).toEqual({
-      success: {
-        ColonyAdded: {
-          contract: {},
-          handler: expect.any(Function),
-        },
+      ColonyAdded: {
+        contract: {},
+        handler: expect.any(Function),
       },
     });
     expect(networkClient.createColony.input).toEqual([
       ['tokenAddress', 'address'],
     ]);
     expect(
-      networkClient.createColony.eventHandlers.success.ColonyAdded.handler({
+      networkClient.createColony.eventHandlers.ColonyAdded.handler({
         colonyId: new BigNumber(100),
         colonyAddress: 'colony address',
       }),

--- a/packages/colony-js-contract-client/src/__tests__/ContractClient.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractClient.js
@@ -220,10 +220,8 @@ describe('ContractClient', () => {
 
     const params = {
       events: {
-        success: {
-          myEvent({ myEventValue }) {
-            return { myEventValue };
-          },
+        myEvent({ myEventValue }) {
+          return { myEventValue };
         },
       },
     };

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
@@ -11,19 +11,17 @@ describe('ContractMethodSender', () => {
   const sandbox = createSandbox();
   const contract = {};
   const eventHandlers = {
-    success: {
-      myEventOne: {
-        handler({ eventOneResult }) {
-          return eventOneResult;
-        },
-        contract,
+    myEventOne: {
+      handler({ eventOneResult }) {
+        return eventOneResult;
       },
-      myEventTwo: {
-        handler({ eventTwoResult }) {
-          return eventTwoResult;
-        },
-        contract,
+      contract,
+    },
+    myEventTwo: {
+      handler({ eventTwoResult }) {
+        return eventTwoResult;
       },
+      contract,
     },
   };
   const functionName = 'myFunction';


### PR DESCRIPTION
## Description

This PR aims to make event handling (and the implementation of #117) a little simpler, by the separate `error`/`success` event handling. The events were previously defined like this because we had a `TransactionFailed` event, but the contract with that event has been replaced, so all of our events are currently defined as `success` events.

In light of this, I think it makes sense to assume that every event should generally be considered as A Good Thing©.

Contributes to #117.

