### PR TITLE
Maintenance/colony js contract loader tests

### DIFF
--- a/packages/colony-js-contract-loader/jest.conf.json
+++ b/packages/colony-js-contract-loader/jest.conf.json
@@ -1,0 +1,10 @@
+{
+    "rootDir": "src",
+    "collectCoverageFrom" : ["*.{js}", "**/*.{js}"],
+    "coverageDirectory": "../coverage",
+    "coverageThreshold": {
+        "global": {
+            "branches": 0
+        }
+    }
+  }

--- a/packages/colony-js-contract-loader/package.json
+++ b/packages/colony-js-contract-loader/package.json
@@ -18,7 +18,9 @@
         "clean": "shx rm -rf lib",
         "flow": "flow check",
         "lint": "eslint src/{,**/}*.js",
-        "precommit": "lint-staged"
+        "precommit": "lint-staged",
+        "test": "yarn run flow && yarn run lint && yarn run test:unit",
+        "test:unit": "jest --coverage --config=jest.conf.json"
     },
     "lint-staged": {
         "./{,interface/}*": [
@@ -37,7 +39,8 @@
     "homepage": "https://github.com/JoinColony/colonyJS#readme",
     "devDependencies": {
         "flow-bin": "^0.73.0",
-        "flow-copy-source": "^2.0.0"
+        "flow-copy-source": "^2.0.0",
+        "jest-sandbox": "^1.1.2"
     },
     "engines": {
         "node": ">=8.2.1",

--- a/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
@@ -1,0 +1,159 @@
+/* eslint-env jest */
+
+import assert from 'assert';
+import createSandbox from 'jest-sandbox';
+import ContractLoader from '../ContractLoader';
+import { DEFAULT_REQUIRED_CONTRACT_PROPS } from '../defaults';
+
+jest.mock('assert');
+
+describe('ContractLoader', () => {
+  const sandbox = createSandbox();
+
+  beforeEach(() => {
+    sandbox.clear();
+    assert.mockReset();
+  });
+
+  test('Default transform', async () => {
+    expect(
+      ContractLoader.defaultTransform()('input', 'query', 'required props'),
+    ).toBe('input');
+  });
+
+  test('Validate contract definition', async () => {
+    const contractDef = {
+      address: 'contract address',
+      abi: 'contract abi',
+      bytecode: 'contract bytecode',
+    };
+    const requiredProps = {
+      address: true,
+      bytecode: true,
+      abi: true,
+    };
+
+    expect(
+      ContractLoader.validateContractDefinition(contractDef, requiredProps),
+    ).toBe(true);
+    expect(assert).toHaveBeenCalledTimes(4);
+
+    // again but without any required props
+    expect(ContractLoader.validateContractDefinition(contractDef, {})).toBe(
+      true,
+    );
+  });
+
+  test('Constructor', async () => {
+    assert.mockImplementation(() => {
+      throw new Error();
+    });
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new ContractLoader({ transform: 'not a function' });
+    }).toThrow();
+    expect(assert).toHaveBeenCalledWith(false, expect.any(String));
+  });
+
+  test('_load', async () => {
+    const loader = new ContractLoader();
+    // eslint-disable-next-line no-underscore-dangle
+    expect(loader._load()).rejects.toThrow();
+  });
+
+  test('Load with no query', async () => {
+    const loader = new ContractLoader();
+
+    await expect(loader.load()).rejects.toThrow(TypeError);
+  });
+
+  test('Load with no result', async () => {
+    const loader = new ContractLoader();
+
+    const query = {
+      contractName: 'contract name',
+    };
+
+    const loadSpy = sandbox
+      .spyOn(loader, '_load')
+      .mockImplementation(() => null);
+
+    await expect(loader.load(query)).rejects.toThrow(Error);
+    expect(loadSpy).toBeCalledWith(query, DEFAULT_REQUIRED_CONTRACT_PROPS);
+  });
+
+  test('Load with contract address', async () => {
+    const loader = new ContractLoader();
+
+    const query = {
+      contractAddress: 'contract address',
+    };
+
+    const loadSpy = sandbox
+      .spyOn(loader, '_load')
+      .mockImplementation(() => ({}));
+
+    const validateContractDefinitionSpy = sandbox
+      .spyOn(ContractLoader, 'validateContractDefinition')
+      .mockImplementation(() => null);
+
+    await expect(loader.load(query)).resolves.toEqual({
+      address: query.contractAddress,
+    });
+    expect(loadSpy).toBeCalledWith(query, DEFAULT_REQUIRED_CONTRACT_PROPS);
+    expect(validateContractDefinitionSpy).toBeCalled();
+  });
+
+  test('Load with router address', async () => {
+    const loader = new ContractLoader();
+
+    const query = {
+      contractName: 'contract name',
+      routerAddress: 'router address',
+    };
+
+    const loadSpy = sandbox
+      .spyOn(loader, '_load')
+      .mockImplementation(() => ({}));
+
+    const validateContractDefinitionSpy = sandbox
+      .spyOn(ContractLoader, 'validateContractDefinition')
+      .mockImplementation(() => null);
+
+    await expect(loader.load(query)).resolves.toEqual({
+      address: query.routerAddress,
+    });
+    expect(loadSpy).toBeCalledWith(
+      { contractName: query.contractName },
+      DEFAULT_REQUIRED_CONTRACT_PROPS,
+    );
+    expect(validateContractDefinitionSpy).toBeCalled();
+  });
+
+  test('Load with router name', async () => {
+    const loader = new ContractLoader();
+
+    const query = {
+      contractName: 'contract name',
+      routerName: 'router name',
+    };
+
+    const loadSpy = sandbox
+      .spyOn(loader, '_load')
+      .mockImplementationOnce(() => ({}))
+      .mockImplementationOnce(() => ({ address: 'router address' }));
+
+    const validateContractDefinitionSpy = sandbox
+      .spyOn(ContractLoader, 'validateContractDefinition')
+      .mockImplementation(() => null);
+
+    await expect(loader.load(query)).resolves.toEqual({
+      address: 'router address',
+    });
+    expect(loadSpy).toBeCalledWith(
+      { contractName: query.contractName },
+      DEFAULT_REQUIRED_CONTRACT_PROPS,
+    );
+    expect(validateContractDefinitionSpy).toBeCalled();
+  });
+});

--- a/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
@@ -44,7 +44,7 @@ describe('ContractLoader', () => {
     );
   });
 
