### PR TITLE
Fix link in ethers adapter readme

### DIFF
--- a/packages/colony-js-adapter-ethers/README.md
+++ b/packages/colony-js-adapter-ethers/README.md
@@ -10,7 +10,7 @@ yarn add ethers @colony/colony-js-adapter-ethers
 
 ## Usage
 
-Please see [the full documentation](https://joincolony.github.io/colonyjs/api-adapters/).
+Please see [the full documentation](https://joincolony.github.io/colonyjs/docs-adapters/).
 
 
 ## Contributing


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

## Description (Required)

Fixes the link to point to colonyjs/docs-adapters/, instead of the API (which was removed) 