### PR TITLE
Get wallet address with `getAddress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Remove the `address` property of the `Wallet` interface, because it is not universal (`@colony/colony-js-adapter`)
+* Clarify that the `getAddress` method of the `Wallet` interface is asynchronous
+* Use the `getAddress` method to get the current address when signing multisig operations (`@colony/colony-js-contract-client`)
 
 ## v1.5.2
 

--- a/packages/colony-js-adapter/interface/Wallet.js
+++ b/packages/colony-js-adapter/interface/Wallet.js
@@ -9,7 +9,6 @@ import type { TransactionOptions } from './TransactionOptions';
 import type { TransactionReceipt } from './TransactionReceipt';
 
 export interface Wallet {
-  address: string;
   privateKey: string;
   provider: IProvider;
   encrypt(
@@ -18,7 +17,7 @@ export interface Wallet {
     progressCallback?: (progress: number) => *,
   ): string;
   estimateGas(transaction: Transaction): Promise<BigNumber>;
-  getAddress(): string;
+  getAddress(): Promise<string>;
   getBalance(blockTag?: string): Promise<BigNumber>;
   getTransactionCount(blockTag?: string): Promise<number>;
   parseTransaction(hexStringOrArrayish: string): Transaction;

--- a/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/__tests__/MultisigOperation.js
@@ -96,7 +96,7 @@ describe('MultisigOperation', () => {
       adapter: {
         signMessage: sandbox.fn().mockImplementation(async () => signature),
         wallet: {
-          address,
+          getAddress: sandbox.fn().mockImplementation(async () => address),
         },
         ecRecover: sandbox.fn().mockImplementation(() => address),
       },
@@ -394,7 +394,7 @@ describe('MultisigOperation', () => {
       .mockReturnValueOnce(address)
       .mockReturnValueOnce('not the right address');
 
-    const mode = op._findSignatureMode(signature);
+    const mode = op._findSignatureMode(signature, address);
 
     expect(mode).toBe(0); // A match was found for the first mode
     expect(op._getMessageDigest).toHaveBeenCalledWith(0);
@@ -411,7 +411,7 @@ describe('MultisigOperation', () => {
     // It should fail when the address does not match in either case
     op.sender.client.adapter.ecRecover.mockReturnValue('not the right address');
     expect(() => {
-      op._findSignatureMode(signature);
+      op._findSignatureMode(signature, address);
     }).toThrowError('Unable to confirm signature mode');
   });
 

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -173,14 +173,13 @@ export default class MultisigOperation<
   }
 
   /**
-   * Given a signature and the address of the current wallet, determine the
-   * signing mode by trying different digests with `ecRecover` until the
-   * wallet address matches the recovered address.
+   * Given a signature and a wallet address, determine the signing mode by
+   * trying different digests with `ecRecover` until the wallet address matches
+   * the recovered address.
    */
-  _findSignatureMode(signature: Signature): SigningMode {
+  _findSignatureMode(signature: Signature, address: string): SigningMode {
     let foundMode;
     const { adapter } = this.sender.client;
-    const { address } = adapter.wallet;
 
     Object.values(SIGNING_MODES).forEach(mode => {
       const digest = this._getMessageDigest(mode);
@@ -252,7 +251,7 @@ export default class MultisigOperation<
    * add the address/signature to the signers.
    */
   _addSignature(signature: Signature, address: string) {
-    const mode = this._findSignatureMode(signature);
+    const mode = this._findSignatureMode(signature, address);
 
     this._signers = Object.assign({}, this._signers, {
       [address]: {
@@ -270,7 +269,8 @@ export default class MultisigOperation<
     await this.refresh();
     const { adapter } = this.sender.client;
     const signature = await adapter.signMessage(this._messageHash);
-    this._addSignature(signature, adapter.wallet.address);
+    const address = await adapter.wallet.getAddress();
+    this._addSignature(signature, address);
     return this;
   }
 


### PR DESCRIPTION
## Description

This PR changes the signing of multisig operations so that the `getAddress` method is used to get the current wallet address, rather than the `address` property of the wallet (which is not always available).

This fixes issues signing multisig ops encountered when signing with metamask.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Remove the `address` property of the `Wallet` interface, because it is not universal 
* Clarify that the `getAddress` method of the `Wallet` interface is asynchronous
