### PR TITLE
Parse `SkillAdded` event properly when emitted via `ColonyClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Ensure that the `SkillAdded` event is parsed correctly when logged in transactions from `ColonyClient` (`@colony/colony-js-client` / `@colony/colony-js-contract-client`)
+
+
 ## v1.6.3
 
 **Maintenance**

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -997,6 +997,14 @@ export default class ColonyClient extends ContractClient {
     this.addEvent('TaskFinalized', [['taskId', 'number']]);
     this.addEvent('TaskCanceled', [['taskId', 'number']]);
 
+    // XXX The SkillAdded event (and its underlying interface) is defined on
+    // the network client, but methods like `ColonyClient.addGlobalSkill`
+    // will cause this event to be logged; this workaround copies the event
+    // definition here so that it can be parsed correctly.
+    this.events.SkillAdded = this.networkClient.events.SkillAdded;
+    // eslint-disable-next-line max-len
+    this.contract.interface.events.SkillAdded = this.networkClient.contract.interface.events.SkillAdded;
+
     // Senders
     this.addSender('addDomain', {
       input: [['parentSkillId', 'number']],

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -64,7 +64,7 @@ export default class ContractMethodSender<
       this.client.adapter.getTransactionReceipt(transaction.hash),
       timeoutMs,
     );
-    const eventData = await this.client.getReceiptEventData(receipt);
+    const eventData = this.client.getReceiptEventData(receipt);
 
     return {
       successful: receipt && receipt.status === 1,
@@ -100,7 +100,7 @@ export default class ContractMethodSender<
       try {
         const receipt = await receiptPromise;
         try {
-          resolve(await this.client.getReceiptEventData(receipt));
+          resolve(this.client.getReceiptEventData(receipt));
         } catch (decodeError) {
           reject(decodeError.toString());
         }


### PR DESCRIPTION
## Description

This PR ensures that the `SkillAdded` event is parsed correctly when logged in transactions from `ColonyClient` instances (previously it was only available when emitted via `ColonyNetworkClient`.

Also removes some unnecessary `await` statements.