### PR TITLE
Change mintTokens type to BigNumber

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -646,7 +646,7 @@ The owner of a Colony may mint new tokens.
 
 |Argument|Type|Description|
 |---|---|---|
-|amount|number|Amount of new tokens to be minted.|
+|amount|BigNumber|Amount of new tokens to be minted.|
 
 **Returns**
 
@@ -662,7 +662,7 @@ In the case of the Colony Network, only the Meta Colony may mint new tokens.
 
 |Argument|Type|Description|
 |---|---|---|
-|amount|number|Amount of new tokens to be minted.|
+|amount|BigNumber|Amount of new tokens to be minted.|
 
 **Returns**
 

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -188,7 +188,7 @@ await colonyClient.token.setOwner.send({ owner: colonyClient.contract.address })
 await colonyClient.authority.setUserRole.send({ user: wallet.address, role: 'ADMIN' });
 
 // Mint some tokens
-await colonyClient.mintTokens.send({ amount: 1000 });
+await colonyClient.mintTokens.send({ amount: new BigNumber(1000) });
 
 // Get the total supply
 const { amount } = await colonyClient.token.getTotalSupply.call();

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -494,7 +494,7 @@ export default class ColonyClient extends ContractClient {
   */
   mintTokens: ColonyClient.Sender<
     {
-      amount: number, // Amount of new tokens to be minted.
+      amount: BigNumber, // Amount of new tokens to be minted.
     },
     {},
     ColonyClient,
@@ -504,7 +504,7 @@ export default class ColonyClient extends ContractClient {
   */
   mintTokensForColonyNetwork: ColonyClient.Sender<
     {
-      amount: number, // Amount of new tokens to be minted.
+      amount: BigNumber, // Amount of new tokens to be minted.
     },
     {},
     ColonyClient,


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.


Changes the FlowType of mintTokens and mintTokensForColonyNetwork to BigNumber.
Also adjusts the "Get started" documentation.

Resolves #212