### PR TITLE
Set Sender's `defaultGasLimit` as a number

### DIFF
--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -336,7 +336,7 @@ export default class ColonyNetworkClient extends ContractClient {
     // Senders
     this.addSender('createColony', {
       input: [['tokenAddress', 'address']],
-      defaultGasLimit: new BigNumber(2500000),
+      defaultGasLimit: 2500000,
       eventHandlers: {
         ColonyAdded: {
           contract: this.contract,

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
@@ -219,8 +219,8 @@ describe('ContractMethodSender', () => {
   });
 
   test('Default send options', () => {
-    const A = new BigNumber(1);
-    const B = new BigNumber(100000);
+    const A = 1;
+    const B = 100000;
 
     const methodWithoutDefault = new ContractMethodSender({
       client,

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -24,7 +24,7 @@ export default class ContractMethodSender<
   IContractClient: ContractClient,
 > extends ContractMethod<InputValues, OutputValues, IContractClient> {
   eventHandlers: EventHandlers;
-  _defaultGasLimit: ?BigNumber;
+  _defaultGasLimit: ?number;
 
   constructor({
     defaultGasLimit,
@@ -32,7 +32,7 @@ export default class ContractMethodSender<
     ...rest
   }: ContractMethodArgs<IContractClient> & {
     eventHandlers?: EventHandlers,
-    defaultGasLimit?: BigNumber,
+    defaultGasLimit?: number,
   }) {
     super(rest);
     if (defaultGasLimit) this._defaultGasLimit = defaultGasLimit;


### PR DESCRIPTION
## Description

This PR defines the `defaultGasLimit` property of Senders as a number as opposed to a `BigNumber`, as wallets (e.g. ethers) require a number for this property when it is sent as an override option.
