### PR TITLE
Fix flaky tests

### DIFF
--- a/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
+++ b/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
@@ -198,17 +198,16 @@ describe('EthersAdapter', () => {
     sandbox.spyOn(contract, '_dispatchEvent');
     sandbox.spyOn(contract, 'removeListener');
 
-    jest.useRealTimers();
     try {
       await adapter.getEventData({
         events: createEvents(contract, contract),
         transactionHash,
         timeoutMs: 1000,
       });
+      jest.runAllTimers();
     } catch (error) {
       expect(error.message).toMatch('Timeout after 1000 ms');
     }
-    jest.useFakeTimers();
 
     // no events dispatched
     expect(contract._dispatchEvent).toHaveBeenCalledTimes(0);

--- a/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
+++ b/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
@@ -198,6 +198,7 @@ describe('EthersAdapter', () => {
     sandbox.spyOn(contract, '_dispatchEvent');
     sandbox.spyOn(contract, 'removeListener');
 
+    jest.useRealTimers();
     try {
       await adapter.getEventData({
         events: createEvents(contract, contract),
@@ -207,6 +208,7 @@ describe('EthersAdapter', () => {
     } catch (error) {
       expect(error.message).toMatch('Timeout after 1 ms');
     }
+    jest.useFakeTimers();
 
     // no events dispatched
     expect(contract._dispatchEvent).toHaveBeenCalledTimes(0);

--- a/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
+++ b/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
@@ -199,12 +199,13 @@ describe('EthersAdapter', () => {
     sandbox.spyOn(contract, 'removeListener');
 
     try {
-      await adapter.getEventData({
+      const promise = adapter.getEventData({
         events: createEvents(contract, contract),
         transactionHash,
         timeoutMs: 1000,
       });
       jest.runAllTimers();
+      await promise;
     } catch (error) {
       expect(error.message).toMatch('Timeout after 1000 ms');
     }

--- a/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
+++ b/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
@@ -203,10 +203,10 @@ describe('EthersAdapter', () => {
       await adapter.getEventData({
         events: createEvents(contract, contract),
         transactionHash,
-        timeoutMs: 1,
+        timeoutMs: 1000,
       });
     } catch (error) {
-      expect(error.message).toMatch('Timeout after 1 ms');
+      expect(error.message).toMatch('Timeout after 1000 ms');
     }
     jest.useFakeTimers();
 


### PR DESCRIPTION
## Description

Uses a real 1000ms timeout in an `EthersAdapter` test in order to avoid sporadic test failures on CI.
