### PR TITLE
Remove mocks for `paramTypes` tests

### DIFF
--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -3,20 +3,6 @@
 import createSandbox from 'jest-sandbox';
 import BigNumber from 'bn.js';
 
-import bs58 from 'bs58';
-import {
-  isValidAddress,
-  isBigNumber,
-  isEmptyHexString,
-} from '@colony/colony-js-utils';
-import {
-  isHex,
-  isHexStrict,
-  utf8ToHex,
-  hexToBytes,
-  hexToUtf8,
-} from 'web3-utils';
-
 import {
   addParamType,
   validateValueType,
@@ -24,57 +10,26 @@ import {
   convertInputValue,
 } from '../modules/paramTypes';
 
-jest.mock('@colony/colony-js-utils', () => ({
-  isBigNumber: jest.fn().mockReturnValue(true),
-  isValidAddress: jest.fn().mockReturnValue(true),
-  isEmptyHexString: jest.fn().mockReturnValue(true),
-  makeAssert: jest.fn(),
-}));
-
-jest.mock('bs58', () => ({
-  encode: jest.fn().mockImplementation(value => value),
-  decode: jest.fn().mockImplementation(value => value),
-}));
-
-jest.mock('web3-utils', () => ({
-  isHex: jest.fn().mockReturnValue(true),
-  isHexStrict: jest.fn().mockReturnValue(true),
-  utf8ToHex: jest.fn().mockImplementation(value => value),
-  hexToBytes: jest.fn().mockImplementation(() => [101]),
-  hexToUtf8: jest.fn().mockImplementation(value => value),
-}));
-
 describe('Parameter types', () => {
   const sandbox = createSandbox();
 
   beforeEach(() => {
     sandbox.clear();
-    isBigNumber.mockClear();
-    isValidAddress.mockClear();
-    isEmptyHexString.mockClear();
-    isHexStrict.mockClear();
-    isHex.mockClear();
-    utf8ToHex.mockClear();
-    hexToBytes.mockClear();
-    bs58.encode.mockClear();
-    bs58.decode.mockClear();
   });
+
+  const validAddress = '0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9';
 
   test('Addresses are handled properly', () => {
     // Validation
-    expect(validateValueType('0x123', 'address')).toBe(true);
-    expect(isValidAddress).toHaveBeenCalledWith('0x123');
-    isValidAddress.mockClear();
+    expect(validateValueType(validAddress, 'address')).toBe(true);
 
     // Converting output values
-    expect(convertOutputValue('0x123', 'address')).toBe('0x123');
-    expect(isValidAddress).toHaveBeenCalledWith('0x123');
+    expect(convertOutputValue(validAddress, 'address')).toBe(validAddress);
 
-    isValidAddress.mockReturnValueOnce(false);
     expect(convertOutputValue(null, 'address')).toBe(null);
 
     // Converting input values
-    expect(convertInputValue('0x123', 'address')).toBe('0x123');
+    expect(convertInputValue(validAddress, 'address')).toBe(validAddress);
   });
 
   test('BigNumbers are handled properly', () => {
@@ -82,14 +37,10 @@ describe('Parameter types', () => {
 
     // Validation
     expect(validateValueType(bn, 'bigNumber')).toBe(true);
-    expect(isBigNumber).toHaveBeenCalledWith(bn);
-    isBigNumber.mockClear();
 
     // Cleaning
     expect(convertOutputValue(bn, 'bigNumber')).toBe(bn);
-    expect(isBigNumber).toHaveBeenCalledWith(bn);
 
-    isBigNumber.mockReturnValueOnce(false);
     expect(convertOutputValue(null, 'bigNumber')).toBe(null);
 
     // Conversion
@@ -121,17 +72,11 @@ describe('Parameter types', () => {
     expect(validateValueType(null, 'number')).toBe(false);
 
     // Converting output values
-    isBigNumber.mockReturnValueOnce(false);
     expect(convertOutputValue(1, 'number')).toBe(1);
-    expect(isBigNumber).toHaveBeenCalledWith(1);
-    isBigNumber.mockClear();
 
     const bn = new BigNumber(1);
-    isBigNumber.mockReturnValueOnce(true);
     expect(convertOutputValue(bn, 'number')).toBe(1);
-    expect(isBigNumber).toHaveBeenCalledWith(bn);
 
-    isBigNumber.mockReturnValueOnce(false);
     expect(convertOutputValue(null, 'number')).toBe(null);
 
     // Converting input values
@@ -156,24 +101,15 @@ describe('Parameter types', () => {
 
     // Converting output values
     const bnDate = new BigNumber(timeWithoutMs);
-    isBigNumber.mockReturnValueOnce(true);
     const outputFromBn = convertOutputValue(bnDate, 'date');
     expect(outputFromBn).toBeInstanceOf(Date);
     expect(outputFromBn.getTime()).toEqual(timeWithMs);
-    expect(isBigNumber).toHaveBeenCalledWith(bnDate);
-    isBigNumber.mockClear();
 
-    isBigNumber.mockReturnValueOnce(false);
     const outputFromNumber = convertOutputValue(timeWithoutMs, 'date');
     expect(outputFromNumber).toBeInstanceOf(Date);
     expect(outputFromNumber.getTime()).toEqual(timeWithMs);
-    expect(isBigNumber).toHaveBeenCalledWith(timeWithoutMs);
-    isBigNumber.mockClear();
 
-    isBigNumber.mockReturnValueOnce(false);
     expect(convertOutputValue(0, 'date')).toEqual(null);
-    expect(isBigNumber).toHaveBeenCalledWith(0);
-    isBigNumber.mockClear();
 
     // Converting input values
     expect(convertInputValue(date, 'date')).toBe(timeWithoutMs);
@@ -187,10 +123,7 @@ describe('Parameter types', () => {
     expect(validateValueType(1, 'string')).toBe(false);
 
     // Converting output values
-    isHexStrict.mockReturnValueOnce(false);
     expect(convertOutputValue('a', 'string')).toBe('a');
-    isEmptyHexString.mockReturnValueOnce(false);
-    hexToUtf8.mockReturnValueOnce('COLNY');
     expect(convertOutputValue('0x434f4c4e59', 'string')).toBe('COLNY');
     expect(convertOutputValue('0x00', 'string')).toBe(null);
 
@@ -201,25 +134,16 @@ describe('Parameter types', () => {
     expect(convertOutputValue(null, 'string')).toBe(null);
 
     // Converting input values
-    isHex.mockReturnValueOnce(true);
-    expect(convertInputValue('0x123', 'string')).toBe('0x123');
-    expect(isHex).toHaveBeenCalledWith('0x123');
-    expect(utf8ToHex).not.toHaveBeenCalledWith();
-    isHex.mockClear();
-    utf8ToHex.mockClear();
-
-    isHex.mockReturnValueOnce(false);
-    utf8ToHex.mockReturnValueOnce('0x123');
-    expect(convertInputValue('not a hex value', 'string')).toBe('0x123');
-    expect(isHex).toHaveBeenCalledWith('not a hex value');
-    expect(utf8ToHex).toHaveBeenCalledWith('not a hex value');
+    expect(convertInputValue(validAddress, 'string')).toBe(validAddress);
+    expect(convertInputValue('not a hex value', 'string')).toBe(
+      '0x6e6f742061206865782076616c7565',
+    );
   });
 
   test('IPFS hashes are handled properly', () => {
     const hash = 'QmcNbGg6EVfFn2Z1QxWauR9XY9KhnEcyb5DUXCXHi8pwMJ';
     const bytes32Hash =
       '0xd082e403efc3a9b0d92f5a325274a2aaf823fefce13abae890cc140e2b84cb99';
-    const bytes = [18, 32, 208]; // not a real example
 
     // Validation
     expect(validateValueType(hash, 'ipfsHash')).toBe(true);
@@ -230,31 +154,13 @@ describe('Parameter types', () => {
     expect(validateValueType(1, 'ipfsHash')).toBe(false);
 
     // Converting output values
-    bs58.encode.mockReturnValueOnce(bytes32Hash);
-    isHex.mockReturnValueOnce(true);
-    hexToBytes.mockReturnValueOnce(bytes);
-    isEmptyHexString.mockReturnValueOnce(false);
-    expect(convertOutputValue(hash, 'ipfsHash')).toBe(bytes32Hash);
-    expect(isHex).toHaveBeenCalledWith(hash);
-    expect(isEmptyHexString).toHaveBeenCalledWith(hash);
-    expect(hexToBytes).toHaveBeenCalledWith(`0x1220${hash.slice(2)}`);
-    expect(bs58.encode).toHaveBeenCalledWith(bytes);
+    expect(convertOutputValue(bytes32Hash, 'ipfsHash')).toBe(hash);
 
     // Empty hashes are cleaned:
-    isHex.mockReturnValueOnce(true);
-    isEmptyHexString.mockReturnValueOnce(true);
     expect(convertOutputValue('', 'ipfsHash')).toBe(null);
 
-    isHex.mockClear();
-    isEmptyHexString.mockClear();
-    hexToBytes.mockClear();
-    bs58.encode.mockClear();
-
     // Converting input values
-    isHex.mockReturnValueOnce(true);
-    bs58.decode.mockReturnValueOnce(bytes32Hash);
     expect(convertInputValue(hash, 'ipfsHash')).toBe(bytes32Hash);
-    expect(bs58.decode).toHaveBeenCalledWith(hash);
   });
 
   test('Adding param types', () => {
@@ -276,8 +182,5 @@ describe('Parameter types', () => {
     validateValueType(1, customType);
     convertInputValue(1, customType);
     convertOutputValue(1, customType);
-    expect(def.validate).toHaveBeenCalledWith(1);
-    expect(def.convertInput).toHaveBeenCalledWith(1);
-    expect(def.convertOutput).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -105,7 +105,7 @@ const PARAM_TYPE_MAP: {
       );
     },
     convertOutput(value: any) {
-      if (isHex(value) && !isEmptyHexString(value)) {
+      if (isHexStrict(value) && !isEmptyHexString(value)) {
         const hex = `0x1220${value.slice(2)}`;
         const bytes = hexToBytes(hex);
         return bs58.encode(bytes);


### PR DESCRIPTION
## Description

This PR simply removes the mocks for the paramTypes tests.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Fixed a bug in the IPFS hash output validation, where values were not checked for strict hex format.
