### PR TITLE
Fix `getTaskRole` return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * The `createToken` method now works as a regular `Sender`, i.e. `networkClient.createToken({ name, symbol })` is now `networkClient.createToken.send({ name, symbol }, options)`.
 
+**Bug fixes**
+
+* The return value of `ColonyClient.getTaskRole` has been changed from `rated` to `rateFail`, properly reflecting the contract.
+
 ## v1.6.4
 
 **Bug fixes**

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -255,7 +255,7 @@ export default class ColonyClient extends ContractClient {
     },
     {
       address: Address, // Address of the user for the given role.
-      rated: boolean, // Has the user work been rated.
+      rateFail: boolean, // Whether the user failed to rate their counterpart.
       rating: number, // Rating the user received (1-3).
     },
     ColonyClient,
@@ -881,7 +881,7 @@ export default class ColonyClient extends ContractClient {
     makeTaskCaller(
       'getTaskRole',
       [['role', 'role']],
-      [['address', 'address'], ['rated', 'boolean'], ['rating', 'number']],
+      [['address', 'address'], ['rateFail', 'boolean'], ['rating', 'number']],
     );
     makeTaskCaller(
       'getTaskWorkRatings',


### PR DESCRIPTION
## Description 

This PR changes one of the return values of `ColonyClient.getTaskRole` to reflect the contracts – `rated` is renamed to `rateFail`.

Resolves #264 