### PR TITLE
Fix timestamp parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Bug fixes**
 
 * Fixed a bug where methods with default values were not validated properly (`@colony/colony-js-contract-client`)
+* Fixed a bug where timestamps were not converted correctly (`@colony/colony-js-contract-client`)
 
 ## v1.2.0
 

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -130,8 +130,13 @@ describe('Parameter types', () => {
   });
 
   test('Dates are handled properly', () => {
-    const date = new Date(1985, 10, 13, 6, 30, 2);
-    const time = date.getTime() / 1000;
+    const date = new Date(2018, 10, 13, 6, 30, 2, 137);
+    const timeWithMs = new Date(2018, 10, 13, 6, 30, 2, 137).setMilliseconds(0);
+    const timeWithoutMs = parseInt(timeWithMs / 1000, 10);
+
+    // Sanity check
+    expect(String(timeWithMs).length).toBe(13);
+    expect(String(timeWithoutMs).length).toBe(10);
 
     // Validation
     expect(validateValue(date, 'date')).toBe(true);
@@ -140,15 +145,19 @@ describe('Parameter types', () => {
     expect(validateValue(null, 'date')).toBe(false);
 
     // Converting output values
-    const bnDate = new BigNumber(time);
+    const bnDate = new BigNumber(timeWithoutMs);
     isBigNumber.mockReturnValueOnce(true);
-    expect(convertOutputValue(bnDate, 'date')).toEqual(date);
+    const outputFromBn = convertOutputValue(bnDate, 'date');
+    expect(outputFromBn).toBeInstanceOf(Date);
+    expect(outputFromBn.getTime()).toEqual(timeWithMs);
     expect(isBigNumber).toHaveBeenCalledWith(bnDate);
     isBigNumber.mockClear();
 
     isBigNumber.mockReturnValueOnce(false);
-    expect(convertOutputValue(time, 'date')).toEqual(date);
-    expect(isBigNumber).toHaveBeenCalledWith(time);
+    const outputFromNumber = convertOutputValue(timeWithoutMs, 'date');
+    expect(outputFromNumber).toBeInstanceOf(Date);
+    expect(outputFromNumber.getTime()).toEqual(timeWithMs);
+    expect(isBigNumber).toHaveBeenCalledWith(timeWithoutMs);
     isBigNumber.mockClear();
 
     isBigNumber.mockReturnValueOnce(false);
@@ -157,7 +166,7 @@ describe('Parameter types', () => {
     isBigNumber.mockClear();
 
     // Converting input values
-    expect(convertInputValue(date, 'date')).toBe(time);
+    expect(convertInputValue(date, 'date')).toBe(timeWithoutMs);
   });
 
   test('Strings are handled properly', () => {

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -53,11 +53,16 @@ const PARAM_TYPE_MAP: {
       return value instanceof Date && !!value.valueOf();
     },
     convertOutput(value: any) {
-      const converted = Number(isBigNumber(value) ? value.toNumber() : value);
+      const converted = parseInt(
+        isBigNumber(value) ? value.toNumber() : value,
+        10,
+      );
+      // Recreate the date by adding milliseconds to the timestamp
       return converted > 0 ? new Date(converted * 1000) : null;
     },
     convertInput(value: Date) {
-      return value.getTime() / 1000;
+      // Dates are stored as timestamps without milliseconds
+      return parseInt(value.setMilliseconds(0) / 1000, 10);
     },
   },
   number: {


### PR DESCRIPTION
## Description

This PR fixes a bug where dates with milliseconds were not converted to/from the contracts properly; now, timestamps are converted as integers without milliseconds.

## TODO

> ⚠️  NOTE: Please make sure all items are checked or remove the TODO list before closing the PR

- [x] Test with hackathonStarter
- [x] Test with integration testing
