### PR TITLE
Add source maps to lib builds for easier debugging

### DIFF
--- a/packages/colony-js-adapter-ethers/package.json
+++ b/packages/colony-js-adapter-ethers/package.json
@@ -12,7 +12,7 @@
         "build": "yarn run clean && yarn run build:dist && yarn run build:lib && yarn run build:flow",
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
-        "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:lib": "babel src --out-dir lib --ignore __tests__ --source-maps",
         "clean": "shx rm -rf lib",
         "flow": "flow src",
         "lint": "eslint src/{,**/}*.js",

--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -12,7 +12,7 @@
         "build": "yarn run clean && yarn run build:dist && yarn run build:lib && yarn run build:flow",
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
-        "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:lib": "babel src --out-dir lib --ignore __tests__ --source-maps",
         "build:docs": "scripts/docgen.js",
         "clean": "shx rm -rf lib",
         "flow": "flow check",

--- a/packages/colony-js-contract-client/package.json
+++ b/packages/colony-js-contract-client/package.json
@@ -12,7 +12,7 @@
         "build": "yarn run clean && yarn run build:dist && yarn run build:lib && yarn run build:flow",
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
-        "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:lib": "babel src --out-dir lib --ignore __tests__ --source-maps",
         "clean": "shx rm -rf lib",
         "flow": "flow check",
         "lint": "eslint src/{,**/}*.js",

--- a/packages/colony-js-contract-loader-http/package.json
+++ b/packages/colony-js-contract-loader-http/package.json
@@ -12,7 +12,7 @@
         "build": "yarn run clean && yarn run build:dist && yarn run build:lib && yarn run build:flow",
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
-        "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:lib": "babel src --out-dir lib --ignore __tests__ --source-maps",
         "clean": "shx rm -rf lib",
         "flow": "flow check",
         "lint": "eslint src/{,**/}*.js",

--- a/packages/colony-js-utils/package.json
+++ b/packages/colony-js-utils/package.json
@@ -12,7 +12,7 @@
         "build": "yarn run clean && yarn run build:dist && yarn run build:lib && yarn run build:flow",
         "build:dist": "webpack",
         "build:flow": "flow-copy-source src lib --ignore '__tests__/*.js'",
-        "build:lib": "babel src --out-dir lib --ignore __tests__",
+        "build:lib": "babel src --out-dir lib --ignore __tests__ --source-maps",
         "clean": "shx rm -rf lib",
         "flow": "flow src",
         "lint": "eslint src/{,**/}*.js",


### PR DESCRIPTION
This PR adds source maps to the built lib files. This allows for easier debugging in browsers or node.

Closes #154.