### PR TITLE
Add ENS functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Export additional flow types: `{ ContractClientConstructorArgs, ContractResponse, MultisigOperationConstructorArgs, SendOptions } (`@colony/colony-js-client` / `@colony/colony-js-contract-client`)
 `
-
+* Add support for [`ColonyNetworkENS`](https://github.com/JoinColony/colonyNetwork/blob/102ec5ec9b36645a2d6893fe6b775c155a226a6f/contracts/ColonyNetworkENS.sol)-based functionality in `ColonyNetworkClient` (`@colony/colony-js-client`)
 
 ## v1.6.3
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -464,7 +464,7 @@ Register the colony's ENS label.
 
 |Argument|Type|Description|
 |---|---|---|
-|colonyName|string|The keccak256 hash of the label to register|
+|colonyName|string|The label to register|
 
 **Returns**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -456,7 +456,7 @@ An instance of a `ContractResponse`
 
 
 
-### `registerColonyLabel.send({ subnode }, options)`
+### `registerColonyLabel.send({ colonyName }, options)`
 
 Register the colony's ENS label.
 
@@ -464,13 +464,17 @@ Register the colony's ENS label.
 
 |Argument|Type|Description|
 |---|---|---|
-|subnode|string|The keccak256 hash of the label to register|
+|colonyName|string|The keccak256 hash of the label to register|
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|colony|Address|Address of the colony that registered a label|
+|label|string|The label registered|
+|ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#events-ColonyLabelRegistered)|
 
 ### `setOwnerRole.send({ user }, options)`
 
@@ -1316,3 +1320,15 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |Argument|Type|Description|
 |---|---|---|
 |payoutId|number|The payout ID logged when a new reward payout cycle has started.|
+
+
+### [events.ColonyLabelRegistered.addListener(({ colony, label }) => { /* ... */ })](#events-ColonyLabelRegistered)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|colony|Address|Address of the colony that registered a label|
+|label|string|The label registered|

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -290,6 +290,78 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |lockingAddress|Address|Token locking contract address|
 
+### `getProfileDBAddress.call({ nameHash })`
+
+Returns the address of a colony when given the hashed ENS username
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|nameHash|Hex string|The hashed human-readable ENS name|
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|orbitDBAddress|Address|Address of the UserProfile DDB|
+
+### `lookupRegisteredENSDomain.call({ ensAddress })`
+
+Given an Ethereum address, returns a user's or colony's human-readable name, or an empty string if the address has no Colony-based ENS name
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|ensAddress|Address|The address we wish to find the corresponding ENS domain for (if any)|
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|domain|string|A string containing the colony-based ENS name corresponding to `ensAddress`|
+
+### `getAddressForENSHash.call({ nameHash })`
+
+Given a hash of the ENS name, returns the Ethereum address registered with it
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|nameHash|Hex string|The hashed human-readable ENS name|
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|ensAddress|Address|The registered ENS username for a colony or a user|
+
+### `ensSupportsInterface.call({ interfaceId })`
+
+Given an ENS interface, returns a boolean indicating whether the interface is supported
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|interfaceId|Hex string|The interface identifier, as specified in ERC-165|
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|isSupported|boolean|Returns `true` if the contract implements `interfaceId`|
+
   
 ## Senders
 
@@ -422,7 +494,7 @@ An instance of a `ContractResponse`
 
 
 
-### `registerUserLabel.send({ subnode }, options)`
+### `registerUserLabel.send({ username, orbitDBPath }, options)`
 
 Register a "user.joincolony.eth" label.
 
@@ -430,13 +502,18 @@ Register a "user.joincolony.eth" label.
 
 |Argument|Type|Description|
 |---|---|---|
-|subnode|string|The keccak256 hash of the label to register|
+|username|string|The label to register|
+|orbitDBPath|string|The path of the OrbitDB database associated with the user profile|
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|user|Address|Address of the user that registered a label|
+|label|string|The label registered|
+|UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#events-UserLabelRegistered)|
 
   
   
@@ -480,3 +557,27 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |auction|string|The address of the auction contract|
 |token|Address|The address of the token being auctioned|
 |quantity|BigNumber|The amount of available tokens for auction|
+
+
+### [events.UserLabelRegistered.addListener(({ user, label }) => { /* ... */ })](#events-UserLabelRegistered)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|Address of the user that registered a label|
+|label|string|The label registered|
+
+
+### [events.ColonyLabelRegistered.addListener(({ colony, label }) => { /* ... */ })](#events-ColonyLabelRegistered)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|colony|Address|Address of the colony that registered a label|
+|label|string|The label registered|

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -91,6 +91,10 @@ type TaskCanceled = ContractClient.Event<{
 type RewardPayoutCycleStarted = ContractClient.Event<{
   payoutId: number, // The payout ID logged when a new reward payout cycle has started.
 }>;
+type ColonyLabelRegistered = ContractClient.Event<{
+  colony: Address, // Address of the colony that registered a label
+  label: string, // The label registered
+}>;
 
 export default class ColonyClient extends ContractClient {
   networkClient: ColonyNetworkClient;
@@ -397,9 +401,9 @@ export default class ColonyClient extends ContractClient {
   */
   registerColonyLabel: ColonyClient.Sender<
     {
-      subnode: string, // The keccak256 hash of the label to register
+      colonyName: string, // The label to register
     },
-    {},
+    { ColonyLabelRegistered: ColonyLabelRegistered },
     ColonyClient,
   >;
   /*
@@ -771,6 +775,7 @@ export default class ColonyClient extends ContractClient {
   >;
 
   events: {
+    ColonyLabelRegistered: ColonyLabelRegistered,
     DomainAdded: DomainAdded,
     PotAdded: PotAdded,
     RewardPayoutCycleStarted: RewardPayoutCycleStarted,
@@ -997,13 +1002,17 @@ export default class ColonyClient extends ContractClient {
     this.addEvent('TaskFinalized', [['taskId', 'number']]);
     this.addEvent('TaskCanceled', [['taskId', 'number']]);
 
-    // XXX The SkillAdded event (and its underlying interface) is defined on
-    // the network client, but methods like `ColonyClient.addGlobalSkill`
-    // will cause this event to be logged; this workaround copies the event
-    // definition here so that it can be parsed correctly.
+    // XXX The SkillAdded/ColonyLabelRegistered events (and their underlying
+    // interfaces) are defined on the network client, but methods like
+    // `ColonyClient.addGlobalSkill` will cause these events to be logged;
+    // this workaround copies the event definition here so that it can be
+    // parsed correctly.
+    /* eslint-disable max-len */
     this.events.SkillAdded = this.networkClient.events.SkillAdded;
-    // eslint-disable-next-line max-len
+    this.events.ColonyLabelRegistered = this.networkClient.events.ColonyLabelRegistered;
     this.contract.interface.events.SkillAdded = this.networkClient.contract.interface.events.SkillAdded;
+    this.contract.interface.events.ColonyLabelRegistered = this.networkClient.contract.interface.events.ColonyLabelRegistered;
+    /* eslint-enable max-len */
 
     // Senders
     this.addSender('addDomain', {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -191,7 +191,7 @@ export default class ColonyNetworkClient extends ContractClient {
       nameHash: HexString, // The hashed human-readable ENS name
     },
     {
-      orbitDBAddress: Address, // Address of the UserProfile DDB
+      orbitDBAddress: string, // Address of the UserProfile DDB
     },
     ColonyNetworkClient,
   >;
@@ -479,7 +479,7 @@ export default class ColonyNetworkClient extends ContractClient {
     });
     this.addCaller('getProfileDBAddress', {
       input: [['nameHash', 'hexString']],
-      output: [['orbitDBAddress', 'address']],
+      output: [['orbitDBAddress', 'string']],
     });
     this.addCaller('lookupRegisteredENSDomain', {
       functionName: 'lookupUsername',

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -184,7 +184,7 @@ export default class ColonyNetworkClient extends ContractClient {
     ColonyNetworkClient,
   >;
   /*
-      Returns the address of a colony when given the hashed ENS username
+      Returns the database address of a user when given the hashed ENS username
     */
   getProfileDBAddress: ColonyNetworkClient.Caller<
     {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -15,6 +15,7 @@ import AuthorityClient from '../AuthorityClient/index';
 const MISSING_ID = 'An ID parameter must be provided';
 
 type Address = string;
+type HexString = string;
 
 type ColonyAdded = ContractClient.Event<{
   colonyId: number, // ID of the newly-created Colony
@@ -29,12 +30,22 @@ type AuctionCreated = ContractClient.Event<{
   token: Address, // The address of the token being auctioned
   quantity: BigNumber, // The amount of available tokens for auction
 }>;
+type UserLabelRegistered = ContractClient.Event<{
+  user: Address, // Address of the user that registered a label
+  label: string, // The label registered
+}>;
+type ColonyLabelRegistered = ContractClient.Event<{
+  colony: Address, // Address of the colony that registered a label
+  label: string, // The label registered
+}>;
 
 export default class ColonyNetworkClient extends ContractClient {
   events: {
     ColonyAdded: ColonyAdded,
     SkillAdded: SkillAdded,
     AuctionCreated: AuctionCreated,
+    ColonyLabelRegistered: ColonyLabelRegistered,
+    UserLabelRegistered: UserLabelRegistered,
   };
   /*
   Returns the address of a colony when given the ID
@@ -173,6 +184,54 @@ export default class ColonyNetworkClient extends ContractClient {
     ColonyNetworkClient,
   >;
   /*
+      Returns the address of a colony when given the hashed ENS username
+    */
+  getProfileDBAddress: ColonyNetworkClient.Caller<
+    {
+      nameHash: HexString, // The hashed human-readable ENS name
+    },
+    {
+      orbitDBAddress: Address, // Address of the UserProfile DDB
+    },
+    ColonyNetworkClient,
+  >;
+  /*
+      Given an Ethereum address, returns a user's or colony's human-readable name, or an empty string if the address has no Colony-based ENS name
+    */
+  lookupRegisteredENSDomain: ColonyNetworkClient.Caller<
+    {
+      ensAddress: Address, // The address we wish to find the corresponding ENS domain for (if any)
+    },
+    {
+      domain: string, // A string containing the colony-based ENS name corresponding to `ensAddress`
+    },
+    ColonyNetworkClient,
+  >;
+  /*
+      Given a hash of the ENS name, returns the Ethereum address registered with it
+    */
+  getAddressForENSHash: ColonyNetworkClient.Caller<
+    {
+      nameHash: HexString, // The hashed human-readable ENS name
+    },
+    {
+      ensAddress: Address, // The registered ENS username for a colony or a user
+    },
+    ColonyNetworkClient,
+  >;
+  /*
+      Given an ENS interface, returns a boolean indicating whether the interface is supported
+    */
+  ensSupportsInterface: ColonyNetworkClient.Caller<
+    {
+      interfaceId: HexString, // The interface identifier, as specified in ERC-165
+    },
+    {
+      isSupported: boolean, // Returns `true` if the contract implements `interfaceId`
+    },
+    ColonyNetworkClient,
+  >;
+  /*
   Adds a new skill to the global or local skills tree.
   */
   addSkill: ColonyNetworkClient.Sender<
@@ -250,9 +309,10 @@ export default class ColonyNetworkClient extends ContractClient {
   */
   registerUserLabel: ColonyNetworkClient.Sender<
     {
-      subnode: string, // The keccak256 hash of the label to register
+      username: string, // The label to register
+      orbitDBPath: string, // The path of the OrbitDB database associated with the user profile
     },
-    {},
+    { UserLabelRegistered: UserLabelRegistered },
     ColonyNetworkClient,
   >;
 
@@ -355,6 +415,14 @@ export default class ColonyNetworkClient extends ContractClient {
       ['token', 'tokenAddress'],
       ['quantity', 'bigNumber'],
     ]);
+    this.addEvent('UserLabelRegistered', [
+      ['user', 'address'],
+      ['label', 'string'],
+    ]);
+    this.addEvent('ColonyLabelRegistered', [
+      ['colony', 'address'],
+      ['label', 'string'],
+    ]);
 
     // Callers
     this.addCaller('getColony', {
@@ -409,6 +477,25 @@ export default class ColonyNetworkClient extends ContractClient {
     this.addCaller('getTokenLocking', {
       output: [['lockingAddress', 'address']],
     });
+    this.addCaller('getProfileDBAddress', {
+      input: [['nameHash', 'hexString']],
+      output: [['orbitDBAddress', 'address']],
+    });
+    this.addCaller('lookupRegisteredENSDomain', {
+      functionName: 'lookupUsername',
+      input: [['ensAddress', 'address']],
+      output: [['domain', 'string']],
+    });
+    this.addCaller('ensSupportsInterface', {
+      functionName: 'supportsInterface',
+      input: [['interfaceId', 'hexString']],
+      output: [['isSupported', 'boolean']],
+    });
+    this.addCaller('getAddressForENSHash', {
+      functionName: 'addr',
+      input: [['nameHash', 'hexString']],
+      output: [['ensAddress', 'address']],
+    });
 
     // Senders
     this.addSender('addSkill', {
@@ -435,7 +522,7 @@ export default class ColonyNetworkClient extends ContractClient {
       input: [['ens', 'address'], ['rootNode', 'string']],
     });
     this.addSender('registerUserLabel', {
-      input: [['subnode', 'string']],
+      input: [['username', 'string'], ['orbitDBPath', 'string']],
     });
   }
 


### PR DESCRIPTION
## Description

This PR updates the network and colony clients so that they support recent changes to ENS-related functionality in the contracts.

Events:

* `ColonyLabelRegistered` added
* `UserLabelRegistered` added

Callers: 

* `ColonyClient.registerColonyLabel` now takes a `colonyName` parameter
* New: `ColonyNetworkClient.getProfileDBAddress`
* New: `ColonyNetworkClient.lookupRegisteredENSDomain`
* New: `ColonyNetworkClient.getAddressForENSHash`
* New: `ColonyNetworkClient.ensSupportsInterface`

Senders:

* `ColonyNetworkClient.registerUserLabel` now takes `{ username, orbitDBPath }` parameters and emits a `UserLabelRegistered` event.

These all take or return `hexString`, `string`, `boolean`, or `address`, and so this PR defines no new types.

Closes #277.