### PR TITLE
Fix contract client links

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -23,7 +23,7 @@ const colonyClient = await networkClient.getColonyClient({ key: 'My Colony' }); 
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
+**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
 ### `generateSecret.call({ salt, value })`
 
@@ -316,7 +316,7 @@ A promise which resolves to an object containing the following properties:
   
 ## Senders
 
-**All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).
+**All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
 ### `createTask.send({ specificationHash, domainId }, options)`
 
 Creates a new task by invoking `makeTask` on-chain.

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -98,7 +98,7 @@ Gets the Meta Colony as an initialized ColonyClient
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
+**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
 ### `getColony.call({ id })`
 
@@ -283,7 +283,7 @@ A promise which resolves to an object containing the following properties:
   
 ## Senders
 
-**All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).
+**All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
 ### `createColony.send({ tokenAddress }, options)`
 
 Creates a new colony on the network.

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -91,7 +91,7 @@ function printCallers(callers) {
   return `
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contract-client/#callers).
+**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 ` +
     callers
       .map(
@@ -117,7 +117,7 @@ function printSenders(senders) {
   return `
 ## Senders
 
-**All senders return an instance of a \`ContractResponse\`.** Every \`send()\` method takes an \`options\` object as the second argument. For a reference please check [here](/colonyjs/docs-contract-client/#senders).` +
+**All senders return an instance of a \`ContractResponse\`.** Every \`send()\` method takes an \`options\` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).` +
     senders
       .map(
         sender => `


### PR DESCRIPTION
The link to the contract client were wrong in the docgen. This should be fixed now.