### PR TITLE
Add missing `from` to `Transfer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug fixes**
 
 * The return value of `ColonyClient.getTaskRole` has been changed from `rated` to `rateFail`, properly reflecting the contract.
+* The parameters of the `Transfer` event in `TokenClient` now reflect the contract properly.
 
 ## v1.6.4
 

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -7,6 +7,7 @@ import GetTokenInfo from './callers/GetTokenInfo';
 type Address = string;
 
 type Transfer = ContractClient.Event<{
+  from: Address, // Event data indicating the 'from' address.
   to: Address, // Event data indicating the 'to' address.
   value: BigNumber, // Event data indicating the amount transferred.
 }>;
@@ -174,7 +175,11 @@ export default class TokenClient extends ContractClient {
     const destinationAddress = ['destinationAddress', 'address'];
     const user = ['user', 'address'];
 
-    this.addEvent('Transfer', [['to', 'address'], ['value', 'bigNumber']]);
+    this.addEvent('Transfer', [
+      ['from', 'address'],
+      ['to', 'address'],
+      ['value', 'bigNumber'],
+    ]);
     this.addEvent('Approval', [
       ['owner', 'address'],
       ['spender', 'address'],


### PR DESCRIPTION
## Description

This PR adds the missing `from` parameter (named `src` in the [ERC20 standard](https://github.com/dapphub/erc20/blob/master/src/erc20.sol#L13)\) to the `Transfer` event on `TokenClient`.

Resolves #282 
