### PR TITLE
Get token information in TokenClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**New features**
+
+* Add `getTokenInfo` caller to `TokenClient` to get the token's `name`, `symbol` and `decimals` (`@colony/colony-js-contract-client`, `@colony/colony-js-client`)
+
 **Enhancements**
 
 * Wait for in-progress transactions when getting the transaction receipt (`@colony/colony-js-contract-client`, `@colony/colony-js-adapter-ethers`)

--- a/docs/_API_Loaders.md
+++ b/docs/_API_Loaders.md
@@ -170,7 +170,7 @@ This is just a `HTTPLoader` with a specific endpoint (`http://127.0.0.1/contract
 
 This is just a `HTTPLoader` with a specific endpoint (`https://api.etherscan.io/api?module=contract&action=getabi&address=%%ADDRESS%%`) and a transform function specialised for Etherscan. It can take the `contractAddress` and `routerAddress` properties.
 
-## `FSLoader`
+### `FSLoader`
 
 **`FSLoader` is only available in node.js environments.**
 This loader loads files by name from a specific directory in a file system.

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -17,6 +17,21 @@ Most functions are fairly self-explanatory and mirror their on-chain counterpart
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
+### `getTokenInfo.call()`
+
+Get information about the ERC20 token itself
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|name|string|The token's name (e.g. Cool Colony Token)|
+|symbol|string|The token's symbol (e.g. CCT)|
+|decimals|number|The token's decimals|
+
 ### `getTotalSupply.call()`
 
 Get the total token supply.

--- a/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
+++ b/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
@@ -1,0 +1,37 @@
+/* @flow */
+/* eslint-disable no-underscore-dangle */
+
+import ContractClient from '@colony/colony-js-contract-client';
+
+import type TokenClient from '../index';
+
+type InputValues = {};
+type CallResult = [string, string, number];
+
+export default class GetTokenInfo extends ContractClient.Caller<
+  InputValues,
+  *,
+  TokenClient,
+> {
+  constructor(params: *) {
+    super({
+      functionName: 'getTokenInfo',
+      input: [],
+      output: [
+        ['name', 'string'],
+        ['symbol', 'string'],
+        ['decimals', 'number'],
+      ],
+      ...params,
+    });
+  }
+  async call() {
+    const name = await this.client.call('name', []);
+    const symbol = await this.client.call('symbol', []);
+    const decimals = await this.client.call('decimals', []);
+
+    const callResult: CallResult = [name, symbol, decimals];
+
+    return this.convertOutputValues(callResult);
+  }
+}

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -2,10 +2,23 @@
 
 import BigNumber from 'bn.js';
 import ContractClient from '@colony/colony-js-contract-client';
+import GetTokenInfo from './callers/GetTokenInfo';
 
 type Address = string;
 
 export default class TokenClient extends ContractClient {
+  /*
+    Get information about the ERC20 token itself
+  */
+  getTokenInfo: TokenClient.Caller<
+    {},
+    {
+      name: string, // The token's name (e.g. Cool Colony Token)
+      symbol: string, // The token's symbol (e.g. CCT)
+      decimals: number, // The token's decimals
+    },
+    TokenClient,
+  >;
   /*
   Get the total token supply.
   */
@@ -198,6 +211,8 @@ export default class TokenClient extends ContractClient {
         };
       },
     };
+
+    this.getTokenInfo = new GetTokenInfo({ client: this });
 
     this.addCaller('getTotalSupply', {
       functionName: 'totalSupply',

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -9,7 +9,13 @@ import {
   isBigNumber,
   isEmptyHexString,
 } from '@colony/colony-js-utils';
-import { isHex, utf8ToHex, hexToBytes } from 'web3-utils';
+import {
+  isHex,
+  isHexStrict,
+  utf8ToHex,
+  hexToBytes,
+  hexToUtf8,
+} from 'web3-utils';
 
 import {
   addParamType,
@@ -32,8 +38,10 @@ jest.mock('bs58', () => ({
 
 jest.mock('web3-utils', () => ({
   isHex: jest.fn().mockReturnValue(true),
+  isHexStrict: jest.fn().mockReturnValue(true),
   utf8ToHex: jest.fn().mockImplementation(value => value),
   hexToBytes: jest.fn().mockImplementation(() => [101]),
+  hexToUtf8: jest.fn().mockImplementation(value => value),
 }));
 
 describe('Parameter types', () => {
@@ -44,6 +52,7 @@ describe('Parameter types', () => {
     isBigNumber.mockClear();
     isValidAddress.mockClear();
     isEmptyHexString.mockClear();
+    isHexStrict.mockClear();
     isHex.mockClear();
     utf8ToHex.mockClear();
     hexToBytes.mockClear();
@@ -178,7 +187,12 @@ describe('Parameter types', () => {
     expect(validateValueType(1, 'string')).toBe(false);
 
     // Converting output values
+    isHexStrict.mockReturnValueOnce(false);
     expect(convertOutputValue('a', 'string')).toBe('a');
+    isEmptyHexString.mockReturnValueOnce(false);
+    hexToUtf8.mockReturnValueOnce('COLNY');
+    expect(convertOutputValue('0x434f4c4e59', 'string')).toBe('COLNY');
+    expect(convertOutputValue('0x00', 'string')).toBe(null);
 
     // empty strings are cleaned:
     expect(convertOutputValue('', 'string')).toBe(null);

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -2,7 +2,13 @@
 
 import bs58 from 'bs58';
 import BigNumber from 'bn.js';
-import { isHex, utf8ToHex, hexToBytes, hexToUtf8 } from 'web3-utils';
+import {
+  isHex,
+  isHexStrict,
+  utf8ToHex,
+  hexToBytes,
+  hexToUtf8,
+} from 'web3-utils';
 import {
   isValidAddress,
   isBigNumber,
@@ -80,7 +86,7 @@ const PARAM_TYPE_MAP: {
       return typeof value === 'string';
     },
     convertOutput(value: any) {
-      if (isHex(value)) {
+      if (isHexStrict(value)) {
         return isEmptyHexString(value) ? null : hexToUtf8(value);
       }
       return typeof value === 'string' && value.length ? value : null;

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -2,7 +2,7 @@
 
 import bs58 from 'bs58';
 import BigNumber from 'bn.js';
-import { isHex, utf8ToHex, hexToBytes } from 'web3-utils';
+import { isHex, utf8ToHex, hexToBytes, hexToUtf8 } from 'web3-utils';
 import {
   isValidAddress,
   isBigNumber,
@@ -80,6 +80,9 @@ const PARAM_TYPE_MAP: {
       return typeof value === 'string';
     },
     convertOutput(value: any) {
+      if (isHex(value)) {
+        return isEmptyHexString(value) ? null : hexToUtf8(value);
+      }
       return typeof value === 'string' && value.length ? value : null;
     },
     convertInput(value: string) {


### PR DESCRIPTION
This PR allows for getting information about the Colony's token via calling `colonyClient.token.getTokenInfo.call()`. It provides the token's name, the symbol and the number of decimals.

Other changes:

- Add hex data conversion to string output type
- Adjust documentation