### PR TITLE
Add 'empty' IPFS hash output validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug fixes**
 
 * Ensure that the returned values in `ColonyClient.getTask` were handled properly (`@colony/colony-js-client`)
+* Clean 'empty' hex strings for IPFS hash output validation (`@colony/colony-js-contract-client`)
 
 ## v1.1.4
 

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -4,7 +4,11 @@ import createSandbox from 'jest-sandbox';
 import BigNumber from 'bn.js';
 
 import bs58 from 'bs58';
-import { isValidAddress, isBigNumber } from '@colony/colony-js-utils';
+import {
+  isValidAddress,
+  isBigNumber,
+  isEmptyHexString,
+} from '@colony/colony-js-utils';
 import { isHex, utf8ToHex, hexToBytes } from 'web3-utils';
 
 import {
@@ -17,6 +21,7 @@ import {
 jest.mock('@colony/colony-js-utils', () => ({
   isBigNumber: jest.fn().mockReturnValue(true),
   isValidAddress: jest.fn().mockReturnValue(true),
+  isEmptyHexString: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('bs58', () => ({
@@ -37,6 +42,7 @@ describe('Parameter types', () => {
     sandbox.clear();
     isBigNumber.mockClear();
     isValidAddress.mockClear();
+    isEmptyHexString.mockClear();
     isHex.mockClear();
     utf8ToHex.mockClear();
     hexToBytes.mockClear();
@@ -172,16 +178,20 @@ describe('Parameter types', () => {
     bs58.encode.mockReturnValueOnce(bytes32Hash);
     isHex.mockReturnValueOnce(true);
     hexToBytes.mockReturnValueOnce(bytes);
+    isEmptyHexString.mockReturnValueOnce(false);
     expect(convertOutputValue(hash, 'ipfsHash')).toBe(bytes32Hash);
     expect(isHex).toHaveBeenCalledWith(hash);
+    expect(isEmptyHexString).toHaveBeenCalledWith(hash);
     expect(hexToBytes).toHaveBeenCalledWith(`0x1220${hash.slice(2)}`);
     expect(bs58.encode).toHaveBeenCalledWith(bytes);
 
     // Empty hashes are cleaned:
-    isHex.mockReturnValueOnce(false);
+    isHex.mockReturnValueOnce(true);
+    isEmptyHexString.mockReturnValueOnce(true);
     expect(convertOutputValue('', 'ipfsHash')).toBe(null);
 
     isHex.mockClear();
+    isEmptyHexString.mockClear();
     hexToBytes.mockClear();
     bs58.encode.mockClear();
 

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -3,7 +3,11 @@
 import bs58 from 'bs58';
 import BigNumber from 'bn.js';
 import { isHex, utf8ToHex, hexToBytes } from 'web3-utils';
-import { isValidAddress, isBigNumber } from '@colony/colony-js-utils';
+import {
+  isValidAddress,
+  isBigNumber,
+  isEmptyHexString,
+} from '@colony/colony-js-utils';
 
 import type { ParamTypes, ParamTypeDef } from '../flowtypes';
 import { isBoolean } from './inputValidation';
@@ -75,7 +79,7 @@ const PARAM_TYPE_MAP: {
       );
     },
     convertOutput(value: any) {
-      if (isHex(value)) {
+      if (isHex(value) && !isEmptyHexString(value)) {
         const hex = `0x1220${value.slice(2)}`;
         const bytes = hexToBytes(hex);
         return bs58.encode(bytes);

--- a/packages/colony-js-utils/src/__tests__/checkValidAddress.js
+++ b/packages/colony-js-utils/src/__tests__/checkValidAddress.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import checkValidAddress from '../checkValidAddress';
-import { NON_EXISTENT_ADDRESS } from '../constants';
 
 describe('checkValidAddress', () => {
   const realAddress = '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d';
@@ -12,7 +11,7 @@ describe('checkValidAddress', () => {
 
   test('Non existent address', () => {
     expect(() => {
-      checkValidAddress(NON_EXISTENT_ADDRESS);
+      checkValidAddress('0x0000000000000000000000000000000000000000');
     }).toThrowError('Undefined address');
   });
 

--- a/packages/colony-js-utils/src/checkValidAddress.js
+++ b/packages/colony-js-utils/src/checkValidAddress.js
@@ -2,7 +2,7 @@
 
 import assert from 'browser-assert';
 import { isAddress } from 'web3-utils';
-import { NON_EXISTENT_ADDRESS } from './constants';
+import isEmptyHexString from './isEmptyHexString';
 
 /**
  * Pure function
@@ -11,6 +11,6 @@ import { NON_EXISTENT_ADDRESS } from './constants';
  */
 export default function checkValidAddress(address: any): boolean {
   assert(typeof address === 'string' && isAddress(address), 'Invalid address');
-  assert(address !== NON_EXISTENT_ADDRESS, 'Undefined address');
+  assert(!isEmptyHexString(address), 'Undefined address');
   return true;
 }

--- a/packages/colony-js-utils/src/constants.js
+++ b/packages/colony-js-utils/src/constants.js
@@ -1,6 +1,0 @@
-/* @flow */
-
-// This comment can be removed when more constants are added here.
-// eslint-disable-next-line import/prefer-default-export
-export const NON_EXISTENT_ADDRESS =
-  '0x0000000000000000000000000000000000000000';

--- a/packages/colony-js-utils/src/index.js
+++ b/packages/colony-js-utils/src/index.js
@@ -6,6 +6,7 @@ import checkValidAddress from './checkValidAddress';
 import isValidAddress from './isValidAddress';
 import makeAssert from './makeAssert';
 import isBigNumber from './isBigNumber';
+import isEmptyHexString from './isEmptyHexString';
 
 export {
   raceAgainstTimeout,
@@ -13,4 +14,5 @@ export {
   isValidAddress,
   makeAssert,
   isBigNumber,
+  isEmptyHexString,
 };

--- a/packages/colony-js-utils/src/isEmptyHexString.js
+++ b/packages/colony-js-utils/src/isEmptyHexString.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+export default function isEmptyHexString(hex: string) {
+  const prefix = hex.slice(0, 2);
+  const rest = [...hex.slice(2)];
+  return prefix === '0x' && rest.every(char => char === '0');
+}

--- a/packages/colony-js-utils/src/isValidAddress.js
+++ b/packages/colony-js-utils/src/isValidAddress.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { isAddress } from 'web3-utils';
-import { NON_EXISTENT_ADDRESS } from './constants';
+import isEmptyHexString from './isEmptyHexString';
 
 /**
  * Given an input, return true if it is a valid address.
@@ -13,6 +13,6 @@ export default function isValidAddress(address: any): boolean {
   return (
     typeof address === 'string' &&
     isAddress(address) &&
-    address !== NON_EXISTENT_ADDRESS
+    !isEmptyHexString(address)
   );
 }


### PR DESCRIPTION
## Description

Clean 'empty' hex strings for IPFS hash output validation.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Added utility function `isEmptyHexString which validates hex strings of any lengths, and used this to replace the `NON_EXISTENT_ADDRESS` constant.

## TODO

> ⚠️  NOTE: Please make sure all items are checked or remove the TODO list before closing the PR

- [x] Test with hackathonStarter repo

Resolves #159
