### PR TITLE
Better handling for 'empty' responses

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -44,6 +44,25 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|string|keccak256 hash of joint Salt and Value|
 
+### `getDomain.call({ domainId })`
+
+Gets the selected domain's local skill ID and funding pot ID
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|domainId|number|ID of the domain|
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|localSkillId|number|The domain's local skill ID|
+|potId|number|The domain's funding pot ID|
+
 ### `getDomainCount.call()`
 
 Gets the total number of domains in a Colony. This number equals the last `domainId` created.

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -230,7 +230,7 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|Length of Reputation update log array|
 
-### `getSkill.call({ id })`
+### `getSkill.call({ skillId })`
 
 Returns the number of parent and child skills associated with the provided skill
 
@@ -238,7 +238,7 @@ Returns the number of parent and child skills associated with the provided skill
 
 |Argument|Type|Description|
 |---|---|---|
-|id|number|skillId to be checked|
+|skillId|number|skillId to be checked|
 
 **Returns**
 

--- a/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
+++ b/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import assert from 'browser-assert';
 import ContractClient from '@colony/colony-js-contract-client';
 
 import type ColonyClient from '../index';
@@ -43,9 +44,17 @@ export default class GetTask extends ContractClient.Caller<
       input: [['taskId', 'number']],
       ...params,
     });
+    this._validateEmpty = async (inputValues?: *) => {
+      const taskId = inputValues && inputValues.taskId;
+      if (taskId) {
+        const { count } = await this.client.getTaskCount.call();
+        assert(taskId <= count, `Task with ID ${taskId} not found`);
+      }
+      return true;
+    };
   }
   // eslint-disable-next-line class-methods-use-this
