### PR TITLE
Provide better context for method validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**Enhancements**
+
+* Validation errors in contract methods now contain the method name (`@colony/colony-js-contract-client`)
+
 ## v1.2.0
 
 **Enhancements**

--- a/packages/colony-js-contract-client/src/__tests__/ContractClient.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractClient.js
@@ -98,12 +98,12 @@ describe('ContractClient', () => {
   test('Methods can be defined', () => {
     const client = new ContractClient({ adapter, contract, options });
     const input = [['id', 'number']];
-    const functionName = 'myMethodOne';
+    const name = 'myMethodOne';
 
     const Caller = jest.fn((...args) => new client.constructor.Caller(...args));
 
     // Define a method on the client
-    client.addMethod(Caller, functionName, { input });
+    client.addMethod(Caller, name, { input, name });
 
     // The method should exist on the client
     expect(client.myMethodOne).toBeInstanceOf(client.constructor.Caller);
@@ -111,7 +111,8 @@ describe('ContractClient', () => {
     // The method should have been created with the client and functionName
     expect(Caller).toHaveBeenCalledWith({
       client,
-      functionName,
+      name,
+      functionName: name,
       input,
     });
 
@@ -123,13 +124,14 @@ describe('ContractClient', () => {
     });
     expect(Caller).toHaveBeenCalledWith({
       client,
+      name: 'innocentlyClaimFunds',
       functionName: 'stealAllTheTokens',
       input,
     });
 
     // Attempting to redefine the same method name should not work
     expect(() => {
-      client.addMethod(Caller, functionName, { input });
+      client.addMethod(Caller, name, { input, name });
     }).toThrowError('A ContractMethod named "myMethodOne" already exists');
 
     // However, the method should not have been redefined

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -125,7 +125,7 @@ export default class ContractClient {
       throw new Error(`A ContractMethod named "${name}" already exists`);
 
     Object.assign(this, {
-      [name]: new Method({ functionName: name, client: this, ...def }),
+      [name]: new Method({ name, functionName: name, client: this, ...def }),
     });
   }
 

--- a/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
@@ -25,11 +25,12 @@ export default class ContractMethodCaller<
     functionName,
     input,
     output,
+    name,
     validateEmpty,
   }: ContractMethodArgs<IContractClient> & {
     validateEmpty?: ValidateEmpty,
   } = {}) {
-    super({ client, functionName, input, output });
+    super({ client, name, functionName, input, output });
     if (validateEmpty) this._validateEmpty = validateEmpty;
   }
 

--- a/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
@@ -39,12 +39,13 @@ export default class ContractMethodMultisigSender<
     eventHandlers,
     functionName,
     input,
+    name,
     getRequiredSignees,
     multisigFunctionName,
     nonceFunctionName,
     output,
   }: ContractMethodMultisigSenderArgs<IContractClient>) {
-    super({ client, output, input, eventHandlers, functionName });
+    super({ client, name, output, input, eventHandlers, functionName });
     this._getRequiredSignees = getRequiredSignees;
     this.multisigFunctionName = multisigFunctionName;
     this.nonceFunctionName = nonceFunctionName;

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -68,6 +68,7 @@ export type ValidateEmpty = (
 export type ContractMethodArgs<IContractClient: ContractClient> = {
   client: IContractClient,
   functionName: string,
+  name: string,
   input: Params,
   output?: Params,
   validateEmpty?: ValidateEmpty,


### PR DESCRIPTION
## Description

* Add a `name` property for contract methods
* Use the name property to provide context for validation messages
