### PR TITLE
Fix flow errors with ContractClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Maintenance**
+
+* Fixes to Flow types, handling of types (`@colony/colony-js-contract-client`)
 
 ## v1.6.2
 

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -181,11 +181,13 @@ export default class MultisigOperation<
     let foundMode;
     const { adapter } = this.sender.client;
 
-    Object.values(SIGNING_MODES).forEach(mode => {
-      const digest = this._getMessageDigest(mode);
-      const recovered = adapter.ecRecover(digest, signature);
-      if (address.toLowerCase() === recovered.toLowerCase()) foundMode = mode;
-    });
+    Object.keys(SIGNING_MODES)
+      .map(key => SIGNING_MODES[key])
+      .forEach(mode => {
+        const digest = this._getMessageDigest(mode);
+        const recovered = adapter.ecRecover(digest, signature);
+        if (address.toLowerCase() === recovered.toLowerCase()) foundMode = mode;
+      });
 
     if (foundMode !== undefined) return foundMode;
 

--- a/packages/colony-js-contract-client/src/flowtypes/methods.js
+++ b/packages/colony-js-contract-client/src/flowtypes/methods.js
@@ -39,7 +39,7 @@ export type ContractResponse<EventData> = {
 
 export type ContractClientConstructorArgs = {
   adapter: IAdapter,
-  query: Query,
+  query: ?Query,
 };
 
 export type ValidateEmpty = (


### PR DESCRIPTION
## Description

The `ContractClientConstructorArgs` Flow type had `query` as required when it should have been optional.

[`MultisigOperation.js#L184`](https://github.com/JoinColony/colonyJS/blob/master/packages/colony-js-contract-client/src/classes/MultisigOperation.js#L184) was using `Object.values` which uses a mixed type by default, incompatible with number.