### PR TITLE
Convert role hex value outputs to numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 * `getTokenInfo` won't throw anymore if one of the properties `symbol`, `name` or `decimals` is not implemented on the token contract. Instead it will just report `null` for the values which are not defined (`@colony/colony-js-client`)
+* Fixed a bug where `authority.getUserRole` would only report `null` for every role by converting the output values from hex numbers first (`@colony/colony-js-client`)
 
 **Documentation**
 

--- a/packages/colony-js-client/src/__tests__/paramTypes.test.js
+++ b/packages/colony-js-client/src/__tests__/paramTypes.test.js
@@ -4,6 +4,7 @@
 import BigNumber from 'bn.js';
 import ContractClient from '@colony/colony-js-contract-client';
 import createSandbox from 'jest-sandbox';
+import { padLeft } from 'web3-utils';
 
 import '../paramTypes';
 import { ROLES, WORKER_ROLE, EVALUATOR_ROLE, MANAGER_ROLE } from '../constants';
@@ -69,6 +70,11 @@ describe('Custom param types', () => {
       client.getRole.convertOutputValues(new BigNumber(ROLES.MANAGER)),
     ).toEqual({
       role: MANAGER_ROLE,
+    });
+    expect(
+      client.getRole.convertOutputValues(padLeft(`0x${ROLES.WORKER}`, 64)),
+    ).toEqual({
+      role: WORKER_ROLE,
     });
     // Bad/missing output values should be null
     expect(client.getRole.convertOutputValues(new BigNumber(4))).toEqual({

--- a/packages/colony-js-client/src/paramTypes.js
+++ b/packages/colony-js-client/src/paramTypes.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { isBigNumber } from '@colony/colony-js-utils';
+import { isHexStrict, hexToNumber } from 'web3-utils';
 import { addParamType } from '@colony/colony-js-contract-client';
 
 import { ROLES, AUTHORITY_ROLES } from './constants';
@@ -13,8 +14,15 @@ const roleType = (roles: { [roleName: string]: number }) => ({
     return roles[value];
   },
   convertOutput(value: any) {
-    const roleNumber = isBigNumber(value) ? value.toNumber() : value;
-    return Object.keys(roles).find(name => roles[name] === roleNumber) || null;
+    let converted;
+    if (isHexStrict(value)) {
+      converted = hexToNumber(value);
+    } else if (isBigNumber(value)) {
+      converted = value.toNumber();
+    } else {
+      converted = value;
+    }
+    return Object.keys(roles).find(name => roles[name] === converted) || null;
   },
 });
 


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.


This PR fixes the issue that roles reported by the contracts were always cast
to `null`. They were reported in hex format which needs to be converted before
finding the correct role for the number.


> ⚠️  NOTE: Use special keywords to close / connect the PR with the issue(s) it solves or contributes with.

Resolves #200