### PR TITLE
Wait for in-progress transactions to be mined before finding the receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Enhancements**
+
+* Wait for in-progress transactions when getting the transaction receipt (`@colony/colony-js-contract-client`, `@colony/colony-js-adapter-ethers`)
 
 ## v1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Enhancements**
 
 * Wait for in-progress transactions when getting the transaction receipt (`@colony/colony-js-contract-client`, `@colony/colony-js-adapter-ethers`)
+* Made the default timeout for sending transactions dependent on the network: 1 hour for mainnet, 5 minutes otherwise (`@colony/colony-js-contract-client`)
 
 ## v1.4.1
 

--- a/packages/colony-js-adapter-ethers/src/EthersAdapter.js
+++ b/packages/colony-js-adapter-ethers/src/EthersAdapter.js
@@ -108,6 +108,9 @@ export default class EthersAdapter implements IAdapter {
   async getTransactionReceipt(transactionHash: string) {
     return this.provider.getTransactionReceipt(transactionHash);
   }
+  async waitForTransaction(transactionHash: string) {
+    return this.provider.waitForTransaction(transactionHash);
+  }
   /**
    * Sign a message hash (as binary) and return a split signature.
    */

--- a/packages/colony-js-adapter/interface/Adapter.js
+++ b/packages/colony-js-adapter/interface/Adapter.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import ContractLoader from '@colony/colony-js-contract-loader';
 import type { Query } from '@colony/colony-js-contract-loader';
 import type { Contract } from './Contract';
 import type { EventHandlers } from './EventHandlers';
@@ -8,8 +9,6 @@ import type { Signature } from './Signature';
 import type { Transaction } from './Transaction';
 import type { TransactionReceipt } from './TransactionReceipt';
 import type { Wallet } from './Wallet';
-
-import ContractLoader from '@colony/colony-js-contract-loader';
 
 export interface Adapter {
   loader: ContractLoader;

--- a/packages/colony-js-adapter/interface/Adapter.js
+++ b/packages/colony-js-adapter/interface/Adapter.js
@@ -26,6 +26,7 @@ export interface Adapter {
     timeoutMs: number,
     transactionHash: string,
   }): Promise<any>;
+  waitForTransaction(transactionHash: string): Promise<Transaction>;
   getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>;
   signMessage(messageHash: string): Promise<Signature>;
 }

--- a/packages/colony-js-adapter/interface/Provider.js
+++ b/packages/colony-js-adapter/interface/Provider.js
@@ -25,6 +25,7 @@ export interface Provider {
     blockTag?: string,
   ): Promise<number>;
   getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>;
+  waitForTransaction(transactionHash: string): Promise<Transaction>;
   lookupAddress(address: string): Promise<string | null>;
   resolveName(ensName: string): Promise<string | null>;
 }

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
@@ -57,6 +57,9 @@ describe('ContractMethodSender', () => {
   const adapter = {
     getTransactionReceipt: sandbox.fn(async () => Promise.resolve(receipt)),
     waitForTransaction: sandbox.fn(async () => Promise.resolve(transaction)),
+    provider: {
+      name: 'mainnet',
+    },
   };
   const client = new ContractClient({ contract, adapter });
   sandbox
@@ -273,5 +276,22 @@ describe('ContractMethodSender', () => {
     expect(
       methodWithDefault._getDefaultSendOptions({ gasLimit: A }).gasLimit,
     ).toEqual(A);
+
+    const mainnetMethod = new ContractMethodSender({
+      client,
+      input,
+      functionName,
+    });
+    // Should have a 1 hour timeout
+    expect(mainnetMethod._getDefaultSendOptions().timeoutMs).toEqual(3600000);
+
+    const testnetMethod = new ContractMethodSender({
+      client,
+      input,
+      functionName,
+    });
+    testnetMethod.client.adapter.provider = { name: 'testnet' };
+    // Should have a 5 minute timeout
+    expect(testnetMethod._getDefaultSendOptions().timeoutMs).toEqual(300000);
   });
 });

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -16,7 +16,6 @@ import type {
   ContractMethodArgs,
   SendOptions,
 } from '../flowtypes';
-import { DEFAULT_SEND_OPTIONS } from '../defaults';
 
 export default class ContractMethodSender<
   InputValues: { [inputValueName: string]: any },
@@ -153,10 +152,17 @@ export default class ContractMethodSender<
    * Given send options, set default values for this Sender.
    */
   _getDefaultSendOptions(options: SendOptions) {
+    const { name: networkName } = this.client.adapter.provider;
+    // Allow a much longer timeout for mainnet transactions.
+    const minutes = networkName === 'mainnet' ? 60 : 5;
+
     return Object.assign(
       {},
-      DEFAULT_SEND_OPTIONS,
-      this._defaultGasLimit ? { gasLimit: this._defaultGasLimit } : {},
+      {
+        timeoutMs: 1000 * 60 * minutes,
+        waitForMining: true,
+        ...(this._defaultGasLimit ? { gasLimit: this._defaultGasLimit } : null),
+      },
       options,
     );
   }

--- a/packages/colony-js-contract-client/src/defaults.js
+++ b/packages/colony-js-contract-client/src/defaults.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-// eslint-disable-next-line import/prefer-default-export
-export const DEFAULT_SEND_OPTIONS = {
-  timeoutMs: 1000 * 60 * 3, // 3 minutes
-  waitForMining: true,
-};


### PR DESCRIPTION
## Description

This PR makes the Senders wait for in-progress transactions to be fully confirmed before getting the receipt. I noticed this issue when testing with Rinkeby; with a low gas price, the receipt was sometimes null; now, it will wait until the timeout runs out, which has also been changed: 60 minutes for mainnet, 5 minutes otherwise.
