### PR TITLE
Added missing curly bracket in createColony sender

### DIFF
--- a/docs/_Docs_ContractClient.md
+++ b/docs/_Docs_ContractClient.md
@@ -94,7 +94,7 @@ await networkClient.createColony.send({
   gasLimit: 400000,
   timeoutMs: 1000 * 60 * 2, // two minutes
   waitForMining: true,
-);
+});
 ```
 
 ### ContractResponse


### PR DESCRIPTION
## Description

There is a missing closing curly bracket in the documentation in SendOptions of createColony method