### PR TITLE
Supply network to transform method for Loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Enabled the `networkId` to be passed from the contract loading query through to the loader transform function; reintroduced support for specifying the `networkId` in `truffleTransform` (`@colony/colony-js-contract-loader`)
 
 ## v1.4.0
 

--- a/packages/colony-js-contract-loader-http/src/__tests__/index.js
+++ b/packages/colony-js-contract-loader-http/src/__tests__/index.js
@@ -19,7 +19,7 @@ describe('ContractHttpLoader', () => {
   const bytecode = '0x1234567890';
   const contractAddress = '0x123';
   const contractName = 'MetaCoin';
-  const networkId = '123456';
+  const network = '123456';
   const routerAbi = [{ myRouterData: 987 }];
   const routerAddress = '0x987';
   const routerBytecode = '0x0987654321';
@@ -210,7 +210,7 @@ describe('ContractHttpLoader', () => {
         contractName,
         routerName,
         version,
-        networkId,
+        network,
       },
       requiredProps,
     );
@@ -219,7 +219,7 @@ describe('ContractHttpLoader', () => {
     expect(loader._load).toHaveBeenCalledWith(
       {
         contractName,
-        networkId,
+        network,
         version,
       },
       requiredProps,
@@ -227,7 +227,7 @@ describe('ContractHttpLoader', () => {
     expect(loader._load).toHaveBeenCalledWith(
       {
         contractName: routerName,
-        networkId,
+        network,
         version,
       },
       requiredProps,
@@ -256,7 +256,7 @@ describe('ContractHttpLoader', () => {
         contractName,
         routerAddress,
         version,
-        networkId,
+        network,
       },
       requiredPropsWithByteCode,
     );
@@ -265,7 +265,7 @@ describe('ContractHttpLoader', () => {
     expect(loader._load).toHaveBeenCalledWith(
       {
         contractName,
-        networkId,
+        network,
         version,
       },
       requiredPropsWithByteCode,

--- a/packages/colony-js-contract-loader/src/interface/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/interface/ContractLoader.js
@@ -6,7 +6,7 @@ export type Query = {
   routerAddress?: string,
   routerName?: string,
   version?: string,
-  networkId?: string,
+  network?: string,
 };
 
 export type ContractDefinition = {

--- a/packages/colony-js-contract-loader/src/interface/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/interface/ContractLoader.js
@@ -6,6 +6,7 @@ export type Query = {
   routerAddress?: string,
   routerName?: string,
   version?: string,
+  networkId?: string,
 };
 
 export type ContractDefinition = {

--- a/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
+++ b/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
@@ -6,7 +6,7 @@ type TruffleArtifact = {
   abi: Array<{}>,
   bytecode: string,
   networks: {
-    [networkId: string | number]: {
+    [network: string | number]: {
       address: string,
     },
   },
@@ -14,20 +14,20 @@ type TruffleArtifact = {
 
 export default function truffleTransform(
   { abi = [], bytecode, networks = {} }: TruffleArtifact = {},
-  { networkId }: Query = {},
+  { network }: Query = {},
 ) {
   let address;
 
   // Some clients (like Ganache) create IDs as integers; normalise them
-  const networkIds = Object.keys(networks).map(id => `${id}`);
+  const networkKeys = Object.keys(networks).map(id => `${id}`);
 
-  if (networkId && networkIds.length) {
-    if (!networks[networkId])
-      throw new Error(`Network ID ${networkId} not found in contract`);
-    ({ address } = networks[networkId]);
+  if (network && networkKeys.length) {
+    if (!networks[network])
+      throw new Error(`Network ID ${network} not found in contract`);
+    ({ address } = networks[network]);
   } else {
     // Pick the last network (assumed to be the most recent)
-    ({ address } = networks[networkIds[networkIds.length - 1]] || {});
+    ({ address } = networks[networkKeys[networkKeys.length - 1]] || {});
   }
 
   return {

--- a/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
+++ b/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
@@ -18,7 +18,8 @@ export default function truffleTransform(
 ) {
   let address;
 
-  const networkIds = Object.keys(networks);
+  // Some clients (like Ganache) create IDs as integers; normalise them
+  const networkIds = Object.keys(networks).map(id => `${id}`);
 
   if (networkId && networkIds.length) {
     if (!networks[networkId])

--- a/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
+++ b/packages/colony-js-contract-loader/src/transforms/truffleTransform.js
@@ -1,24 +1,33 @@
 /* @flow */
 
+import type { Query } from '../interface/ContractLoader';
+
 type TruffleArtifact = {
   abi: Array<{}>,
   bytecode: string,
   networks: {
-    [networkId: number]: {
+    [networkId: string | number]: {
       address: string,
     },
   },
 };
 
-export default function truffleTransform({
-  abi = [],
-  bytecode,
-  networks = {},
-}: TruffleArtifact = {}) {
+export default function truffleTransform(
+  { abi = [], bytecode, networks = {} }: TruffleArtifact = {},
+  { networkId }: Query = {},
+) {
+  let address;
+
   const networkIds = Object.keys(networks);
-  // Pick the last network (assumed to be the most recent)
-  const { address } =
-    networks[parseInt(networkIds[networkIds.length - 1], 10)] || {};
+
+  if (networkId && networkIds.length) {
+    if (!networks[networkId])
+      throw new Error(`Network ID ${networkId} not found in contract`);
+    ({ address } = networks[networkId]);
+  } else {
+    // Pick the last network (assumed to be the most recent)
+    ({ address } = networks[networkIds[networkIds.length - 1]] || {});
+  }
 
   return {
     abi,


### PR DESCRIPTION
## Description

This PR makes it possible to use the `NetworkLoader` from `@colony/colony/contract-loader-network` to load a contract like `EtherRouter`, which has a deployed address for `rinkeby` set, without specifying the address explicitly.

Usage:

```js
const loader = new NetworkLoader({ network: 'rinkeby' });
const adapter = new EthersAdapter({ provider, loader, wallet });
const networkClient = new ColonyNetworkClient({ adapter });
await networkClient.init();
```

* Enables the `network` to be passed from the contract loading query through to the loader transform function
* Reintroduces support for specifying the `networkId` in `truffleTransform`
* Renames `networkId` to `network` in the loader interface
