### PR TITLE
Supply options for `createToken` (make it a `Sender`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Breaking changes**
+
+* The `createToken` method now works as a regular `Sender`, i.e. `networkClient.createToken({ name, symbol })` is now `networkClient.createToken.send({ name, symbol }, options)`.
 
 ## v1.6.4
 

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -27,22 +27,6 @@ await networkClient.init();
 
 **All instance methods return promises.**
 
-### `createToken({ name, symbol, decimals })`
-
-Deploys a new ERC20 compatible token contract for you to use with your Colony. You can also use your own token when creating a Colony.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|name|string|Name of the token to create (e.g. Cool Colony Token)|
-|symbol|string|Symbol of the token to create (e.g. CCT)|
-|decimals|string|Decimals of your token (default: 18).|
-
-**Returns**
-
-`Promise<Address>` The address of the newly deployed token contract
-
 ### `getColonyClientByAddress(contractAddress)`
 
 Returns an initialized ColonyClient for the contract at address `contractAddress`
@@ -366,6 +350,24 @@ A promise which resolves to an object containing the following properties:
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
+### `createToken.send({ name, symbol, decimals }, options)`
+
+Deploys a new ERC20 compatible token contract for you to use with your Colony. You can also use your own token when creating a Colony.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|name|string|Name of the token to create|
+|symbol|string|Symbol of the token (e.g. CLNY)|
+|decimals|number|Decimals to use for your token|
+
+**Returns**
+
+An instance of a `ContractResponse` which will receive a receipt with a `contractAddress` property (the address of the newly-deployed contract)
+
+
+
 ### `addSkill.send({ parentSkillId, globalSkill }, options)`
 
 Adds a new skill to the global or local skills tree.

--- a/docs/_Docs_GetStarted.md
+++ b/docs/_Docs_GetStarted.md
@@ -157,18 +157,18 @@ const example = async () => {
 
   // Let's deploy a new ERC20 token for our Colony.
   // You could also skip this step and use a pre-existing/deployed contract.
-  const tokenAddress = await networkClient.createToken({
+  const { meta: { receipt: { contractAddress } } } = await networkClient.createToken.send({
     name: 'Cool Colony Token',
     symbol: 'COLNY',
   });
 
   // Congrats, you've created a Token!
-  console.log('Token address: ' + tokenAddress);
+  console.log('Token address: ' + contractAddress);
 
   // Create a cool Colony!
   const {
     eventData: { colonyId, colonyAddress },
-  } = await networkClient.createColony.send({ tokenAddress });
+  } = await networkClient.createColony.send({ tokenAddress: contractAddress });
 
   // Congrats, you've created a Colony!
   console.log('Colony ID: ' + colonyId);

--- a/packages/colony-js-adapter/interface/Provider.js
+++ b/packages/colony-js-adapter/interface/Provider.js
@@ -9,6 +9,7 @@ import type { TransactionReceipt } from './TransactionReceipt';
 export interface Provider {
   name: string;
   chainId: string;
+  estimateGas(transaction: Transaction): Promise<number>;
   getAddress(): string | Promise<string>;
   getBalance(addressOrName: string, blockTag?: string): Promise<BigNumber>;
   getBlock(blockHashOrBlockNumber: string | number): Promise<Block>;

--- a/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
@@ -27,22 +27,6 @@ await networkClient.init();
 
 **All instance methods return promises.**
 
-### `createToken({ name, symbol, decimals })`
-
-Deploys a new ERC20 compatible token contract for you to use with your Colony. You can also use your own token when creating a Colony.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|name|string|Name of the token to create (e.g. Cool Colony Token)|
-|symbol|string|Symbol of the token to create (e.g. CCT)|
-|decimals|string|Decimals of your token (default: 18).|
-
-**Returns**
-
-`Promise<Address>` The address of the newly deployed token contract
-
 ### `getColonyClientByAddress(contractAddress)`
 
 Returns an initialized ColonyClient for the contract at address `contractAddress`

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -154,7 +154,16 @@ ${sender.args && sender.args.length ? '\n**Arguments**\n\n' : ''}${printProps('A
 
 **Returns**
 
-An instance of a \`ContractResponse\`${sender.events && sender.events.length ? ' which will eventually receive the following event data:' : ''}
+An instance of a \`ContractResponse\`${
+  // XXX If this gets even more complicated, find another way!
+  sender.name === 'createToken'
+    ? ' which will receive a receipt with a \`contractAddress\` property (the address of the newly-deployed contract)'
+    : (
+        sender.events && sender.events.length
+          ? ' which will eventually receive the following event data:'
+          : ''
+      )
+}
 
 ${printProps('Event data', getEventProps(events, sender.events))}
 `,

--- a/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import ContractClient from '@colony/colony-js-contract-client';
+
+export default class CreateToken<
+  InputValues: *,
+  OutputValues: *,
+  Client: *,
+> extends ContractClient.Sender<InputValues, OutputValues, Client> {
+  constructor({
+    name = 'createToken',
+    defaultValues = { decimals: 18 },
+    input = [['name', 'string'], ['symbol', 'string'], ['decimals', 'number']],
+    ...props
+  }: *) {
+    super({ name, defaultValues, input, ...props });
+  }
+
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const transaction = await this._getContractDeployTransaction(args);
+    return this.client.adapter.provider.estimateGas(transaction);
+  }
+
+  async _sendTransaction(args: *, options: *) {
+    const transaction = await this._getContractDeployTransaction(args);
+    return this.client.adapter.wallet.sendTransaction(transaction, options);
+  }
+
+  async _getContractDeployTransaction(args: *) {
+    return this.client.adapter.getContractDeployTransaction(
+      { contractName: 'Token' },
+      args,
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR makes the `createToken` method work as a regular `Sender`.

Before:

```js
const address = await networkClient.createToken({ name, symbol });
```

After:

```js
const { meta: { receipt: { contractAddress } } } = await networkClient.createToken.send(
  {
    name,
    symbol,
  },
  options,
);
```

This means that we can supply options for the transaction that we send and also estimate it. Hopefully it makes things a little more predictable (at the expense of a more complicated first step).
