### PR TITLE
Handle events not on interface (incl. `Transfer`, `Mint`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * The return value of `ColonyClient.getTaskRole` has been changed from `rated` to `rateFail`, properly reflecting the contract.
 * The parameters of the `Transfer` event in `TokenClient` now reflect the contract properly.
+* Added support for `Mint` and `Transfer` events in `ColonyClient`.
 
 ## v1.6.4
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -253,7 +253,7 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |address|Address|Address of the user for the given role.|
-|rated|boolean|Has the user work been rated.|
+|rateFail|boolean|Whether the user failed to rate their counterpart.|
 |rating|number|Rating the user received (1-3).|
 
 ### `getTaskWorkRatings.call({ taskId })`
@@ -759,9 +759,13 @@ Claims the payout for `token` denomination for work completed in task `taskId` b
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|to|Address|Event data indicating the 'to' address.|
+|value|BigNumber|Event data indicating the amount transferred.|
+|Transfer|object|Contains the data defined in [Transfer](#events-Transfer)|
 
 ### `addDomain.send({ parentSkillId }, options)`
 
@@ -866,9 +870,13 @@ The owner of a Colony may mint new tokens.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|address|Address|The address that initiated the mint event.|
+|amount|BigNumber|Event data indicating the amount of tokens minted.|
+|Mint|object|Contains the data defined in [Mint](#events-Mint)|
 
 ### `mintTokensForColonyNetwork.send({ amount }, options)`
 
@@ -882,9 +890,13 @@ In the case of the Colony Network, only the Meta Colony may mint new tokens.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|address|Address|The address that initiated the mint event.|
+|amount|BigNumber|Event data indicating the amount of tokens minted.|
+|Mint|object|Contains the data defined in [Mint](#events-Mint)|
 
 ### `startNextRewardPayout.send({ token }, options)`
 
@@ -1332,3 +1344,27 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |---|---|---|
 |colony|Address|Address of the colony that registered a label|
 |label|string|The label registered|
+
+
+### [events.Transfer.addListener(({ to, value }) => { /* ... */ })](#events-Transfer)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|to|Address|Event data indicating the 'to' address.|
+|value|BigNumber|Event data indicating the amount transferred.|
+
+
+### [events.Mint.addListener(({ address, amount }) => { /* ... */ })](#events-Mint)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|address|Address|The address that initiated the mint event.|
+|amount|BigNumber|Event data indicating the amount of tokens minted.|

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -95,6 +95,14 @@ type ColonyLabelRegistered = ContractClient.Event<{
   colony: Address, // Address of the colony that registered a label
   label: string, // The label registered
 }>;
+type Transfer = ContractClient.Event<{
+  to: Address, // Event data indicating the 'to' address.
+  value: BigNumber, // Event data indicating the amount transferred.
+}>;
+type Mint = ContractClient.Event<{
+  address: Address, // The address that initiated the mint event.
+  amount: BigNumber, // Event data indicating the amount of tokens minted.
+}>;
 
 export default class ColonyClient extends ContractClient {
   networkClient: ColonyNetworkClient;
@@ -645,7 +653,7 @@ export default class ColonyClient extends ContractClient {
       role: Role, // Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER
       token: TokenAddress, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
     },
-    {},
+    { Transfer: Transfer },
     ColonyClient,
   >;
   /*
@@ -708,7 +716,7 @@ export default class ColonyClient extends ContractClient {
     {
       amount: BigNumber, // Amount of new tokens to be minted.
     },
-    {},
+    { Mint: Mint },
     ColonyClient,
   >;
   /*
@@ -718,7 +726,7 @@ export default class ColonyClient extends ContractClient {
     {
       amount: BigNumber, // Amount of new tokens to be minted.
     },
-    {},
+    { Mint: Mint },
     ColonyClient,
   >;
   /*
@@ -777,6 +785,7 @@ export default class ColonyClient extends ContractClient {
   events: {
     ColonyLabelRegistered: ColonyLabelRegistered,
     DomainAdded: DomainAdded,
+    Mint: Mint,
     PotAdded: PotAdded,
     RewardPayoutCycleStarted: RewardPayoutCycleStarted,
     SkillAdded: SkillAdded,
@@ -792,6 +801,7 @@ export default class ColonyClient extends ContractClient {
     TaskSkillChanged: TaskSkillChanged,
     TaskWorkerPayoutChanged: TaskWorkerPayoutChanged,
     TaskWorkRatingRevealed: TaskWorkRatingRevealed,
+    Transfer: Transfer,
   };
 
   static get defaultQuery() {
@@ -1007,11 +1017,15 @@ export default class ColonyClient extends ContractClient {
     // `ColonyClient.addGlobalSkill` will cause these events to be logged;
     // this workaround copies the event definition here so that it can be
     // parsed correctly.
+    // Similarly, the `Transfer` and `Mint` events from the token contract also
+    // need to be defined here, since they are emitted from various methods.
     /* eslint-disable max-len */
     this.events.SkillAdded = this.networkClient.events.SkillAdded;
     this.events.ColonyLabelRegistered = this.networkClient.events.ColonyLabelRegistered;
     this.contract.interface.events.SkillAdded = this.networkClient.contract.interface.events.SkillAdded;
     this.contract.interface.events.ColonyLabelRegistered = this.networkClient.contract.interface.events.ColonyLabelRegistered;
+    this.contract.interface.events.Transfer = this.token.contract.interface.events.Transfer;
+    this.contract.interface.events.Mint = this.token.contract.interface.events.Mint;
     /* eslint-enable max-len */
 
     // Senders

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -96,6 +96,7 @@ type ColonyLabelRegistered = ContractClient.Event<{
   label: string, // The label registered
 }>;
 type Transfer = ContractClient.Event<{
+  from: Address, // Event data indicating the 'from' address.
   to: Address, // Event data indicating the 'to' address.
   value: BigNumber, // Event data indicating the amount transferred.
 }>;
@@ -1022,6 +1023,8 @@ export default class ColonyClient extends ContractClient {
     /* eslint-disable max-len */
     this.events.SkillAdded = this.networkClient.events.SkillAdded;
     this.events.ColonyLabelRegistered = this.networkClient.events.ColonyLabelRegistered;
+    this.events.Transfer = this.token.events.Transfer;
+    this.events.Mint = this.token.events.Mint;
     this.contract.interface.events.SkillAdded = this.networkClient.contract.interface.events.SkillAdded;
     this.contract.interface.events.ColonyLabelRegistered = this.networkClient.contract.interface.events.ColonyLabelRegistered;
     this.contract.interface.events.Transfer = this.token.contract.interface.events.Transfer;

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -128,10 +128,13 @@ export default class ContractClient {
       logs
         // Find matching event info by the topic
         .map(log => {
-          const eventName = eventNames.find(name =>
-            // The first topic should be the hashed event signature
-            log.topics.includes(events[name].topics[0]),
-          );
+          const eventName = eventNames
+            // Filter out events not supported by the interface (e.g. from BYOT)
+            .filter(name => !!events[name])
+            .find(name =>
+              // The first topic should be the hashed event signature
+              log.topics.includes(events[name].topics[0]),
+            );
           return eventName ? { ...log, eventInfo: events[eventName] } : null;
         })
         // Filter out logs we couldn't find on the interface as events


### PR DESCRIPTION
## Description

This PR adds support for some events that are emitted from transactions on `ColonyClient` but originate from another contract (`Token.sol`). The approach taken is to simply copy over the defined event interface from the `token` (`TokenClient`) property of the `ColonyClient` to itself, as was done previously for events originating on the network contract. Though not ideal, I think this is a more reasonable approach than changing `IColony.sol` (I'm not convinced that a file like this should have a copy of all event definitions from contracts it calls methods on).

## Other changes

* Handles an edge case where an event exists in the logs but is not available on the contract interface; this could happen with e.g. BYOT (Bring Your Own Token), where additional events are defined. The missing events are ignored (but are still available in a raw format in the receipt logs).

Resolves #288 
