### PR TITLE
Ensure transaction receipt is received for clients with no mining time

### DIFF
--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -144,6 +144,14 @@ export default class ContractMethodSender<
   }
 
   async _waitForTransactionReceipt(transactionHash: string) {
+    // Firstly attempt to get the receipt immediately; the transaction
+    // may be running on TestRPC with no mining time.
+    const receipt = await this.client.adapter.getTransactionReceipt(
+      transactionHash,
+    );
+    if (receipt != null) return receipt;
+
+    // Failing that, wait until the transaction has been mined.
     await this.client.adapter.waitForTransaction(transactionHash);
     return this.client.adapter.getTransactionReceipt(transactionHash);
   }


### PR DESCRIPTION
## Description 

This PR ensures that transaction receipts are received for clients with no mining time (e.g. some configurations of Ganache), and networks with normal mining behaviour. 

When waiting for a transaction receipt, firstly attempt to get the receipt immediately; the transaction may be running on TestRPC with no mining time. Failing that, wait until the transaction has been mined.
