### PR TITLE
Return isGlobalSkill in ColonyNetworkClient.getSkill

### DIFF
--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -248,6 +248,7 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |nParents|number|Number of parent skills|
 |nChildren|number|Number of child skills|
+|isGlobalSkill|boolean|Whether or not the skill is global|
 
 ### `getSkillCount.call()`
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -120,6 +120,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       nParents: number, // Number of parent skills
       nChildren: number, // Number of child skills
+      isGlobalSkill: boolean, // Whether or not the skill is global
     },
     ColonyNetworkClient,
   >;
@@ -332,7 +333,7 @@ export default class ColonyNetworkClient extends ContractClient {
     });
     this.addCaller('getSkill', {
       input: [['skillId', 'number']],
-      output: [['nParents', 'number'], ['nChildren', 'number']],
+      output: [['nParents', 'number'], ['nChildren', 'number'], ['isGlobalSkill', 'boolean']],
       validateEmpty: async ({ skillId }: { skillId: number }) => {
         const { count } = await this.getSkillCount.call();
         if (skillId > count) throw new Error(`Skill ID ${skillId} not found`);


### PR DESCRIPTION
## Description
Support new `isGlobalSkill` boolean flag from `ColonyNetwork.getSkill` (https://github.com/JoinColony/colonyNetwork/issues/249)

Resolves #239 
