### PR TITLE
Improve consistency of token attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Documentation**
+
+* Clarified the naming of parameters involving token addresses (`@colony/colony-js-contract-client`, `@colony/colony-js-client`)
 
 ## v1.5.1
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -181,7 +181,7 @@ Given a specific task, a defined role for the task, and a token address, will re
 |---|---|---|
 |taskId|number|Integer taskId.|
 |role|Role|Role the payout is specified for: MANAGER, EVALUATOR, or WORKER.|
-|token|Address|Address of the token's contract. `0x0` value indicates Ether.|
+|token|Token address|Address of the token's contract. `0x0` value indicates Ether.|
 
 **Returns**
 
@@ -259,7 +259,7 @@ Gets a balance for a certain token in a specific pot.
 |Argument|Type|Description|
 |---|---|---|
 |potId|number|Integer potId.|
-|token|Address|Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)|
+|token|Token address|Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -277,7 +277,7 @@ The `nonRewardPotsTotal` is a value that keeps track of the total assets a colon
 
 |Argument|Type|Description|
 |---|---|---|
-|token|Address|Address of the token's contract. `0x0` value indicates Ether.|
+|token|Token address|Address of the token's contract. `0x0` value indicates Ether.|
 
 **Returns**
 
@@ -306,7 +306,7 @@ A promise which resolves to an object containing the following properties:
 |blockNumber|number|Block number at the time of creation.|
 |remainingTokenAmount|BigNumber|Remaining (unclaimed) amount of tokens.|
 |reputationRootHash|string|Reputation root hash at the time of creation.|
-|token|Address|Token address (`0x0` value indicates Ether).|
+|token|Token address|Token address (`0x0` value indicates Ether).|
 |totalTokenAmountForRewardPayout|BigNumber|Total amount of tokens taken aside for reward payout.|
 |totalTokens|BigNumber|Total colony tokens at the time of creation.|
 
@@ -420,7 +420,7 @@ Sets the payout given to the MANAGER role when the task is finalized. This Sende
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Token address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**
@@ -541,7 +541,7 @@ Claims the payout for `token` denomination for work completed in task `taskId` b
 |---|---|---|
 |taskId|number|Integer taskId.|
 |role|Role|Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER|
-|token|Address|Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Token address|Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -595,7 +595,7 @@ Move any funds received by the colony for `token` denomination to the top-levl d
 
 |Argument|Type|Description|
 |---|---|---|
-|token|Address|Address to claim funds from; empty address (`0x0` for Ether)|
+|token|Token address|Address to claim funds from; empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -630,7 +630,7 @@ Move a given amount of `token` funds from one pot to another.
 |fromPot|number|Origin pot Id.|
 |toPot|number|Destination pot Id.|
 |amount|BigNumber|Amount of funds to move.|
-|token|Address|Address of the token contract (`0x0` value indicates Ether).|
+|token|Token address|Address of the token contract (`0x0` value indicates Ether).|
 
 **Returns**
 
