### PR TITLE
Bug fix: Convert non-hex string input values to hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Fixed the documentation site link in the `README`
+* Fixed a bug where string input values were not converted properly (`@colony/colony-js-contract-client`)
 
 ## v1.1.0
 

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -131,16 +131,17 @@ describe('Parameter types', () => {
 
     // Converting input values
     isHex.mockReturnValueOnce(true);
-    expect(convertInputValue('a', 'string')).toBe('a');
-    expect(isHex).toHaveBeenCalledWith('a');
-    expect(utf8ToHex).toHaveBeenCalledWith('a');
+    expect(convertInputValue('0x123', 'string')).toBe('0x123');
+    expect(isHex).toHaveBeenCalledWith('0x123');
+    expect(utf8ToHex).not.toHaveBeenCalledWith();
     isHex.mockClear();
     utf8ToHex.mockClear();
 
     isHex.mockReturnValueOnce(false);
-    expect(convertInputValue('a', 'string')).toBe('a');
-    expect(isHex).toHaveBeenCalledWith('a');
-    expect(utf8ToHex).not.toHaveBeenCalled();
+    utf8ToHex.mockReturnValueOnce('0x123');
+    expect(convertInputValue('not a hex value', 'string')).toBe('0x123');
+    expect(isHex).toHaveBeenCalledWith('not a hex value');
+    expect(utf8ToHex).toHaveBeenCalledWith('not a hex value');
   });
 
   test('Adding param types', () => {

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -61,7 +61,8 @@ const PARAM_TYPE_MAP: {
       return typeof value === 'string' && value.length ? value : null;
     },
     convertInput(value: string) {
-      return isHex(value) ? utf8ToHex(value) : value;
+      // String values are converted to hex (if they aren't hex already)
+      return isHex(value) ? value : utf8ToHex(value);
     },
   },
 };


### PR DESCRIPTION
## Description

The parameter mapping introduce in #121 contained a bug relating to string conversion: the statement was the wrong way round, leading to non-hex strings not being converted to hex strings. 

The tests have been made more explicit in order to try and prevent this.
