### PR TITLE
Autogenerate docs when commiting

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -20,6 +20,7 @@ You _could_ create a ColonyClient by using an adapter and a query: `new ColonyCl
 const colonyClient = await networkClient.getColonyClient({ key: 'My Colony' }); // This is already initialised
 ```
 
+  
 ## Callers
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
@@ -293,6 +294,7 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|Number of all transactions in this Colony; == the last added transactionId|
 
+  
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).
@@ -640,6 +642,7 @@ An instance of a `ContractResponse`
 
 
 
+  
 ## Task MultiSig
 
 **All MultiSig functions return an instance of a `MultiSigOperation`.** For a reference please check [here](/colonyjs/docs-multisignature-transactions/).

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -95,6 +95,7 @@ Gets the Meta Colony as an initialized ColonyClient
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the MetaColony contract
 
+  
 ## Callers
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
@@ -279,6 +280,7 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |balance|BigNumber|Amount of staked CLNY|
 
+  
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -1,0 +1,21 @@
+---
+title: ColonyClient
+section: API
+order: 3
+---
+
+The `ColonyClient` class is a standard interface for interactions with the on-chain functions and events described in `IColony.sol`
+
+These interactions are generally concerned with functions and events internal to a colony, such as creating a task, assigning a work rating, or moving funds between pots.
+
+For functions and events that concern the colonyNetwork as a whole, refer to the [ColonyNetworkClient API](/colonyjs/api-colonynetworkclient/)
+
+==TOC==
+
+## Creating a new instance
+
+You _could_ create a ColonyClient by using an adapter and a query: `new ColonyClient({ adapter, query })` and then `.init()` it but it is advised to ask the network client for a new instance:
+
+```javascript
+const colonyClient = await networkClient.getColonyClient({ key: 'My Colony' }); // This is already initialised
+```

--- a/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
@@ -1,0 +1,96 @@
+---
+title: ColonyNetworkClient
+section: API
+order: 2
+---
+
+The `ColonyNetworkClient` is a standard interface for interactions with functions and events described in `IColonyNetwork.sol`.
+
+These interactions are generally concerned with the colony network as a whole, rather than at the colony level. This includes operations like getting a count of all colonies on the network, querying for information about a parent skillId, or deposits/withdrawals of staked CLNY for use in the reputation system.
+
+You can learn more about the solidity implementation from the [Colony Network Docs](/colonynetwork/docs-colony).
+
+For interactions within a particular colony, see [the ColonyClient docs](/colonyjs/api-colonyclient/).
+
+==TOC==
+
+## Creating a new instance
+
+Assuming you're inside an `async` function:
+
+```javascript
+const networkClient = new ColonyNetworkClient({ adapter });
+await networkClient.init();
+```
+
+## Instance methods
+
+**All instance methods return promises.**
+
+### `createToken({ name, symbol, decimals })`
+
+Deploys a new ERC20 compatible token contract for you to use with your Colony. You can also use your own token when creating a Colony.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|name|string|Name of the token to create (e.g. Cool Colony Token)|
+|symbol|string|Symbol of the token to create (e.g. CCT)|
+|decimals|string|Decimals of your token (default: 18).|
+
+**Returns**
+
+`Promise<Address>` The address of the newly deployed token contract
+
+### `getColonyClientByAddress(contractAddress)`
+
+Returns an initialized ColonyClient for the contract at address `contractAddress`
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|contractAddress|Adress|Address of a deployed Colony contract|
+
+**Returns**
+
+`Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
+
+### `getColonyClient(id)`
+
+Returns an initialized ColonyClient for the specified id of a deployed colony contract.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|key|string|Name of the Colony to get|
+|id|number|Integer number of the Colony|
+
+**Returns**
+
+`Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
+
+### `getColonyAddress(id)`
+
+Get the address of a Colony for the specified id of a deployed colony contract.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|key|string|Name of the Colony to get|
+|id|number|Integer number of the Colony|
+
+**Returns**
+
+`Promise<Address>`. The address of the given Colony contract
+
+### `getMetaColonyClient()`
+
+Gets the Meta Colony as an initialized ColonyClient
+
+**Returns**
+
+`Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the MetaColony contract

--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -13,10 +13,11 @@
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
         "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:docs": "scripts/docgen.js",
         "clean": "shx rm -rf lib",
         "flow": "flow check",
         "lint": "eslint src/{,**/}*.js",
-        "precommit": "lint-staged",
+        "precommit": "lint-staged && yarn run build:docs",
         "prepublish": "yarn run precommit && yarn run build",
         "test": "yarn run lint && yarn run test:unit",
         "test:unit": "jest --coverage --config=jest.conf.json"


### PR DESCRIPTION
This adds a command to the package.json of the colony-client: build:docs. This will run the doc generation process of the contract client classes (currently ColonyClient and ColonyNetworkClient). This uses template files to generate the actual doc files (these sit in the docs folder of the colony client).

Also, it will trigger this build step pre every commit (it's kinda unnecessary but it only takes 0.5s so for now that's probably acceptable).

Closes #91.