@@ -678,7 +678,7 @@ Start the next reward payout for `token`. All funds in the reward pot for `token
 
 |Argument|Type|Description|
 |---|---|---|
-|token|Address|Address of token used for reward payout (`0x0` value indicates Ether).|
+|token|Token address|Address of token used for reward payout (`0x0` value indicates Ether).|
 
 **Returns**
 
@@ -749,7 +749,7 @@ Sets the payout given to the EVALUATOR role when the task is finalized.
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Token address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**
@@ -767,7 +767,7 @@ Sets the payout given to the WORKER role when the task is finalized.
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Token address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -161,7 +161,7 @@ A promise which resolves to an object containing the following properties:
 |skillId|number|Integer Skill ID the task is assigned to.|
 |specificationHash|IPFS hash|Unique hash of the specification content.|
 
-### `getTaskPayout.call({ taskId, role, source })`
+### `getTaskPayout.call({ taskId, role, token })`
 
 Given a specific task, a defined role for the task, and a token address, will return any payout attached to the task in the token specified.
 
@@ -171,7 +171,7 @@ Given a specific task, a defined role for the task, and a token address, will re
 |---|---|---|
 |taskId|number|Integer taskId.|
 |role|Role|Role the payout is specified for: MANAGER, EVALUATOR, or WORKER.|
-|source|Payable address|Address of the token's contract `0x0` value indicates Ether.|
+|token|Address|Address of the token's contract. `0x0` value indicates Ether.|
 
 **Returns**
 
@@ -240,16 +240,16 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|string|the hashed rating (equivalent to the output of `keccak256(_salt, _rating)`).|
 
-### `getPotBalance.call({ potId, source })`
+### `getPotBalance.call({ potId, token })`
 
-Gets a balance for a certain source in a specific pot.
+Gets a balance for a certain token in a specific pot.
 
 **Arguments**
 
 |Argument|Type|Description|
 |---|---|---|
 |potId|number|Integer potId.|
-|source|Payable address|Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)|
+|token|Address|Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -259,7 +259,7 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |balance|BigNumber|Balance for token `token` in pot `potId`.|
 
-### `getNonRewardPotsTotal.call({ source })`
+### `getNonRewardPotsTotal.call({ token })`
 
 The `nonRewardPotsTotal` is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
 
@@ -267,7 +267,7 @@ The `nonRewardPotsTotal` is a value that keeps track of the total assets a colon
 
 |Argument|Type|Description|
 |---|---|---|
-|source|Payable address|Address of the token's contract `0x0` value indicates Ether.|
+|token|Address|Address of the token's contract. `0x0` value indicates Ether.|
 
 **Returns**
 
@@ -296,7 +296,7 @@ A promise which resolves to an object containing the following properties:
 |blockNumber|number|Block number at the time of creation.|
 |remainingTokenAmount|BigNumber|Remaining (unclaimed) amount of tokens.|
 |reputationRootHash|string|Reputation root hash at the time of creation.|
-|source|Payable address|Token address (`0x0` value indicates Ether).|
+|token|Address|Token address (`0x0` value indicates Ether).|
 |totalTokenAmountForRewardPayout|BigNumber|Total amount of tokens taken aside for reward payout.|
 |totalTokens|BigNumber|Total colony tokens at the time of creation.|
 
@@ -401,7 +401,7 @@ An instance of a `ContractResponse`
 
 
 
-### `setTaskManagerPayout.send({ taskId, source, amount }, options)`
+### `setTaskManagerPayout.send({ taskId, token, amount }, options)`
 
 Sets the payout given to the MANAGER role when the task is finalized. This Sender can only be called by the manager for the task in question.
 
@@ -410,7 +410,7 @@ Sets the payout given to the MANAGER role when the task is finalized. This Sende
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|source|Payable address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**
@@ -521,9 +521,9 @@ An instance of a `ContractResponse`
 
 
 
-### `claimPayout.send({ taskId, role, source }, options)`
+### `claimPayout.send({ taskId, role, token }, options)`
 
-Claims the payout in `source` denomination for work completed in task `taskId` by contributor with role `role`. Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout. Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
+Claims the payout for `token` denomination for work completed in task `taskId` by contributor with role `role`. Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout. Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
 
 **Arguments**
 
@@ -531,7 +531,7 @@ Claims the payout in `source` denomination for work completed in task `taskId` b
 |---|---|---|
 |taskId|number|Integer taskId.|
 |role|Role|Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER|
-|source|Payable address|Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Address|Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -577,15 +577,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |skillId|number|Integer id of the newly created skill.|
 |parentSkillId|number|Integer id of the parent skill.|
 
-### `claimColonyFunds.send({ source }, options)`
+### `claimColonyFunds.send({ token }, options)`
 
-Move any funds received by the colony in `source` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
+Move any funds received by the colony for `token` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
 
 **Arguments**
 
 |Argument|Type|Description|
 |---|---|---|
-|source|Payable address|Address to claim funds from; empty address (`0x0` for Ether)|
+|token|Address|Address to claim funds from; empty address (`0x0` for Ether)|
 
 **Returns**
 
@@ -609,7 +609,7 @@ An instance of a `ContractResponse`
 
 
 
-### `moveFundsBetweenPots.send({ fromPot, toPot, amount, address }, options)`
+### `moveFundsBetweenPots.send({ fromPot, toPot, amount, token }, options)`
 
 Move a given amount of `token` funds from one pot to another.
 
@@ -620,7 +620,7 @@ Move a given amount of `token` funds from one pot to another.
 |fromPot|number|Origin pot Id.|
 |toPot|number|Destination pot Id.|
 |amount|BigNumber|Amount of funds to move.|
-|address|Payable address|Address of the token contract (`0x0` value indicates Ether).|
+|token|Address|Address of the token contract (`0x0` value indicates Ether).|
 
 **Returns**
 
@@ -730,7 +730,7 @@ An instance of a `MultiSigOperation`
 
 
 
-### `setTaskEvaluatorPayout.startOperation({ taskId, source, amount })`
+### `setTaskEvaluatorPayout.startOperation({ taskId, token, amount })`
 
 Sets the payout given to the EVALUATOR role when the task is finalized.
 
@@ -739,7 +739,7 @@ Sets the payout given to the EVALUATOR role when the task is finalized.
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|source|Payable address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**
@@ -748,7 +748,7 @@ An instance of a `MultiSigOperation`
 
 
 
-### `setTaskWorkerPayout.startOperation({ taskId, source, amount })`
+### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
 
 Sets the payout given to the WORKER role when the task is finalized.
 
@@ -757,7 +757,7 @@ Sets the payout given to the WORKER role when the task is finalized.
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|Integer taskId.|
-|source|Payable address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
+|token|Address|Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)|
 |amount|BigNumber|Amount to be paid.|
 
 **Returns**

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -20,6 +20,16 @@ You _could_ create a ColonyClient by using an adapter and a query: `new ColonyCl
 const colonyClient = await networkClient.getColonyClient(colonyId); // This is already initialised
 ```
 
+## Instance properties
+
+### `authority`
+
+The Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.
+
+### `token`
+
+The Colony's [TokenClient](/colonyjs/api-tokenclient/) instance.
+
   
 ## Callers
 

--- a/docs/_API_Loaders.md
+++ b/docs/_API_Loaders.md
@@ -96,7 +96,7 @@ Consider the `NetworkLoader` the official Loader to load deployed Colony contrac
 #### Installation and usage
 
 ```
