### PR TITLE
Maintain nonce value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**Enhancements**
+
+* The nonce value is now carried through when serializing and restoring MultisigOperations (`@colony/colony-js-contract-client)`
+
 **Maintenance**
 
 * Update `ethers` to `3.0.17` (`@colony/colony-js-adapter-ethers)`
@@ -9,6 +13,7 @@
 **Bug fixes**
 
 * Fix `ROLES` values to reflect contracts (`@colony/colony-js-client`)
+* Fixed a bug where `MultisigOperation`s erroneously had required signees reset upon restoring an operation (`@colony/colony-js-contract-client)`
 
 ## v1.1.2
 

--- a/docs/_API_MultisigOperation.md
+++ b/docs/_API_MultisigOperation.md
@@ -32,7 +32,9 @@ The `MultisigOperation` instance.
 
 ### `refresh()`
 
-Refresh the required signees, nonce value and message hash. If the nonce value has changed, `_signers` will be reset.
+Refresh the nonce value, required signees, and message hash.
+
+If there was no nonce value, a new one will be set; otherwise, if the nonce value changed, the it will be updated, and the `_signers` will be reset. This is done because when the nonce values changes, the signatures that were collected will not work, and the operation will need to be re-signed by all parties.
 
 **Returns**
 

--- a/docs/_Docs_Multisignature.md
+++ b/docs/_Docs_Multisignature.md
@@ -90,7 +90,7 @@ Firstly, we'll need to export some JSON from the `MultisigOperation` we want to 
 
 ```js
 const json = op.toJSON();
-// -> "{ "payload": {...}, "signers": {...} }"
+// -> "{ "nonce": 0, "payload": {...}, "signers": {...} }"
 ```
 
 We can restore this elsewhere with the appropriate `MultisigSender`:

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodMultisigSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodMultisigSender.js
@@ -154,10 +154,13 @@ describe('ContractMethodMultisigSender', () => {
       },
     };
 
-    const op = await method._startOperation(payload, signers);
+    const op = await method._startOperation({ payload, signers });
 
     expect(op).toBeInstanceOf(MultisigOperation);
-    expect(MultisigOperation).toHaveBeenCalledWith(method, payload, signers);
+    expect(MultisigOperation).toHaveBeenCalledWith(
+      method,
+      expect.objectContaining({ payload, signers }),
+    );
     expect(op.refresh).toHaveBeenCalled();
   });
 
@@ -193,11 +196,13 @@ describe('ContractMethodMultisigSender', () => {
     expect(op).toBeInstanceOf(MultisigOperation);
     expect(method._startOperation).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: txData,
-        destinationAddress: method.client.contract.address,
-        inputValues,
-        sourceAddress: method.client.contract.address,
-        value: 0,
+        payload: {
+          data: txData,
+          destinationAddress: method.client.contract.address,
+          inputValues,
+          sourceAddress: method.client.contract.address,
+          value: 0,
+        },
       }),
     );
   });
@@ -213,6 +218,7 @@ describe('ContractMethodMultisigSender', () => {
     });
 
     const state = {
+      nonce: 5,
       payload: {
         data: '0x123',
         destinationAddress: method.client.contract.address,
@@ -239,8 +245,7 @@ describe('ContractMethodMultisigSender', () => {
 
     expect(op).toBeInstanceOf(MultisigOperation);
     expect(method._startOperation).toHaveBeenCalledWith(
-      state.payload,
-      state.signers,
+      expect.objectContaining(state),
     );
   });
 });

--- a/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
@@ -189,14 +189,11 @@ describe('MultisigOperation', () => {
     ]);
   });
 
