### PR TITLE
Add `waitForTransactionReceipt` abstraction to adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v.NEXT
 
+**Features**
+
+* `Adapter.getTransactionReceipt` now waits for an in-progress transaction to be mined before attempting to get the receipt (`@colony/colony-js-adapter-ethers`, `@colony/colony-js-client`)
+
 **Bug fixes**
 
 * Partial empty hex strings (e.g. `0x0`) are now padded to full-length, which resolves an issue with `EthersAdapter` (`@colony/colony-js-contract-client`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 * `Adapter.getTransactionReceipt` now waits for an in-progress transaction to be mined before attempting to get the receipt (`@colony/colony-js-adapter-ethers`, `@colony/colony-js-client`)
+* `Adapter.getTransactionReceipt` and `Adapter.waitForTransaction` now accept a timeout argument (default: 5 minutes) (`@colony/colony-js-adapter-ethers`)
 
 **Bug fixes**
 

--- a/packages/colony-js-adapter-ethers/src/EthersAdapter.js
+++ b/packages/colony-js-adapter-ethers/src/EthersAdapter.js
@@ -54,11 +54,12 @@ export default class EthersAdapter implements IAdapter {
     this.wallet = wallet;
   }
   async getContract(query: Query): Promise<IContract> {
-    const { address, abi } = await this.loader.load(query, {
-      abi: true,
-      address: true,
-      bytecode: false,
-    });
+    const { address, abi } =
+      (await this.loader.load(query, {
+        abi: true,
+        address: true,
+        bytecode: false,
+      })) || {};
 
     if (typeof address !== 'string')
       throw new Error('Unable to parse contract address');
@@ -105,11 +106,33 @@ export default class EthersAdapter implements IAdapter {
       });
     }
   }
