### PR TITLE
Refresh new MultisigOperations

### DIFF
--- a/docs/_Docs_Multisignature.md
+++ b/docs/_Docs_Multisignature.md
@@ -96,7 +96,7 @@ const json = op.toJSON();
 We can restore this elsewhere with the appropriate `MultisigSender`:
 
 ```js
-const op = colonyClient.setTaskBrief.restoreOperation(json);
+const op = await colonyClient.setTaskBrief.restoreOperation(json);
 // -> MultisigOperation (with the same parameters and the first signature already in place)
 ```
 
@@ -165,7 +165,7 @@ console.log(secondOp._nonce); // 2
 console.log(firstOp.missingSignees); // ['0x...', '0x...']
 ```
 
-It's worth noting that sending an operation will always trigger a refresh first, so this can reset the (now invalid) signers.
+It's worth noting that starting a new operation or sending an existing operation will always trigger a refresh first, so this can reset the (now invalid) signers.
 
 If desired, we can make the resetting of signers more explicit by attaching a callback:
 


### PR DESCRIPTION
## Description

When a new `MultisigOperation` is started/restored, call `refresh` first, in order to set `requiredSignees`, `nonce` and the message hash.

This means that it's now possible to immediately call `op.requiredSignees` after creating the operation, instead of getting an error message telling you to call `refresh` manually.

Resolves #129 

Contributes to colonyDapp#110
