### PR TITLE
Update ethers to 3.0.17 (from 3.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**Maintenance**
+
+* Update `ethers` to `3.0.17` (`@colony/colony-js-adapter-ethers)`
+
 **Bug fixes**
 
 * Fix `ROLES` values to reflect contracts (`@colony/colony-js-client`)

--- a/packages/colony-js-adapter-ethers/package.json
+++ b/packages/colony-js-adapter-ethers/package.json
@@ -56,7 +56,7 @@
         "@colony/colony-js-contract-loader-http": "^1.1.2",
         "@colony/colony-js-utils": "^1.1.2",
         "babel-runtime": "^6.26.0",
-        "ethers": "^3.0.3"
+        "ethers": "^3.0.17"
     },
     "devDependencies": {
         "flow-bin": "^0.72.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,12 +611,19 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.2.2, babel-jest@^22.4.3:
+babel-jest@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.3.tgz#4b7a0b6041691bbd422ab49b3b73654a49a6627a"
   dependencies:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.3"
+
+babel-jest@^23.0.0:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.1.tgz#bbad3bf523fb202da05ed0a6540b48c84eed13a6"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.0.1"
 
 babel-loader@^7.1.2:
   version "7.1.4"
@@ -644,7 +651,7 @@ babel-plugin-dynamic-import-node@^1.2.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
-babel-plugin-istanbul@^4.1.5:
+babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -656,6 +663,10 @@ babel-plugin-istanbul@^4.1.5:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-jest-hoist@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz#eaa11c964563aea9c21becef2bdf7853f7f3c148"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1043,6 +1054,13 @@ babel-preset-jest@^22.4.3:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
   dependencies:
     babel-plugin-jest-hoist "^22.4.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
+  dependencies:
+    babel-plugin-jest-hoist "^23.0.1"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-stage-1@^6.5.0:
@@ -2670,9 +2688,9 @@ eth-lib@0.1.27:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
-ethers@^3.0.3:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.9.tgz#19da254a2e8adacff380f6090be8b8ea367bda00"
+ethers@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.17.tgz#b24cbca4d5faaf738efcbab00e916f3f49def434"
   dependencies:
     aes-js "3.0.0"
     bn.js "^4.4.0"
@@ -3027,9 +3045,9 @@ flow-parser@^0.*:
   version "0.69.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
 
-flow-parser@^0.72.0:
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.72.0.tgz#6c8041e76ac7d0be1a71ce29c00cd1435fb6013c"
+flow-parser@^0.73.0:
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.73.0.tgz#525ac0776f743e16b6dca1a3dd6c602260b15773"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
## Description (Required)

Updates `ethers` from 3.0.0 to 3.0.17. 

A diff is available here: https://github.com/ethers-io/ethers.js/compare/bd7e8e708f9874180739156f03994c7109f9a70d...master 

AFAICT, there are no breaking changes for `EthersAdapter`.

## TODO

> ⚠️  NOTE: Please make sure all items are checked or remove the TODO list before closing the PR

- [x] Confirm that this branch does not break the integration testing