-  getOutputValues(
+  _getOutputValues(
     [
       specificationHash,
       deliverableHash,

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -33,6 +33,19 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
+    Gets the selected domain's local skill ID and funding pot ID
+  */
+  getDomain: ColonyClient.Caller<
+    {
+      domainId: number, // ID of the domain
+    },
+    {
+      localSkillId: number, // The domain's local skill ID
+      potId: number, // The domain's funding pot ID
+    },
+    ColonyClient,
+  >;
+  /*
     Gets the total number of domains in a Colony. This number equals the last `domainId` created.
   */
   getDomainCount: ColonyClient.Caller<
@@ -560,6 +573,16 @@ export default class ColonyClient extends ContractClient {
     this.addCaller('generateSecret', {
       input: [['salt', 'string'], ['value', 'bignumber']],
       output: [['secret', 'string']],
+    });
+    this.addCaller('getDomain', {
+      input: [['domainId', 'number']],
+      output: [['localSkillId', 'number'], ['potId', 'number']],
+      validateEmpty: async ({ domainId }: { domainId: number }) => {
+        const { count } = await this.getDomainCount.call();
+        if (domainId > count)
+          throw new Error(`Domain ID ${domainId} not found`);
+        return true;
+      },
     });
     this.addCaller('getDomainCount', {
       output: [['count', 'number']],

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -2,6 +2,7 @@
 
 import assert from 'browser-assert';
 import { utf8ToHex } from 'web3-utils';
+import { isValidAddress } from '@colony/colony-js-utils';
 import BigNumber from 'bn.js';
 
 import ContractClient from '@colony/colony-js-contract-client';
@@ -261,7 +262,8 @@ export default class ColonyNetworkClient extends ContractClient {
 
     const { address } = await this.getColony.call({ id });
 
-    if (!address) throw new Error(`Colony with ID ${id} could not be found`);
+    if (!isValidAddress(address))
+      throw new Error(`Colony with ID ${id} could not be found`);
 
     return address;
   }
@@ -270,6 +272,10 @@ export default class ColonyNetworkClient extends ContractClient {
    */
   async getMetaColonyClient() {
     const { address } = await this.getMetaColonyAddress.call();
+
+    if (!isValidAddress(address))
+      throw new Error(`Meta Colony could not be found`);
+
     return this.getColonyClientByAddress(address);
   }
   initializeContractMethods() {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -112,7 +112,7 @@ export default class ColonyNetworkClient extends ContractClient {
   */
   getSkill: ColonyNetworkClient.Caller<
     {
-      id: number, // skillId to be checked
+      skillId: number, // skillId to be checked
     },
     {
       nParents: number, // Number of parent skills
@@ -315,7 +315,7 @@ export default class ColonyNetworkClient extends ContractClient {
       output: [['count', 'number']],
     });
     this.addCaller('getSkill', {
-      input: [['id', 'number']],
+      input: [['skillId', 'number']],
       output: [['nParents', 'number'], ['nChildren', 'number']],
     });
     this.addCaller('getSkillCount', {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -323,6 +323,11 @@ export default class ColonyNetworkClient extends ContractClient {
     this.addCaller('getSkill', {
       input: [['skillId', 'number']],
       output: [['nParents', 'number'], ['nChildren', 'number']],
+      validateEmpty: async ({ skillId }: { skillId: number }) => {
+        const { count } = await this.getSkillCount.call();
+        if (skillId > count) throw new Error(`Skill ID ${skillId} not found`);
+        return true;
+      },
     });
     this.addCaller('getSkillCount', {
       output: [['count', 'number']],

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodCaller.js
@@ -15,6 +15,29 @@ describe('ContractMethodCaller', () => {
 
   beforeEach(() => sandbox.clear());
 
+  test('Null values in results are identified correctly', () => {
+    const noneNull = {
+      role: 'WORKER',
+      user: '0x123',
+      taskId: 1,
+    };
+    const someNull = {
+      role: 'WORKER',
+      user: null,
+      taskId: 1,
+    };
+    const allNull = {
+      role: null,
+      user: null,
+      taskId: null,
+    };
+
+    expect(ContractMethodCaller.containsNullValues()).toBe(false);
+    expect(ContractMethodCaller.containsNullValues(noneNull)).toBe(false);
+    expect(ContractMethodCaller.containsNullValues(someNull)).toBe(true);
+    expect(ContractMethodCaller.containsNullValues(allNull)).toBe(true);
+  });
+
   test('Constant functions can be called', async () => {
     const method = new ContractMethodCaller({
       client,
@@ -26,6 +49,9 @@ describe('ContractMethodCaller', () => {
     const result = 'hello';
     const returnValue = { message: result };
 
+    sandbox
+      .spyOn(method.constructor, 'containsNullValues')
+      .mockImplementation(() => false);
     sandbox.spyOn(client, 'call').mockImplementation(() => result);
     sandbox
       .spyOn(method, 'getValidatedArgs')
@@ -40,6 +66,88 @@ describe('ContractMethodCaller', () => {
       method.functionName,
       callArgs,
     );
+    expect(method.constructor.containsNullValues).toHaveBeenCalledWith(
+      returnValue,
+    );
     expect(method._getOutputValues).toHaveBeenCalledWith(result, inputValues);
+  });
+
+  test('Empty results are checked', async () => {
+    const method = new ContractMethodCaller({
+      client,
+      input,
+      functionName,
+    });
+
+    const returnValue = { someNullValue: null };
+
+    sandbox
+      .spyOn(method.constructor, 'containsNullValues')
+      .mockImplementation(() => true);
+    sandbox.spyOn(method, 'validateEmpty').mockImplementation(async () => true);
+    sandbox.spyOn(method, 'getValidatedArgs').mockImplementation(() => {});
+    sandbox.spyOn(client, 'call').mockImplementation(() => {});
+    sandbox
+      .spyOn(method, '_getOutputValues')
+      .mockImplementation(() => returnValue);
+
+    expect(await method.call(inputValues)).toEqual(returnValue);
+    expect(method.constructor.containsNullValues).toHaveBeenCalledWith(
+      returnValue,
+    );
+    expect(method.validateEmpty).toHaveBeenCalledWith(inputValues, returnValue);
+  });
+
+  test('Empty results are validated with _validateEmpty', async () => {
+    const methodWithoutValidateEmpty = new ContractMethodCaller({
+      client,
+      input,
+      functionName,
+    });
+
+    const validateEmpty = sandbox.fn().mockImplementation(async () => true);
+    const methodWithValidateEmpty = new ContractMethodCaller({
+      client,
+      input,
+      functionName,
+      validateEmpty,
+    });
+    expect(methodWithValidateEmpty._validateEmpty).toBe(validateEmpty);
+
+    const returnValue = { someNullValue: null };
+
+    expect(
+      await methodWithoutValidateEmpty.validateEmpty(inputValues, returnValue),
+    ).toBe(true);
+    expect(validateEmpty).not.toHaveBeenCalled();
+
+    expect(
+      await methodWithValidateEmpty.validateEmpty(inputValues, returnValue),
+    ).toBe(true);
+    expect(validateEmpty).toHaveBeenCalledWith(inputValues, returnValue);
+
+    // Without a reason
+    validateEmpty.mockClear().mockImplementationOnce(async () => false);
+    try {
+      await methodWithValidateEmpty.validateEmpty(inputValues, returnValue);
+      expect(false).toBe(true); // unreachable
+    } catch (error) {
+      expect(error.toString()).toBe('Error: Empty response');
+      expect(validateEmpty).toHaveBeenCalledWith(inputValues, returnValue);
+    }
+
+    // With a reason
+    validateEmpty.mockClear().mockImplementationOnce(async () => {
+      throw new Error('Could not find task ID 4');
+    });
+    try {
+      await methodWithValidateEmpty.validateEmpty(inputValues, returnValue);
+      expect(false).toBe(true); // unreachable
+    } catch (error) {
+      expect(error.toString()).toBe(
+        'Error: Empty response (Could not find task ID 4)',
+      );
+      expect(validateEmpty).toHaveBeenCalledWith(inputValues, returnValue);
+    }
   });
 });

--- a/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
@@ -1,20 +1,66 @@
 /* @flow */
 
+import isPlainObject from 'lodash.isplainobject';
+
 import ContractClient from './ContractClient';
 import ContractMethod from './ContractMethod';
+
+import type { ContractMethodArgs, ValidateEmpty } from '../flowtypes';
 
 export default class ContractMethodCaller<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
 > extends ContractMethod<InputValues, OutputValues, IContractClient> {
+  _validateEmpty: ?ValidateEmpty;
+
+  static containsNullValues(values: Object | null) {
+    if (isPlainObject(values))
+      return Object.values(values || {}).some(value => value === null);
+    return false;
+  }
+
+  constructor({
+    client,
+    functionName,
+    input,
+    output,
+    validateEmpty,
+  }: ContractMethodArgs<IContractClient> & {
+    validateEmpty?: ValidateEmpty,
+  } = {}) {
+    super({ client, functionName, input, output });
+    if (validateEmpty) this._validateEmpty = validateEmpty;
+  }
+
+  async validateEmpty(inputValues: *, outputValues: *) {
+    if (this._validateEmpty) {
+      let isValid: boolean = false;
+      let reason;
+      try {
+        isValid = await this._validateEmpty(inputValues, outputValues);
+      } catch (error) {
+        reason = error.message || error.toString();
+      }
+      if (!isValid)
+        throw new Error(`Empty response${reason ? ` (${reason})` : ''}`);
+    }
+    return true;
+  }
+
   /**
    * Given named input values, perform a call on the method's
    * contract function, and get named output values from the result.
    */
   async call(inputValues?: InputValues) {
     const args = this.getValidatedArgs(inputValues);
-    const result = await this.client.call(this.functionName, args);
-    return this._getOutputValues(result, inputValues);
+    const response = await this.client.call(this.functionName, args);
+
+    const outputValues = this._getOutputValues(response, inputValues);
+
+    if (this.constructor.containsNullValues(outputValues))
+      await this.validateEmpty(inputValues, outputValues);
+
+    return outputValues;
   }
 }

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -57,11 +57,17 @@ export type ContractClientConstructorArgs = {
   query: Query,
 };
 
+export type ValidateEmpty = (
+  outputValues: Object | null,
+  inputValues: Object | null,
+) => Promise<boolean>;
+
 export type ContractMethodArgs<IContractClient: ContractClient> = {
   client: IContractClient,
   functionName: string,
   input: ParamTypePairs,
   output?: ParamTypePairs,
+  validateEmpty?: ValidateEmpty,
 };
 
 export type ContractMethodSenderArgs<IContractClient: ContractClient> = {

--- a/packages/colony-js-utils/src/isBigNumber.js
+++ b/packages/colony-js-utils/src/isBigNumber.js
@@ -8,7 +8,7 @@ export default function isBigNumber(value: any) {
     // XXX Some libraries (cough *ethers* cough) wrap BigNumbers in a way
     // that breaks `isBN`; this is a workaround for that issue:
     (value != null &&
-      Object.hasOwnProperty.call(value, 'bn') &&
+      Object.hasOwnProperty.call(value, '_bn') &&
       // eslint-disable-next-line no-underscore-dangle
       BigNumber.isBN(value._bn))
   );


### PR DESCRIPTION
## Description

This PR improves the handling of 'empty' responses (responses from the contract functions called by `Caller`s which have null values). 

If some of the values returned by a `Caller` are null, and that `Caller` has a `validateEmpty` function, the call may throw an error if the validation deemed the result to be empty.

For example, when we call

```js
const task = await ColonyClient.getTask.call({ taskId: 3 });
```

If task 3 doesn't exist, we should get some null values in the response (e.g. `specificationHash: null`). The `validateEmpty` function makes a call to `ColonyClient.getTaskCount` and compares the task count with the ID we wanted; if the ID is greater than the count, we know for sure that the task doesn't exist, and an error is thrown ('Task ID 3 not found').
  

## Other changes

* Add missing `getDomain` Caller to `ColonyClient`, with `validateEmpty` based on `getDomainCount`
* Add `validateEmpty` function for task-related Callers, `getDomain` and `getSkill`
* Check for empty/invalid responses in `ColonyNetworkClient.getColonyClient`/`ColonyNetworkClient.getMetaColonyClient`
* Rename `getSkill` parameter to `skillId` (was `id`) for consistency
* Update docs
* Bugfix: fixed a bug where the `isBigNumber` utility function didn't look for the correct property in ethers-ified BigNumbers.


## TODOs

- [ ] Confirm that the integration tests work

Resolves #86 
