### PR TITLE
Fix broken documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To learn more about Colony, you can visit [the website](https://colony.io/) or r
 
 ## Documentation
 
-Please see the [full documentation](https://joincolony.github.io/colonyjs/) with detailed examples and explanations.
+Please see the [full documentation](https://joincolony.github.io/colonyjs/docs-overview/) with detailed examples and explanations.
 
 ## Contributing
 


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

## Description (Required)
Just fixing the link in the README to go to the docs overview. 