-  test('Validating required signees (all signees present)', async () => {
+  test('Validating required signees (all signees present)', () => {
     const op = new MultisigOperation(sender, { payload, signers });
+    op._requiredSignees = Object.keys(signers);
 
-    const valid = await op._validateRequiredSignees();
-
-    expect(op.sender.getRequiredSignees).toHaveBeenCalledWith(
-      op.payload.inputValues,
-    );
+    const valid = op._validateRequiredSignees();
 
     expect(assert).toHaveBeenCalledWith(
       true,
@@ -206,7 +203,7 @@ describe('MultisigOperation', () => {
     expect(valid).toBe(true);
   });
 
-  test('Validating required signees (missing a required signee)', async () => {
+  test('Validating required signees (missing a required signee)', () => {
     const [addressOne, addressTwo, addressThree] = Object.keys(signers);
     const twoSigners = {
       [addressOne]: signers[addressOne],
@@ -214,8 +211,9 @@ describe('MultisigOperation', () => {
     };
 
     const op = new MultisigOperation(sender, { payload, signers: twoSigners });
+    op._requiredSignees = [addressOne, addressTwo, addressThree];
 
-    await op._validateRequiredSignees();
+    expect(op._validateRequiredSignees()).toBe(true);
 
     expect(assert).toHaveBeenCalledWith(
       false,

--- a/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
@@ -47,6 +47,8 @@ describe('MultisigOperation', () => {
     isEqual.mockClear();
   });
 
+  const nonce = 5;
+
   const signature = {
     sigR: '0x3810976581519370936455002930541734832270292486195672859026812854',
     sigS: '0x2717400036569076491467357688191371198012187172992592815125647808',
@@ -148,7 +150,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Combining signatures', () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
 
     // Test helper to get a certain prop from the signatures in order
     const sortedSigs = Object.keys(op._signers).sort();
@@ -165,7 +167,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Getting Multisig arguments', () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
     const combined = {
       sigV: 'sigV',
       sigR: 'sigR',
@@ -188,7 +190,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Validating required signees (all signees present)', async () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
 
     const valid = await op._validateRequiredSignees();
 
@@ -211,7 +213,7 @@ describe('MultisigOperation', () => {
       [addressTwo]: signers[addressTwo],
     };
 
-    const op = new MultisigOperation(sender, payload, twoSigners);
+    const op = new MultisigOperation(sender, { payload, signers: twoSigners });
 
     await op._validateRequiredSignees();
 
@@ -225,17 +227,20 @@ describe('MultisigOperation', () => {
     sandbox.spyOn(MultisigOperation, '_validatePayload').mockReturnValue(true);
     sandbox.spyOn(MultisigOperation, '_validateSigners').mockReturnValue(true);
 
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers, nonce });
 
     expect(op).toBeInstanceOf(MultisigOperation);
-    expect(op.sender).toBe(sender);
-    expect(op.payload).toEqual(payload);
+    expect(assert).toHaveBeenCalledWith(true, expect.stringMatching('nonce'));
     expect(op.constructor._validatePayload).toHaveBeenCalledWith(payload);
     expect(op.constructor._validateSigners).toHaveBeenCalledWith(signers);
+    expect(op.sender).toBe(sender);
+    expect(op.payload).toEqual(payload);
+    expect(op._signers).toBe(signers);
+    expect(op._nonce).toBe(nonce);
   });
 
   test('Payload is immutable', () => {
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
 
     expect(() => {
       op.payload.data = 'some new value';
@@ -243,7 +248,7 @@ describe('MultisigOperation', () => {
   });
 
   test('JSON contains payload and signers', () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
     const json = op.toJSON();
     expect(typeof json).toBe('string');
     expect(JSON.parse(json)).toEqual({
@@ -262,7 +267,10 @@ describe('MultisigOperation', () => {
       [addressThree]: signers[addressThree],
     };
 
-    const op = new MultisigOperation(sender, payload, initialSigners);
+    const op = new MultisigOperation(sender, {
+      payload,
+      signers: initialSigners,
+    });
 
     const json = JSON.stringify({ payload, signers: addedSigners });
 
@@ -287,7 +295,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Adding state as JSON (invalid json)', () => {
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
 
     expect(() => {
       op.addSignersFromJSON('aksjdhkjasdhkj');
@@ -295,7 +303,7 @@ describe('MultisigOperation', () => {
   });
 
   test('ERC191 Message hash is created properly', async () => {
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
     op._nonce = 5;
 
     // It should be undefined until operation is refreshed
@@ -319,7 +327,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Signed message digests', () => {
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
     op._nonce = 5;
 
     // Initialise the hash
@@ -357,7 +365,7 @@ describe('MultisigOperation', () => {
       'get',
     );
 
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
 
     op._getMessageDigest(0);
     expect(digestSpy).toHaveBeenCalled();
@@ -381,7 +389,7 @@ describe('MultisigOperation', () => {
       .spyOn(MultisigOperation.prototype, '_signedTrezorMessageDigest', 'get')
       .mockReturnValue(trezorDigest);
 
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
 
     sandbox.spyOn(op, '_getMessageDigest');
     op.sender.client.adapter.ecRecover
@@ -410,7 +418,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Adding signatures', () => {
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
     const mode = 1;
 
     sandbox.spyOn(op, '_findSignatureMode').mockReturnValue(mode);
@@ -424,7 +432,7 @@ describe('MultisigOperation', () => {
   test('Signing', async () => {
     const messageHash = 'messageHash';
 
-    const op = new MultisigOperation(sender, payload);
+    const op = new MultisigOperation(sender, { payload });
     op._messageHash = messageHash;
 
     sandbox.spyOn(op, '_addSignature').mockReturnValue(signature);
@@ -444,7 +452,7 @@ describe('MultisigOperation', () => {
 
   test('Operation can be sent with Sender', async () => {
     const args = [123, 'abc'];
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
     sandbox
       .spyOn(op, '_validateRequiredSignees')
       .mockImplementation(() => true);
@@ -460,24 +468,27 @@ describe('MultisigOperation', () => {
   });
 
   test('Refreshing', async () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
 
+    sandbox.spyOn(op, '_refreshNonce').mockImplementation(async () => {});
     sandbox
       .spyOn(op, '_refreshRequiredSignees')
       .mockImplementation(async () => {});
-    sandbox.spyOn(op, '_refreshNonce').mockImplementation(async () => {});
     sandbox.spyOn(op, '_refreshMessageHash').mockImplementation(() => {});
 
     await op.refresh();
 
-    expect(op._refreshRequiredSignees).toHaveBeenCalled();
+    // Ideally, jest would support asserting that _refreshNonce is called
+    // before _refreshRequiredSignees, because if a new nonce value was set,
+    // the signers are reset.
     expect(op._refreshNonce).toHaveBeenCalled();
+    expect(op._refreshRequiredSignees).toHaveBeenCalled();
     expect(op._refreshMessageHash).toHaveBeenCalled();
   });
 
   test('Refreshing the nonce', async () => {
     const onReset = sandbox.fn();
-    const op = new MultisigOperation(sender, payload, signers, onReset);
+    const op = new MultisigOperation(sender, { payload, signers, onReset });
 
     const oldNonce = 20;
     const newNonce = 21;
@@ -501,7 +512,7 @@ describe('MultisigOperation', () => {
   });
 
   test('Refreshing required signees', async () => {
-    const op = new MultisigOperation(sender, payload, signers);
+    const op = new MultisigOperation(sender, { payload, signers });
 
     const newSigners = ['signer one', 'signer two'];
     op.sender.getRequiredSignees.mockImplementationOnce(async () => newSigners);
@@ -511,5 +522,55 @@ describe('MultisigOperation', () => {
       op.payload.inputValues,
     );
     expect(op._requiredSignees).toEqual(newSigners);
+  });
+
+  test('Getting missing signees', async () => {
+    const signer1 = 'signer1';
+    const signer2 = 'signer2';
+    const requiredSignees = [signer1, signer2];
+    const op = new MultisigOperation(sender, {
+      payload,
+      signers: {
+        signer1,
+      },
+    });
+    op._requiredSignees = requiredSignees;
+
+    expect(op.requiredSignees).toEqual(requiredSignees);
+    expect(op.missingSignees).toEqual([signer2]);
+
+    // with refreshing
+    sandbox
+      .spyOn(op.sender, 'getRequiredSignees')
+      .mockImplementation(async () => requiredSignees);
+    await op._refreshRequiredSignees();
+
+    expect(op.requiredSignees).toEqual(requiredSignees);
+    expect(op.missingSignees).toEqual([signer2]);
+  });
+
+  test('Validating nonce', () => {
+    sandbox
+      .spyOn(MultisigOperation, '_validatePayload')
+      .mockImplementation(() => true);
+    sandbox
+      .spyOn(MultisigOperation, '_validateSigners')
+      .mockImplementation(() => true);
+
+    // Invalid nonce supplied
+    ['1', 0.1].forEach(input => {
+      // eslint-disable-next-line no-new
+      new MultisigOperation(sender, { payload, nonce: input });
+      expect(assert).toHaveBeenCalledWith(
+        false,
+        expect.stringMatching('nonce'),
+      );
+    });
+
+    // No nonce supplied, or valid nonce supplied
+    [undefined, null, 0, 1, 5].forEach(input => {
+      const op = new MultisigOperation(sender, { payload, nonce: input });
+      expect(op).toBeInstanceOf(MultisigOperation);
+    });
   });
 });

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -12,6 +12,7 @@ import ContractClient from './ContractClient';
 
 import type {
   CombinedSignatures,
+  MultisigOperationConstructorArgs,
   MultisigOperationPayload,
   SendOptions,
   Signature,
@@ -96,22 +97,26 @@ export default class MultisigOperation<
 
   constructor(
     sender: Sender,
-    payload: MultisigOperationPayload<InputValues>,
-    signers?: Signers = {},
-    onReset?: Function,
+    args: MultisigOperationConstructorArgs<InputValues>,
   ) {
+    const { payload, signers = {}, nonce, onReset } = args;
     this.constructor._validatePayload(payload);
     this.constructor._validateSigners(signers);
+    defaultAssert(
+      nonce == null || Number.isInteger(nonce),
+      'The optional `nonce` parameter should be an integer',
+    );
 
     this.sender = sender;
     this.payload = Object.freeze(Object.assign({}, payload));
     this._signers = signers;
     if (onReset) this._onReset = onReset;
+    if (nonce !== undefined && Number(nonce) === nonce) this._nonce = nonce;
   }
 
   toJSON() {
-    const { payload, _signers: signers } = this;
-    return JSON.stringify({ payload, signers });
+    const { _nonce: nonce, payload, _signers: signers } = this;
+    return JSON.stringify({ nonce, payload, signers });
   }
 
   /**
@@ -277,13 +282,21 @@ export default class MultisigOperation<
    * If the nonce value has changed, `_signers` will be reset.
    */
   async refresh() {
-    await this._refreshRequiredSignees();
     await this._refreshNonce();
+    await this._refreshRequiredSignees();
     this._refreshMessageHash();
     return this;
   }
 
   async _refreshNonce() {
+    // If the nonce has not yet been set, simply set it; Don't reset signers,
+    // because we don't have a way of knowing whether they're valid or nor;
+    // assume they are still valid.
+    if (!Object.hasOwnProperty.call(this, '_nonce')) {
+      this._nonce = await this.sender.getNonce();
+      return;
+    }
+
     const oldNonce = Number(this._nonce);
     const newNonce = await this.sender.getNonce();
     if (oldNonce !== newNonce) {

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -230,9 +230,7 @@ export default class MultisigOperation<
    * Ensure that there are no missing signees (based on the input values for
    * this operation).
    */
-  async _validateRequiredSignees() {
-    await this._refreshRequiredSignees();
-
+  _validateRequiredSignees() {
     defaultAssert(
       this.missingSignees.length === 0,
       `Missing signatures (from addresses ${this.missingSignees.join(', ')})`,
@@ -246,7 +244,7 @@ export default class MultisigOperation<
    */
   async send(options: SendOptions) {
     await this.refresh();
-    await this._validateRequiredSignees();
+    this._validateRequiredSignees();
     return this.sender.sendMultisig(this._getArgs(), options);
   }
 

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -118,3 +118,10 @@ export type MultisigOperationPayload<InputValues> = {
   sourceAddress: string,
   value: number,
 };
+
+export type MultisigOperationConstructorArgs<InputValues> = {
+  payload: MultisigOperationPayload<InputValues>,
+  signers?: Signers,
+  nonce?: number,
+  onReset?: Function,
+};


### PR DESCRIPTION
## Description (Required)

* The nonce value is now carried through when serializing and restoring a `MultisigOperation`
* Fixes a bug where `MultisigOperation`s erroneously had required signees reset upon restoring an operation


## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Changed the parameters for `MultisigOperation`; it now accepts a Sender and an object with (optional) parameters such as `payload`/`signers`/`nonce`
* Adds test coverage for validating the nonce and getting missing signees
* Updated docs to reflect changes

## TODO

> ⚠️  NOTE: Please make sure all items are checked or remove the TODO list before closing the PR

- [x] Check with integration testing (task workflow branch)

Resolves #140 