-  test('Constructor', async () => {
+  test('Constructor should throw for invalid transform function', async () => {
     assert.mockImplementation(() => {
       throw new Error();
     });
@@ -55,19 +55,19 @@ describe('ContractLoader', () => {
     expect(assert).toHaveBeenCalledWith(false, expect.any(String));
   });
 
-  test('_load', async () => {
+  test('Placeholder _load should throw', async () => {
     const loader = new ContractLoader();
     // eslint-disable-next-line no-underscore-dangle
     expect(loader._load()).rejects.toThrow();
   });
 
-  test('Load with no query', async () => {
+  test('Load should throw if required query params not provided', async () => {
     const loader = new ContractLoader();
 
     await expect(loader.load()).rejects.toThrow(TypeError);
   });
 
-  test('Load with no result', async () => {
+  test('Load should throw if _load returns null', async () => {
     const loader = new ContractLoader();
 
     const query = {

--- a/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/__tests__/ContractLoader.js
@@ -16,9 +16,7 @@ describe('ContractLoader', () => {
   });
 
   test('Default transform', async () => {
-    expect(
-      ContractLoader.defaultTransform()('input', 'query', 'required props'),
-    ).toBe('input');
+    expect(ContractLoader.defaultTransform()('input')).toBe('input');
   });
 
   test('Validate contract definition', async () => {

--- a/packages/colony-js-contract-loader/src/__tests__/truffleTransform.js
+++ b/packages/colony-js-contract-loader/src/__tests__/truffleTransform.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+import createSandbox from 'jest-sandbox';
+import truffleTransform from '../transforms/truffleTransform';
+
+describe('truffleTransform', () => {
+  const sandbox = createSandbox();
+
+  const artifact = {
+    abi: ['abi item'],
+    bytecode: 'bytecode',
+    networks: {
+      1: {
+        address: 'address 1',
+      },
+      '2': {
+        address: 'address 2',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    sandbox.clear();
+  });
+
+  test('With no Truffle artifact', async () => {
+    expect(truffleTransform()).toEqual({
+      abi: [],
+    });
+  });
+
+  test('With latest network', async () => {
+    expect(truffleTransform(artifact)).toEqual({
+      abi: ['abi item'],
+      address: 'address 2',
+      bytecode: 'bytecode',
+    });
+  });
+
+  test('With present specific network', async () => {
+    expect(truffleTransform(artifact, { network: '1' })).toEqual({
+      abi: ['abi item'],
+      address: 'address 1',
+      bytecode: 'bytecode',
+    });
+  });
+
+  test('With absent specific network', async () => {
+    expect(() => truffleTransform(artifact, { network: 3 })).toThrow(Error);
+  });
+});


### PR DESCRIPTION
## Description

Adds unit tests for `colony-js-contract-loader`, along with the package scripts to run them.
