### PR TITLE
Fix `TaskDueDateChanged` event parameter type

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -724,7 +724,7 @@ export default class ColonyClient extends ContractClient {
     ]);
     this.addEvent('TaskDueDateChanged', [
       ['id', 'number'],
-      ['dueDate', 'number'],
+      ['dueDate', 'date'],
     ]);
     this.addEvent('TaskDomainChanged', [
       ['id', 'number'],


### PR DESCRIPTION
## Description 

The type of the `TaskDueDateChanged` event's `dueDate` parameter was stated as `number`, which isn't necessarily wrong, but it's more appropriate to consider it as `Date`. A simple fix!