-yarn add @colony/colony-contract-loader-network
+yarn add @colony/colony-js-contract-loader-network
 ```
 
 ```

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -59,7 +59,7 @@ TrufflePig will take truffle-generated contract files and serve them to colonyJS
 
 For our local test blockchain, there are a few tweaks to default settings that need to be made: We want to set the `gasLimit` to 7000000, and we want all our account keys to be stored in a .json file that we'll be able to easily call inside our application. With `ganache-cli` we can do this all in one command at start. Open up a new terminal window, and `cd` back to your colonyNetwork/ working directory:
 ```
-$ ./node_modues/.bin/ganache-cli -d --gasLimit 7000000 --acctKeys ganache-accounts.json
+$ ./node_modules/.bin/ganache-cli -d --gasLimit 7000000 --acctKeys ganache-accounts.json
 ```
 
 This will start up a new test blockchain that keeps account keys in a place that is easy to access for TrufflePig and colonyJS.

--- a/docs/_Docs_Loaders.md
+++ b/docs/_Docs_Loaders.md
@@ -66,8 +66,6 @@ const { abi, address, bytecode } = await loader.load({ contractAddress: '0xdeadb
 ## Future/Imaginable loaders
 Both the `etherscanLoader` and `TrufflepigLoader` are modified versions of the more general `ContractHttpLoader`. We hope to extend functionality to load from more data sources, such as:
 
-
-- File system (node)
 - Databases (indexeddb on the browser, other dbs in node)
 - IPFS (which might be a very specific http loader)
 - Swarm

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -19,3 +19,13 @@ You _could_ create a ColonyClient by using an adapter and a query: `new ColonyCl
 ```javascript
 const colonyClient = await networkClient.getColonyClient(colonyId); // This is already initialised
 ```
+
+## Instance properties
+
+### `authority`
+
+The Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.
+
+### `token`
+
+The Colony's [TokenClient](/colonyjs/api-tokenclient/) instance.

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -39,7 +39,7 @@ const TYPES = {
   Role: 'Role',
   AuthorityRole: 'Authority Role',
   IPFSHash: 'IPFS hash',
-  PayableAddress: 'Payable address',
+  TokenAddress: 'Token address',
 };
 
 const generateMarkdown = ({ file, templateFile, output }) => {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -22,6 +22,7 @@ import {
 } from '../constants';
 
 type Address = string;
+type TokenAddress = string;
 type Role = $Keys<typeof ROLES>;
 type IPFSHash = string;
 
@@ -135,7 +136,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId.
       role: Role, // Role the payout is specified for: MANAGER, EVALUATOR, or WORKER.
-      token: Address, // Address of the token's contract. `0x0` value indicates Ether.
+      token: TokenAddress, // Address of the token's contract. `0x0` value indicates Ether.
     },
     {
       amount: BigNumber, // Amount of specified tokens to payout for that task and a role.
@@ -189,7 +190,7 @@ export default class ColonyClient extends ContractClient {
   getPotBalance: ColonyClient.Caller<
     {
       potId: number, // Integer potId.
-      token: Address, // Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)
     },
     {
       balance: BigNumber, // Balance for token `token` in pot `potId`.
@@ -201,7 +202,7 @@ export default class ColonyClient extends ContractClient {
   */
   getNonRewardPotsTotal: ColonyClient.Caller<
     {
-      token: Address, // Address of the token's contract. `0x0` value indicates Ether.
+      token: TokenAddress, // Address of the token's contract. `0x0` value indicates Ether.
     },
     {
       total: BigNumber, // All tokens that are not within the colony's `rewards` pot.
@@ -219,7 +220,7 @@ export default class ColonyClient extends ContractClient {
       blockNumber: number, // Block number at the time of creation.
       remainingTokenAmount: BigNumber, // Remaining (unclaimed) amount of tokens.
       reputationRootHash: string, // Reputation root hash at the time of creation.
-      token: Address, // Token address (`0x0` value indicates Ether).
+      token: TokenAddress, // Token address (`0x0` value indicates Ether).
       totalTokenAmountForRewardPayout: BigNumber, // Total amount of tokens taken aside for reward payout.
       totalTokens: BigNumber, // Total colony tokens at the time of creation.
     },
@@ -320,7 +321,7 @@ export default class ColonyClient extends ContractClient {
   setTaskEvaluatorPayout: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
-      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -332,7 +333,7 @@ export default class ColonyClient extends ContractClient {
   setTaskManagerPayout: ColonyClient.Sender<
     {
       taskId: number, // Integer taskId.
-      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -344,7 +345,7 @@ export default class ColonyClient extends ContractClient {
   setTaskWorkerPayout: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
-      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -423,7 +424,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId.
       role: Role, // Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER
-      token: Address, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
     },
     {},
     ColonyClient,
@@ -459,7 +460,7 @@ export default class ColonyClient extends ContractClient {
   */
   claimColonyFunds: ColonyClient.Sender<
     {
-      token: Address, // Address to claim funds from; empty address (`0x0` for Ether)
+      token: TokenAddress, // Address to claim funds from; empty address (`0x0` for Ether)
     },
     {},
     ColonyClient,
@@ -482,7 +483,7 @@ export default class ColonyClient extends ContractClient {
       fromPot: number, // Origin pot Id.
       toPot: number, // Destination pot Id.
       amount: BigNumber, // Amount of funds to move.
-      token: Address, // Address of the token contract (`0x0` value indicates Ether).
+      token: TokenAddress, // Address of the token contract (`0x0` value indicates Ether).
     },
     {},
     ColonyClient,
@@ -512,7 +513,7 @@ export default class ColonyClient extends ContractClient {
   */
   startNextRewardPayout: ColonyClient.Sender<
     {
-      token: Address, // Address of token used for reward payout (`0x0` value indicates Ether).
+      token: TokenAddress, // Address of token used for reward payout (`0x0` value indicates Ether).
     },
     {},
     ColonyClient,
@@ -553,7 +554,7 @@ export default class ColonyClient extends ContractClient {
     }>,
     TaskWorkerPayoutChanged: ContractClient.Event<{
       id: number,
-      token: Address,
+      token: TokenAddress,
       amount: number,
     }>,
     TaskFinalized: ContractClient.Event<{
@@ -640,7 +641,7 @@ export default class ColonyClient extends ContractClient {
 
     makeTaskCaller(
       'getTaskPayout',
-      [['role', 'role'], ['token', 'address']],
+      [['role', 'role'], ['token', 'tokenAddress']],
       [['amount', 'bigNumber']],
     );
     makeTaskCaller(
@@ -689,11 +690,11 @@ export default class ColonyClient extends ContractClient {
       output: [['count', 'number']],
     });
     this.addCaller('getNonRewardPotsTotal', {
-      input: [['token', 'address']],
+      input: [['token', 'tokenAddress']],
       output: [['total', 'bigNumber']],
     });
     this.addCaller('getPotBalance', {
-      input: [['potId', 'number'], ['token', 'address']],
+      input: [['potId', 'number'], ['token', 'tokenAddress']],
       output: [['balance', 'bigNumber']],
     });
     this.addCaller('getRewardPayoutInfo', {
@@ -703,7 +704,7 @@ export default class ColonyClient extends ContractClient {
         ['totalTokens', 'bigNumber'],
         ['totalTokenAmountForRewardPayout', 'bigNumber'],
         ['remainingTokenAmount', 'bigNumber'],
-        ['token', 'address'],
+        ['token', 'tokenAddress'],
         ['blockNumber', 'number'],
       ],
     });
@@ -739,7 +740,7 @@ export default class ColonyClient extends ContractClient {
     ]);
     this.addEvent('TaskWorkerPayoutChanged', [
       ['id', 'number'],
-      ['token', 'address'],
+      ['token', 'tokenAddress'],
       ['amount', 'number'],
     ]);
     this.addEvent('TaskFinalized', [['id', 'number']]);
@@ -780,10 +781,14 @@ export default class ColonyClient extends ContractClient {
       input: [['taskId', 'number']],
     });
     this.addSender('claimColonyFunds', {
-      input: [['token', 'address']],
+      input: [['token', 'tokenAddress']],
     });
     this.addSender('claimPayout', {
-      input: [['taskId', 'number'], ['role', 'role'], ['token', 'address']],
+      input: [
+        ['taskId', 'number'],
+        ['role', 'role'],
+        ['token', 'tokenAddress'],
+      ],
     });
     this.addSender('createTask', {
       functionName: 'makeTask',
@@ -819,7 +824,7 @@ export default class ColonyClient extends ContractClient {
         ['fromPot', 'number'],
         ['toPot', 'number'],
         ['amount', 'bigNumber'],
-        ['token', 'address'],
+        ['token', 'tokenAddress'],
       ],
     });
     this.addSender('revealTaskWorkRating', {
@@ -839,7 +844,7 @@ export default class ColonyClient extends ContractClient {
     this.addSender('setTaskManagerPayout', {
       input: [
         ['taskId', 'number'],
-        ['token', 'address'],
+        ['token', 'tokenAddress'],
         ['amount', 'bigNumber'],
       ],
     });
@@ -850,7 +855,7 @@ export default class ColonyClient extends ContractClient {
       input: [['taskId', 'number'], ['deliverableHash', 'ipfsHash']],
     });
     this.addSender('startNextRewardPayout', {
-      input: [['token', 'address']],
+      input: [['token', 'tokenAddress']],
     });
     this.addSender('waiveRewardPayouts', {
       input: [['numPayouts', 'number']],
@@ -893,12 +898,12 @@ export default class ColonyClient extends ContractClient {
     );
     makeExecuteTaskChange(
       'setTaskWorkerPayout',
-      [['token', 'address'], ['amount', 'bigNumber']],
+      [['token', 'tokenAddress'], ['amount', 'bigNumber']],
       [MANAGER_ROLE, WORKER_ROLE],
     );
     makeExecuteTaskChange(
       'setTaskEvaluatorPayout',
-      [['token', 'address'], ['amount', 'bigNumber']],
+      [['token', 'tokenAddress'], ['amount', 'bigNumber']],
       [MANAGER_ROLE, EVALUATOR_ROLE],
     );
   }

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -22,7 +22,6 @@ import {
 } from '../constants';
 
 type Address = string;
-type PayableAddress = string;
 type Role = $Keys<typeof ROLES>;
 type IPFSHash = string;
 
@@ -136,7 +135,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId.
       role: Role, // Role the payout is specified for: MANAGER, EVALUATOR, or WORKER.
-      source: PayableAddress, // Address of the token's contract `0x0` value indicates Ether.
+      token: Address, // Address of the token's contract. `0x0` value indicates Ether.
     },
     {
       amount: BigNumber, // Amount of specified tokens to payout for that task and a role.
@@ -185,12 +184,12 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Gets a balance for a certain source in a specific pot.
+    Gets a balance for a certain token in a specific pot.
   */
   getPotBalance: ColonyClient.Caller<
     {
       potId: number, // Integer potId.
-      source: PayableAddress, // Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)
+      token: Address, // Address to get funds from, such as the token contract address, or empty address (`0x0` for Ether)
     },
     {
       balance: BigNumber, // Balance for token `token` in pot `potId`.
@@ -202,7 +201,7 @@ export default class ColonyClient extends ContractClient {
   */
   getNonRewardPotsTotal: ColonyClient.Caller<
     {
-      source: PayableAddress, // Address of the token's contract `0x0` value indicates Ether.
+      token: Address, // Address of the token's contract. `0x0` value indicates Ether.
     },
     {
       total: BigNumber, // All tokens that are not within the colony's `rewards` pot.
@@ -220,7 +219,7 @@ export default class ColonyClient extends ContractClient {
       blockNumber: number, // Block number at the time of creation.
       remainingTokenAmount: BigNumber, // Remaining (unclaimed) amount of tokens.
       reputationRootHash: string, // Reputation root hash at the time of creation.
-      source: PayableAddress, // Token address (`0x0` value indicates Ether).
+      token: Address, // Token address (`0x0` value indicates Ether).
       totalTokenAmountForRewardPayout: BigNumber, // Total amount of tokens taken aside for reward payout.
       totalTokens: BigNumber, // Total colony tokens at the time of creation.
     },
@@ -321,7 +320,7 @@ export default class ColonyClient extends ContractClient {
   setTaskEvaluatorPayout: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
-      source: PayableAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -333,7 +332,7 @@ export default class ColonyClient extends ContractClient {
   setTaskManagerPayout: ColonyClient.Sender<
     {
       taskId: number, // Integer taskId.
-      source: PayableAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -345,7 +344,7 @@ export default class ColonyClient extends ContractClient {
   setTaskWorkerPayout: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
-      source: PayableAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: Address, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
     {},
@@ -418,13 +417,13 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Claims the payout in `source` denomination for work completed in task `taskId` by contributor with role `role`. Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout. Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
+    Claims the payout for `token` denomination for work completed in task `taskId` by contributor with role `role`. Allowed only by the contributors themselves after task is finalized. Here the network receives its fee from each payout. Ether fees go straight to the Meta Colony whereas Token fees go to the Network to be auctioned off.
   */
   claimPayout: ColonyClient.Sender<
     {
       taskId: number, // Integer taskId.
       role: Role, // Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER
-      source: PayableAddress, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
+      token: Address, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
     },
     {},
     ColonyClient,
@@ -456,11 +455,11 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Move any funds received by the colony in `source` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
+    Move any funds received by the colony for `token` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
   */
   claimColonyFunds: ColonyClient.Sender<
     {
-      source: PayableAddress, // Address to claim funds from; empty address (`0x0` for Ether)
+      token: Address, // Address to claim funds from; empty address (`0x0` for Ether)
     },
     {},
     ColonyClient,
@@ -483,7 +482,7 @@ export default class ColonyClient extends ContractClient {
       fromPot: number, // Origin pot Id.
       toPot: number, // Destination pot Id.
       amount: BigNumber, // Amount of funds to move.
-      address: PayableAddress, // Address of the token contract (`0x0` value indicates Ether).
+      token: Address, // Address of the token contract (`0x0` value indicates Ether).
     },
     {},
     ColonyClient,
@@ -641,7 +640,7 @@ export default class ColonyClient extends ContractClient {
 
     makeTaskCaller(
       'getTaskPayout',
-      [['role', 'role'], ['source', 'payableAddress']],
+      [['role', 'role'], ['token', 'address']],
       [['amount', 'bigNumber']],
     );
     makeTaskCaller(
@@ -690,11 +689,11 @@ export default class ColonyClient extends ContractClient {
       output: [['count', 'number']],
     });
     this.addCaller('getNonRewardPotsTotal', {
-      input: [['source', 'payableAddress']],
+      input: [['token', 'address']],
       output: [['total', 'bigNumber']],
     });
     this.addCaller('getPotBalance', {
-      input: [['potId', 'number'], ['source', 'payableAddress']],
+      input: [['potId', 'number'], ['token', 'address']],
       output: [['balance', 'bigNumber']],
     });
     this.addCaller('getRewardPayoutInfo', {
@@ -704,7 +703,7 @@ export default class ColonyClient extends ContractClient {
         ['totalTokens', 'bigNumber'],
         ['totalTokenAmountForRewardPayout', 'bigNumber'],
         ['remainingTokenAmount', 'bigNumber'],
-        ['source', 'payableAddress'],
+        ['token', 'address'],
         ['blockNumber', 'number'],
       ],
     });
@@ -781,14 +780,10 @@ export default class ColonyClient extends ContractClient {
       input: [['taskId', 'number']],
     });
     this.addSender('claimColonyFunds', {
-      input: [['source', 'payableAddress']],
+      input: [['token', 'address']],
     });
     this.addSender('claimPayout', {
-      input: [
-        ['taskId', 'number'],
-        ['role', 'role'],
-        ['source', 'payableAddress'],
-      ],
+      input: [['taskId', 'number'], ['role', 'role'], ['token', 'address']],
     });
     this.addSender('createTask', {
       functionName: 'makeTask',
@@ -824,7 +819,7 @@ export default class ColonyClient extends ContractClient {
         ['fromPot', 'number'],
         ['toPot', 'number'],
         ['amount', 'bigNumber'],
-        ['address', 'address'],
+        ['token', 'address'],
       ],
     });
     this.addSender('revealTaskWorkRating', {
@@ -844,7 +839,7 @@ export default class ColonyClient extends ContractClient {
     this.addSender('setTaskManagerPayout', {
       input: [
         ['taskId', 'number'],
-        ['source', 'payableAddress'],
+        ['token', 'address'],
         ['amount', 'bigNumber'],
       ],
     });
@@ -898,12 +893,12 @@ export default class ColonyClient extends ContractClient {
     );
     makeExecuteTaskChange(
       'setTaskWorkerPayout',
-      [['source', 'payableAddress'], ['amount', 'bigNumber']],
+      [['token', 'address'], ['amount', 'bigNumber']],
       [MANAGER_ROLE, WORKER_ROLE],
     );
     makeExecuteTaskChange(
       'setTaskEvaluatorPayout',
-      [['source', 'payableAddress'], ['amount', 'bigNumber']],
+      [['token', 'address'], ['amount', 'bigNumber']],
       [MANAGER_ROLE, EVALUATOR_ROLE],
     );
   }

--- a/packages/colony-js-client/src/paramTypes.js
+++ b/packages/colony-js-client/src/paramTypes.js
@@ -1,13 +1,9 @@
 /* @flow */
 
-import {
-  isBigNumber,
-  isValidAddress,
-  isEmptyHexString,
-} from '@colony/colony-js-utils';
+import { isBigNumber } from '@colony/colony-js-utils';
 import { addParamType } from '@colony/colony-js-contract-client';
 
-import { ROLES, AUTHORITY_ROLES, EMPTY_ADDRESS } from './constants';
+import { ROLES, AUTHORITY_ROLES } from './constants';
 
 const roleType = (roles: { [roleName: string]: number }) => ({
   validate(value: any) {
@@ -25,17 +21,3 @@ const roleType = (roles: { [roleName: string]: number }) => ({
 addParamType('role', roleType(ROLES));
 
 addParamType('authorityRole', roleType(AUTHORITY_ROLES));
-
-// Either a valid address, or an empty address to indicate ether
-// (0x0 or 0x0000000000000000000000000000000000000000)
-addParamType('payableAddress', {
-  validate(value: any) {
-    return isValidAddress(value) || isEmptyHexString(value);
-  },
-  convertInput(value: any) {
-    return isValidAddress(value) ? value : EMPTY_ADDRESS;
-  },
-  convertOutput(value: any) {
-    return value;
-  },
-});

--- a/packages/colony-js-contract-client/src/flowtypes.js
+++ b/packages/colony-js-contract-client/src/flowtypes.js
@@ -22,6 +22,7 @@ export type ParamTypes =
   | 'date'
   | 'ipfsHash'
   | 'number'
+  | 'tokenAddress'
   | 'string';
 
 // [param name, param type, default value (optional)]

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -119,6 +119,19 @@ const PARAM_TYPE_MAP: {
         .toString('hex')}`;
     },
   },
+  // Either a valid address, or an empty address to indicate ether
+  // (0x0 or 0x0000000000000000000000000000000000000000)
+  tokenAddress: {
+    validate(value: any) {
+      return isValidAddress(value) || isEmptyHexString(value);
+    },
+    convertInput(value: string) {
+      return value;
+    },
+    convertOutput(value: string) {
+      return value;
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

_

Doc fixes. For consistency and better naming we renamed `source` to `tokenAddress`,
moved the payable address type to the contract client, and renamed it to `tokenAddress`.
_