### PR TITLE
Parse EtherscanLoader result (ABI) as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Parse the result (ABI) of Etherscan responses as JSON, as the Etherscan API has changed (`@colony/colony-js-contract-loader-http`)
+
+
 **New features**
 
 * Add `getReputation` methods to `ColonyClient` and `ColonyNetworkClient` (currently only availble for Rinkeby) (`@colony/colony-js-client`)

--- a/packages/colony-js-contract-loader-http/src/__tests__/index.js
+++ b/packages/colony-js-contract-loader-http/src/__tests__/index.js
@@ -116,17 +116,22 @@ describe('ContractHttpLoader', () => {
     const query = { contractAddress };
     const successfulResponse = {
       status: '1',
-      result: abi,
+      result: JSON.stringify(abi),
     };
     const malformedResponse = 'abc';
     const erroneousResponse = {
       status: '0',
       result: 'Something went wrong',
     };
+    const badJSONResponse = {
+      status: '1',
+      result: '',
+    };
     fetch
       .once(JSON.stringify(successfulResponse))
       .once(JSON.stringify(malformedResponse))
-      .once(JSON.stringify(erroneousResponse));
+      .once(JSON.stringify(erroneousResponse))
+      .once(JSON.stringify(badJSONResponse));
 
     // Successful response
     const contract = await loader.load(query, requiredProps);
@@ -163,6 +168,18 @@ describe('ContractHttpLoader', () => {
       );
       expect(loader._transform).toHaveBeenCalledWith(
         erroneousResponse,
+        query,
+        requiredProps,
+      );
+    }
+
+    // Bad JSON result
+    try {
+      await loader.load(query, requiredProps);
+    } catch (error) {
+      expect(error.toString()).toContain('Error parsing result from Etherscan');
+      expect(loader._transform).toHaveBeenCalledWith(
+        badJSONResponse,
         query,
         requiredProps,
       );

--- a/packages/colony-js-contract-loader-http/src/loaders/EtherscanLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/EtherscanLoader.js
@@ -19,10 +19,17 @@ function etherscanTransform(response: any, query?: Query = {}) {
     throw new Error('Malformed response from Etherscan');
   }
 
-  const { result: abi, status } = response;
+  const { result, status } = response;
 
   if (status !== '1')
     throw new Error(`Erroneous response from Etherscan (status: ${status})`);
+
+  let abi;
+  try {
+    abi = JSON.parse(result);
+  } catch (error) {
+    throw new Error(`Error parsing result from Etherscan: ${error.toString()}`);
+  }
 
   const parsed = {
     abi,


### PR DESCRIPTION
## Description 

Parse the result (ABI) of Etherscan responses as JSON, as the Etherscan API has changed.

Example: https://api.etherscan.io/api?module=contract&action=getabi&address=0xB8c77482e45F1F44dE1745F52C74426C631bDD52
