### PR TITLE
Improve getTokenInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+* `getTokenInfo` won't throw anymore if one of the properties `symbol`, `name` or `decimals` is not implemented on the token contract. Instead it will just report `null` for the values which are not defined (`@colony/colony-js-client`)
+
 **Documentation**
 
 * Clarified the naming of parameters involving token addresses (`@colony/colony-js-contract-client`, `@colony/colony-js-client`)

--- a/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
+++ b/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
@@ -6,7 +6,7 @@ import ContractClient from '@colony/colony-js-contract-client';
 import type TokenClient from '../index';
 
 type InputValues = {};
-type CallResult = [string, string, number];
+type CallResult = [?string, ?string, ?number];
 
 export default class GetTokenInfo extends ContractClient.Caller<
   InputValues,
@@ -26,12 +26,21 @@ export default class GetTokenInfo extends ContractClient.Caller<
     });
   }
   async call() {
-    const name = await this.client.call('name', []);
-    const symbol = await this.client.call('symbol', []);
-    const decimals = await this.client.call('decimals', []);
+    const name = await this.getValueFor('name');
+    const symbol = await this.getValueFor('symbol');
+    const decimals = await this.getValueFor('decimals');
 
     const callResult: CallResult = [name, symbol, decimals];
 
     return this.convertOutputValues(callResult);
+  }
+  async getValueFor(prop: string) {
+    let data;
+    try {
+      data = await this.client.call(prop, []);
+    } catch (e) {
+      data = null;
+    }
+    return data;
   }
 }


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.


`getTokenInfo` won't throw anymore if one of the properties `symbol`, `name` or
`decimals` is not implemented on the token contract. Instead it will just repot
`null` for the values which are not defined.

> ⚠️  NOTE: Use special keywords to close / connect the PR with the issue(s) it solves or contributes with.

Resolves #203.