### PR TITLE
Fixes Getting Started usage of colony-wallet, update Getting Started/Quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Documentation**
+
+* Updated the Quickstart and Get Started documentation; these guides now show how to use an `ethers` wallet, use `require` statements over `import`, and provide some additional information about prerequisites.
 
 ## v.1.1.3
 

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -22,7 +22,7 @@ You can learn about how to install the Colony Network contracts [here](/colonyne
 If you haven't done so already, add the required libraries to your project with `yarn`:
 
 ```bash
-yarn add @colony/colony-js-client @colony/colony-js-adapter-ethers @colony/colony-js-contract-loader-http @colony/colony-wallet
+yarn add @colony/colony-js-client @colony/colony-js-adapter-ethers @colony/colony-js-contract-loader-http ethers
 ```
 
 ### Example
@@ -36,11 +36,16 @@ import EthersAdapter from '@colony/colony-js-adapter-ethers';
 
 import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
 
-import { software as wallet } from 'colony-wallet/wallets';
-import { localhost } from 'colony-wallet/providers';
+import { providers, Wallet } from 'ethers';
 
 const loader = new TrufflepigLoader();
-const provider = localhost('http://localhost:8545/');
+const provider = new providers.JsonRpcProvider(
+  'http://localhost:8545/',
+  'homestead',
+);
+
+const wallet = new Wallet.createRandom();
+wallet.provider = provider;
 
 const adapter = new EthersAdapter({ loader, provider, wallet });
 

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -15,7 +15,7 @@ First of all, we will need to set up some prerequisites (clients for the Colony 
 
 ### Colony Network
 
-You can learn about how to install the Colony Network contracts [here](/colonynetwork/docs-get-started/). It's important to note that the recommended commit to clone is currently [`ce9811a`](https://github.com/JoinColony/colonyNetwork/commit/ce9811a9f0fca53d9ab417d5fc24bbcf29c351c8).
+You can learn about how to install the Colony Network contracts [here](/colonynetwork/docs-get-started/). It's important to note that the recommended commit to clone is currently [`ce9811a`](https://github.com/JoinColony/colonyNetwork/commit/ce9811a9f0fca53d9ab417d5fc24bbcf29c351c8). Once the contracts are compiled and running with e.g. Ganache, you should be good to go for this guide.
 
 ### Libraries
 
@@ -25,63 +25,73 @@ If you haven't done so already, add the required libraries to your project with 
 yarn add @colony/colony-js-client @colony/colony-js-adapter-ethers @colony/colony-js-contract-loader-http ethers
 ```
 
+### Tooling
+
+You will need some means of loading the contract definitions into your app. This is easy to do with [TrufflePig](https://github.com/JoinColony/trufflepig). See our guide to [starting TrufflePig](/colonynetwork/docs-get-started/#install-and-configure-a-contract-loader-like-trufflepig).
+
+It's also beneficial to have a JavaScript environment that supports `async`/`await`, since colonyJS uses Promises extensively. Recent versions of Node and Chrome support Promises out of the box, but you may want to consider using [webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/) for better support.
+
 ### Example
 
 For your application to be able to communicate with colony, you'll need to configure a [Loader](/colonyjs/docs-loaders/) to read contracts, an [Adapter](/colonyjs/docs-adapters/) to communicate with the blockchain, and a wallet to be able to send transactions that require a signature.
 
 ```js
-import ColonyNetworkClient, { ROLES } from '@colony/colony-js-client';
+// Import the prerequisites
+const { providers, Wallet } = require('ethers');
+const { default: EthersAdapter } = require('@colony/colony-js-adapter-ethers');
+const { TrufflepigLoader } = require('@colony/colony-js-contract-loader-http');
 
-import EthersAdapter from '@colony/colony-js-adapter-ethers';
+// Import the ColonyNetworkClient
+const { default: ColonyNetworkClient } = require('@colony/colony-js-client');
 
-import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
-
-import { providers, Wallet } from 'ethers';
-
+// Create an instance of the Trufflepig contract loader
 const loader = new TrufflepigLoader();
-const provider = new providers.JsonRpcProvider(
-  'http://localhost:8545/',
-  'homestead',
-);
 
-const wallet = new Wallet.createRandom();
-wallet.provider = provider;
+// Create a provider for local TestRPC (Ganache)
+const provider = new providers.JsonRpcProvider('http://localhost:8545/');
 
-const adapter = new EthersAdapter({ loader, provider, wallet });
+// The following methods use Promises
+(async () => {
+  // Get the private key from the first account from the Truffle config
+  const { privateKey } = await loader.getAccount(0);
 
-// Create a ColonyNetworkClient instance
-const networkClient = new ColonyNetworkClient({ adapter });
-await networkClient.init();
+  // Create a wallet with the private key (so we have a balance we can use)
+  const wallet = new Wallet(privateKey, provider);
 
-```
+  // Create an adapter (powered by ethers)
+  const adapter = new EthersAdapter({
+    loader,
+    provider,
+    wallet,
+  });
 
-You'll need to either create a new colony or talk to an existing one.
+  // Connect to ColonyNetwork with the adapter!
+  const networkClient = new ColonyNetworkClient({ adapter });
+  await networkClient.init();
 
-```js
-// To create a new cool colony:
-const colonyData = {
-  name: 'MyCoolColony', // Unique name for the colony
-  tokenAddress: '0xf000000000000000000000000000000000000000', // Address of the colony's native token
-};
+  // You'll need to either create a new colony or talk to an existing one.
 
-// Create a cool Colony!
-const { eventData: { colonyId, colonyAddress }} = await networkClient.createColony.send(colonyData);
+  // To create a new cool colony:
+  const colonyData = {
+    tokenAddress: '0xf000000000000000000000000000000000000000', // Address of the colony's native token
+  };
 
-// Congrats, you've created a Colony!
-console.log(colonyId, colonyAddress);
-```
+  // Create a cool Colony!
+  const { eventData: { colonyId, colonyAddress }} = await networkClient.createColony.send(colonyData);
 
-```js
-// For a colony that exists already, you just need its ID:
-const colonyClient = await networkClient.getColonyClient(colonyId);
+  // Congrats, you've created a Colony!
+  console.log(colonyId, colonyAddress);
 
-// Or alternatively, just its address:
-const colonyClient = await networkClient.getColonyClientByAddress(colonyAddress);
-```
+  // For a colony that exists already, you just need its ID:
+  const colonyClient = await networkClient.getColonyClient(colonyId);
 
-```js
-// You can also get the Meta Colony:
-const metaColonyClient = await networkClient.getMetaColonyClient();
+  // Or alternatively, just its address:
+  // const colonyClient = await networkClient.getColonyClientByAddress(colonyAddress);
+
+  // You can also get the Meta Colony:
+  const metaColonyClient = await networkClient.getMetaColonyClient();
+
+})();
 ```
 
 

--- a/docs/_Docs_Quickstart.md
+++ b/docs/_Docs_Quickstart.md
@@ -38,14 +38,25 @@ npm install --save @colony/colony-js-client @colony/colony-js-adapter-ethers @co
 ## Example code
 
 ```js
-(async () => {
-  const DEFAULT_GANACHE_HOST = 'http://localhost:8545/';
+// Import the prerequisites
+const { providers, Wallet } = require('ethers');
+const { default: EthersAdapter } = require('@colony/colony-js-adapter-ethers');
+const { TrufflepigLoader } = require('@colony/colony-js-contract-loader-http');
 
-  // Get the first account's private key from Trufflepig
+// Import the ColonyNetworkClient
+const { default: ColonyNetworkClient } = require('@colony/colony-js-client');
+
+// Create an instance of the Trufflepig contract loader
+const loader = new TrufflepigLoader();
+
+// Create a provider for local TestRPC (Ganache)
+const provider = new providers.JsonRpcProvider('http://localhost:8545/');
+
+(async () => {
+  // Get the private key from the first account from the Truffle config
   const { privateKey } = await loader.getAccount(0);
 
-  // Create a provider and wallet with ethers
-  const provider = new providers.JsonRpcProvider(DEFAULT_GANACHE_HOST);
+  // Create a wallet with the private key (so we have a balance we can use)
   const wallet = new Wallet(privateKey, provider);
 
   // Create an adapter (powered by ethers)
@@ -55,18 +66,9 @@ npm install --save @colony/colony-js-client @colony/colony-js-adapter-ethers @co
     wallet,
   });
 
-  // Connect to ColonyNetwork!
+  // Connect to ColonyNetwork with the adapter!
   const networkClient = new ColonyNetworkClient({ adapter });
   await networkClient.init();
-
-  // Log networkClient in the console so we can poke around
-  console.log(networkClient);
-
-  // Get an instance of the Meta Colony!
-  const metaColonyClient = await networkClient.getMetaColonyClient();
-
-  // Log metaColonyClient in the console so we can poke around
-  console.log(metaColonyClient);
 
   // Create a new Token contract
   const tokenAddress = await networkClient.createToken({
@@ -75,9 +77,8 @@ npm install --save @colony/colony-js-client @colony/colony-js-adapter-ethers @co
   });
   console.log(`CoolonyToken contract address: ${tokenAddress}`);
 
-  // Create a cool Colony! (with a unique name)
+  // Create a cool Colony!
   const { eventData: { colonyId, colonyAddress } } = await networkClient.createColony.send({
-    name: `Coolony-${Date.now()}`,
     tokenAddress,
   });
 
@@ -87,7 +88,7 @@ npm install --save @colony/colony-js-client @colony/colony-js-adapter-ethers @co
   // We can now connect to our Colony
   const colonyClient = await networkClient.getColonyClient(colonyId);
 
-  // Log colonyClient in the console so we can poke around
-  console.log(colonyClient);
+  // We can also get an instance of the Meta Colony
+  const metaColonyClient = await networkClient.getMetaColonyClient();
 })();
 ```


### PR DESCRIPTION
## Description

Updates the Quickstart and Get Started documentation; these guides now show how to use an `ethers` wallet, use `require` statements over `import`, and provide some additional information about prerequisites.

Closes #143.