### PR TITLE
Add event processors for new task change events

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -748,6 +748,16 @@ export default class ColonyClient extends ContractClient {
       ['token', 'tokenAddress'],
       ['amount', 'number'],
     ]);
+    this.addEvent('TaskDeliverableSubmitted', [
+      ['id', 'number'],
+      ['deliverableHash', 'ipfsHash'],
+    ]);
+    this.addEvent('TaskWorkRatingRevealed', [
+      ['id', 'number'],
+      // $FlowFixMe
+      ['role', 'role'],
+      ['rating', 'number'],
+    ]);
     this.addEvent('TaskFinalized', [['id', 'number']]);
     this.addEvent('TaskCanceled', [['id', 'number']]);
 


### PR DESCRIPTION
## Description

We recently introduced the `TaskDeliverableSubmitted` and `TaskWorkRatingRevealed` events on `colonyNetwork` (https://github.com/JoinColony/colonyNetwork/pull/263). This commit adds the respective event processors for these to `ColonyClient`.
