### PR TITLE
Update docs site configuration description

### DIFF
--- a/docs/doc.config.json
+++ b/docs/doc.config.json
@@ -2,5 +2,5 @@
     "logo": "img/colonyJS_color.svg",
     "logoSmall": "img/colonyJS_color.svg",
     "sectionOrder": ["Docs", "API"],
-    "description": "The colonyJS library is a tool to help developers use Colony to power their projects. colonyJS provides a simple and predictable interface to interact with the Colony Network directly. It fits neatly into your project and works with the rest of your stack."
+    "description": "The colonyJS library is a tool to help developers use Colony to power their projects. colonyJS provides a simple and predictable interface to interact with the Colony Network directly."
 }


### PR DESCRIPTION
## Description

Shortens the doc site description to be more consistent with the other descriptions on the site.

### Before:

<img width="1318" alt="screen shot 2018-10-09 at 4 41 57 pm" src="https://user-images.githubusercontent.com/12519942/46705587-0bc1ce00-cbe5-11e8-90e8-08c3c473cac8.png">

### After:

<img width="1290" alt="screen shot 2018-10-09 at 5 02 11 pm" src="https://user-images.githubusercontent.com/12519942/46705609-1bd9ad80-cbe5-11e8-9d3f-72b432dc22c1.png">
