### PR TITLE
Pad input hex strings (`tokenAddress` param type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Partial empty hex strings (e.g. `0x0`) are now padded to full-length, which resolves an issue with `EthersAdapter` (`@colony/colony-js-contract-client`)
+* The `isEmptyHexString` utility function now evaluates the input type (`@colony/colony-js-utils`)
+
 **Maintenance**
 
 * Add a `DomainAdded` event, which is emitted when calling `ColonyClient.addDomain` (`@colony/colony-js-client`)

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -32,6 +32,28 @@ describe('Parameter types', () => {
     expect(convertInputValue(validAddress, 'address')).toBe(validAddress);
   });
 
+  test('Token addresses are handled properly', () => {
+    const etherShort = '0x0';
+    const etherFull = '0x0000000000000000000000000000000000000000';
+
+    // Validation
+    expect(validateValueType(validAddress, 'tokenAddress')).toBe(true);
+    expect(validateValueType(etherShort, 'tokenAddress')).toBe(true);
+    expect(validateValueType(etherFull, 'tokenAddress')).toBe(true);
+
+    // Converting output values
+    expect(convertOutputValue(validAddress, 'tokenAddress')).toBe(validAddress);
+    expect(convertOutputValue(etherShort, 'tokenAddress')).toBe(etherFull);
+    expect(convertOutputValue(etherFull, 'tokenAddress')).toBe(etherFull);
+
+    expect(convertOutputValue(null, 'tokenAddress')).toBe(null);
+
+    // Converting input values
+    expect(convertInputValue(validAddress, 'tokenAddress')).toBe(validAddress);
+    expect(convertInputValue(etherShort, 'tokenAddress')).toBe(etherFull);
+    expect(convertInputValue(etherFull, 'tokenAddress')).toBe(etherFull);
+  });
+
   test('BigNumbers are handled properly', () => {
     const bn = new BigNumber(1);
 

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -136,10 +136,14 @@ const PARAM_TYPE_MAP: {
       return isValidAddress(value) || isEmptyHexString(value);
     },
     convertInput(value: string) {
-      return value;
+      // Expand `0x0` to a full-length address
+      return value.padEnd(42, '0');
     },
-    convertOutput(value: string) {
-      return value;
+    convertOutput(value: any) {
+      // Expand `0x0` to a full-length address (for a valid address)
+      return isValidAddress(value) || isEmptyHexString(value)
+        ? value.padEnd(42, '0')
+        : null;
     },
   },
 };

--- a/packages/colony-js-utils/src/__tests__/isEmptyHexString.js
+++ b/packages/colony-js-utils/src/__tests__/isEmptyHexString.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+import isEmptyHexString from '../isEmptyHexString';
+
+describe('isEmptyHexString', () => {
+  test('Non string value should be evaluated as false', () => {
+    expect(isEmptyHexString(1234567890)).toBe(false);
+    expect(isEmptyHexString(null)).toBe(false);
+  });
+
+  test('Valid address should be evaluated as false', () => {
+    const validAddress = '0x76d508fa65654654ffdb334a3023353587112e09';
+    expect(isEmptyHexString(validAddress)).toBe(false);
+  });
+
+  test('Empty address should be evaluated as true', () => {
+    const emptyAddressShort = '0x0';
+    const emptyAddressFull = '0x0000000000000000000000000000000000000000';
+    expect(isEmptyHexString(emptyAddressShort)).toBe(true);
+    expect(isEmptyHexString(emptyAddressFull)).toBe(true);
+  });
+});

--- a/packages/colony-js-utils/src/isEmptyHexString.js
+++ b/packages/colony-js-utils/src/isEmptyHexString.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 export default function isEmptyHexString(hex: string) {
+  if (typeof hex !== 'string') return false;
+
   const prefix = hex.slice(0, 2);
   const rest = [...hex.slice(2)];
   return prefix === '0x' && rest.every(char => char === '0');


### PR DESCRIPTION
## Description

Partial empty hex strings (e.g. `0x0`) are now padded to full-length, which resolves an issue with `EthersAdapter`.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* The `isEmptyHexString` utility function now evaluates the input type
* Adds test coverage for `isEmptyHexString`
* Adds test coverage for the `tokenAddress` param type

Resolves #213 
