### PR TITLE
Wait for TX receipt in token deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Actually wait for transaction receipt in Token contract deployment. This fixes issues with real-life environments like testnets or mainnet (`@colony/colony-js-client`)
 
 ## v1.5.0
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -242,6 +242,10 @@ export default class ColonyNetworkClient extends ContractClient {
       [utf8ToHex(name), utf8ToHex(symbol), decimals],
     );
     const { hash } = await this.adapter.wallet.sendTransaction(transaction);
+    const receipt = await this.adapter.getTransactionReceipt(hash);
+    if (receipt != null) return receipt.contractAddress;
+
+    await this.adapter.waitForTransaction(hash);
     const { contractAddress } = await this.adapter.getTransactionReceipt(hash);
     return contractAddress;
   }


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.


We adjusted the waiting time for senders but this also adjusts it for the token
deployment. It now properly waits for a tx receipt before getting it. This
helps with deployment on test networks or mainnet.