-  async getTransactionReceipt(transactionHash: string) {
-    return this.provider.getTransactionReceipt(transactionHash);
+  async _getTransactionReceipt(transactionHash: string) {
+    const receipt = await this.provider.getTransactionReceipt(transactionHash);
+    if (receipt == null)
+      throw new Error(
+        `Transaction receipt not found (transaction: ${transactionHash})`,
+      );
+    return receipt;
   }
   async waitForTransaction(transactionHash: string) {
     return this.provider.waitForTransaction(transactionHash);
+  }
+  async getTransactionReceipt(transactionHash: string) {
+    let receipt;
+    try {
+      // Attempt to get the receipt immediately; the transaction may have
+      // already been mined, or we're running on TestRPC with no mining time.
+      receipt = await this._getTransactionReceipt(transactionHash);
+    } catch (error) {
+      // Ignore the error if the receipt wasn't found
+      if (!error.toString().includes('Transaction receipt not found'))
+        throw error;
+    }
+
+    // Wait until the transaction has been mined, then get the receipt.
+    await this.waitForTransaction(transactionHash);
+    receipt = this._getTransactionReceipt(transactionHash);
+    return receipt;
   }
   /**
    * Sign a message hash (as binary) and return a split signature.

--- a/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
+++ b/packages/colony-js-adapter-ethers/src/__tests__/EthersAdapter.test.js
@@ -250,7 +250,7 @@ describe('EthersAdapter', () => {
 
     try {
       mockProvider.getTransactionReceipt.mockResolvedValueOnce(null);
-      await adapter.getTransactionReceipt(transactionHash);
+      await adapter._getTransactionReceipt(transactionHash);
       expect(false).toBe(true); // Should be unreachable
     } catch (error) {
       expect(error.toString()).toMatch('Transaction receipt not found');
@@ -261,7 +261,7 @@ describe('EthersAdapter', () => {
     }
 
     mockProvider.getTransactionReceipt.mockResolvedValueOnce(receipt);
-    const receivedValue = await adapter.getTransactionReceipt(transactionHash);
+    const receivedValue = await adapter._getTransactionReceipt(transactionHash);
     expect(receivedValue).toEqual(receipt);
     expect(mockProvider.getTransactionReceipt).toHaveBeenCalledWith(
       transactionHash,
@@ -308,9 +308,7 @@ describe('EthersAdapter', () => {
 
     mockProvider.waitForTransaction.mockResolvedValue(transaction);
 
-    const receivedValue = await adapter.waitForTransactionReceipt(
-      transactionHash,
-    );
+    const receivedValue = await adapter.getTransactionReceipt(transactionHash);
 
     expect(mockProvider.getTransactionReceipt).toHaveBeenCalledTimes(2);
     expect(mockProvider.getTransactionReceipt).toHaveBeenCalledWith(
@@ -329,7 +327,7 @@ describe('EthersAdapter', () => {
         throw new Error('Kaboom!');
       });
     try {
-      await adapter.waitForTransactionReceipt(transactionHash);
+      await adapter.getTransactionReceipt(transactionHash);
       expect(false).toBe(true); // Should be unreachable
     } catch (error) {
       expect(error.toString()).toMatch('Kaboom!');

--- a/packages/colony-js-adapter-ethers/src/defaults.js
+++ b/packages/colony-js-adapter-ethers/src/defaults.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+// eslint-disable-next-line import/prefer-default-export
+export const DEFAULT_TRANSACTION_WAIT_TIMEOUT = 60 * 5 * 1000; // 5 mins

--- a/packages/colony-js-adapter/interface/Adapter.js
+++ b/packages/colony-js-adapter/interface/Adapter.js
@@ -25,7 +25,13 @@ export interface Adapter {
     timeoutMs: number,
     transactionHash: string,
   }): Promise<any>;
-  waitForTransaction(transactionHash: string): Promise<Transaction>;
-  getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>;
+  waitForTransaction(
+    transactionHash: string,
+    timeoutMs?: number,
+  ): Promise<Transaction>;
+  getTransactionReceipt(
+    transactionHash: string,
+    timeoutMs?: number,
+  ): Promise<TransactionReceipt>;
   signMessage(messageHash: string): Promise<Signature>;
 }

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -242,10 +242,6 @@ export default class ColonyNetworkClient extends ContractClient {
       [utf8ToHex(name), utf8ToHex(symbol), decimals],
     );
     const { hash } = await this.adapter.wallet.sendTransaction(transaction);
-    const receipt = await this.adapter.getTransactionReceipt(hash);
-    if (receipt != null) return receipt.contractAddress;
-
-    await this.adapter.waitForTransaction(hash);
     const { contractAddress } = await this.adapter.getTransactionReceipt(hash);
     return contractAddress;
   }

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -71,7 +71,7 @@ export default class ContractMethodSender<
       transactionHash: transaction.hash,
     });
     const receipt = await raceAgainstTimeout(
-      this._waitForTransactionReceipt(transaction.hash),
+      this.client.adapter.getTransactionReceipt(transaction.hash),
       timeoutMs,
     );
 
@@ -95,7 +95,7 @@ export default class ContractMethodSender<
       transactionHash: transaction.hash,
     });
     const receiptPromise = raceAgainstTimeout(
-      this._waitForTransactionReceipt(transaction.hash),
+      this.client.adapter.getTransactionReceipt(transaction.hash),
       timeoutMs,
     );
     const successfulPromise = new Promise(async (resolve, reject) => {
@@ -141,19 +141,6 @@ export default class ContractMethodSender<
     transactionOptions: TransactionOptions,
   ) {
     return this.client.send(this.functionName, callArgs, transactionOptions);
-  }
-
-  async _waitForTransactionReceipt(transactionHash: string) {
-    // Firstly attempt to get the receipt immediately; the transaction
-    // may be running on TestRPC with no mining time.
-    const receipt = await this.client.adapter.getTransactionReceipt(
-      transactionHash,
-    );
-    if (receipt != null) return receipt;
-
-    // Failing that, wait until the transaction has been mined.
-    await this.client.adapter.waitForTransaction(transactionHash);
-    return this.client.adapter.getTransactionReceipt(transactionHash);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds a method on the adapters: `waitForTransactionReceipt`. This method will wait for an in-progress transaction to be mined (if necessary) before getting the receipt. The new method is now used in the Senders and also during token contract creation.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

* Raises `EthersAdapter` test coverage to 100%
* Fixes a possible object destructuring issue with `Adapter.getContract` found during testing

Resolves #195 
