### PR TITLE
Update ethers to 3.0.27

### DIFF
--- a/packages/colony-js-adapter-ethers/package.json
+++ b/packages/colony-js-adapter-ethers/package.json
@@ -53,7 +53,7 @@
         "@colony/colony-js-contract-loader": "^1.5.4",
         "@colony/colony-js-utils": "^1.5.4",
         "babel-runtime": "^6.26.0",
-        "ethers": "^3.0.17"
+        "ethers": "^3.0.27"
     },
     "devDependencies": {
         "flow-bin": "^0.72.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,9 +2691,9 @@ eth-lib@0.1.27:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
-ethers@^3.0.17:
-  version "3.0.17"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.17.tgz#b24cbca4d5faaf738efcbab00e916f3f49def434"
+ethers@^3.0.27:
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.27.tgz#f9e89bb43a7265a65512d3142c51f26489667f53"
   dependencies:
     aes-js "3.0.0"
     bn.js "^4.4.0"


### PR DESCRIPTION
## Description

Updates ethers to the current stable version. There seem to be no breaking changes for us.

## TODO

- [x] Test with colonyDapp integration tests (locally)
