### PR TITLE
Define default values for Caller/Sender params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * New `ipfsHash` parameter type, to more easily store/retrieve IPFS hashes from the contracts (`@colony/colony-js-contract-client`)
 * Implement the `ipfsHash` type in `ColonyClient`: `getTask`, `createTask`, `submitTaskDeliverable`, `setTaskBrief` (`@colony/colony-js-client`)
+* Add a default value (1) for `ColonyClient.createTask` (`@colony/colony-js-client`)
 
 **Bug fixes**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -326,7 +326,7 @@ Creates a new task by invoking `makeTask` on-chain.
 |Argument|Type|Description|
 |---|---|---|
 |specificationHash|IPFS hash|Hashed output of the task's work specification, stored so that it can later be referenced for task ratings or in the event of a dispute.|
-|domainId|number|Domain in which the task has been created.|
+|domainId|number|Domain in which the task has been created (default value: `1`).|
 
 **Returns**
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -11,7 +11,13 @@ import type { ContractClientConstructorArgs } from '@colony/colony-js-contract-c
 
 import ColonyNetworkClient from '../ColonyNetworkClient/index';
 import GetTask from './callers/GetTask';
-import { ROLES, WORKER_ROLE, EVALUATOR_ROLE, MANAGER_ROLE } from '../constants';
+import {
+  ROLES,
+  WORKER_ROLE,
+  EVALUATOR_ROLE,
+  MANAGER_ROLE,
+  DEFAULT_DOMAIN_ID,
+} from '../constants';
 
 type Address = string;
 type Role = $Keys<typeof ROLES>;
@@ -231,7 +237,7 @@ export default class ColonyClient extends ContractClient {
   createTask: ColonyClient.Sender<
     {
       specificationHash: IPFSHash, // Hashed output of the task's work specification, stored so that it can later be referenced for task ratings or in the event of a dispute.
-      domainId: number, // Domain in which the task has been created.
+      domainId: number, // Domain in which the task has been created (default value: `1`).
     },
     {
       taskId: number, // Will return an integer taskId, from the `TaskAdded` event.
@@ -663,7 +669,10 @@ export default class ColonyClient extends ContractClient {
     });
     this.addSender('createTask', {
       functionName: 'makeTask',
-      input: [['specificationHash', 'ipfsHash'], ['domainId', 'number']],
+      input: [
+        ['specificationHash', 'ipfsHash'],
+        ['domainId', 'number', DEFAULT_DOMAIN_ID],
+      ],
       eventHandlers: {
         TaskAdded: {
           contract: this.contract,

--- a/packages/colony-js-client/src/constants.js
+++ b/packages/colony-js-client/src/constants.js
@@ -9,3 +9,5 @@ export const ROLES = {
   [EVALUATOR_ROLE]: 1,
   [WORKER_ROLE]: 2,
 };
+
+export const DEFAULT_DOMAIN_ID = 1;

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethod.js
@@ -200,4 +200,32 @@ describe('ContractMethod', () => {
       callArgs,
     );
   });
+
+  test('Input values fall back to default values if not provided', () => {
+    convertInputValue.mockImplementation(value => value);
+
+    const specificationHash = 'QmcNbGg6EVfFn2Z1QxWauR9XY9KhnEcyb5DUXCXHi8pwMJ';
+    const domainId = 1;
+    const input = [
+      ['specificationHash', 'ipfsHash'],
+      ['domainId', 'number', domainId],
+    ];
+    const inputValues = { specificationHash };
+
+    const method = new ContractMethod({
+      client,
+      input,
+      functionName: 'myFunction',
+    });
+
+    expect(method._parseInputValues(inputValues)).toEqual([
+      specificationHash,
+      domainId,
+    ]);
+    expect(convertInputValue).toHaveBeenCalledWith(
+      specificationHash,
+      'ipfsHash',
+    );
+    expect(convertInputValue).toHaveBeenCalledWith(domainId, 'number');
+  });
 });

--- a/packages/colony-js-contract-client/src/classes/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethod.js
@@ -4,7 +4,7 @@
 import isPlainObject from 'lodash.isplainobject';
 import { makeAssert } from '@colony/colony-js-utils';
 
-import type { ContractMethodArgs, ParamTypePairs } from '../flowtypes';
+import type { ContractMethodArgs, Params } from '../flowtypes';
 import ContractClient from './ContractClient';
 import {
   validateValue,
@@ -25,8 +25,8 @@ export default class ContractMethod<
 > {
   client: IContractClient;
   functionName: string;
-  input: ParamTypePairs;
-  output: ParamTypePairs;
+  input: Params;
+  output: Params;
 
   static _validateValue(value: any, paramType: *, paramName: string) {
     let reason;
@@ -85,10 +85,16 @@ export default class ContractMethod<
   /**
    * Given input values, map them against the method's expected parameters,
    * with the appropriate conversion for each type.
+   * Fall back to default values for each parameter.
    */
   _parseInputValues(inputValues: InputValues) {
-    return this.input.map(([paramName, paramType]) =>
-      convertInputValue(inputValues[paramName], paramType),
+    return this.input.map(([paramName, paramType, defaultValue]) =>
+      convertInputValue(
+        Object.hasOwnProperty.call(inputValues, paramName)
+          ? inputValues[paramName]
+          : defaultValue,
+        paramType,
+      ),
     );
   }
 

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -23,9 +23,10 @@ export type ParamTypes =
   | 'number'
   | 'string';
 
-export type ParamTypePair = [string, ParamTypes];
+// [param name, param type, default value (optional)]
+export type Param = [string, ParamTypes, *];
 
-export type ParamTypePairs = Array<ParamTypePair>;
+export type Params = Array<Param>;
 
 export type ParamTypeDef = {
   validate: (value: any) => boolean,
@@ -66,8 +67,8 @@ export type ValidateEmpty = (
 export type ContractMethodArgs<IContractClient: ContractClient> = {
   client: IContractClient,
   functionName: string,
-  input: ParamTypePairs,
-  output?: ParamTypePairs,
+  input: Params,
+  output?: Params,
   validateEmpty?: ValidateEmpty,
 };
 
@@ -89,8 +90,8 @@ export type ContractMethodMultisigSenderArgs<
 export type ContractMethodDef<IContractClient: ContractClient> = {
   client: IContractClient,
   functionName?: string,
-  input: ParamTypePairs,
-  output?: ParamTypePairs,
+  input: Params,
+  output?: Params,
 };
 
 export type SigningMode = $Values<typeof SIGNING_MODES>;

--- a/packages/colony-js-contract-client/src/modules/inputValidation.js
+++ b/packages/colony-js-contract-client/src/modules/inputValidation.js
@@ -2,11 +2,11 @@
 
 import isPlainObject from 'lodash.isplainobject';
 
-import type { ParamTypePairs } from '../flowtypes';
+import type { Params } from '../flowtypes';
 
 export const isBoolean = (value: any) => typeof value === 'boolean';
 
-export const areParamPairsEmpty = (paramPairs: ParamTypePairs) =>
+export const areParamPairsEmpty = (paramPairs: Params) =>
   paramPairs == null || (Array.isArray(paramPairs) && paramPairs.length === 0);
 
 export const isInputEmpty = (input: any) =>


### PR DESCRIPTION
## Description

This PR allows developers to define default values for Caller/Sender parameters, and implements this for `ColonyClient.createTask`.

* Add a third (optional) parameter for the `Param` flow type; the default value
* Fall back to default values in `ContractClient._parseInputValues`
* Add a default value (1) for `domainId` in `ColonyClient.createTask`

Contributes to #153 
