### PR TITLE
Fix `ColonyNetworkClient.lookupRegisteredENSDomain` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Fix the function called by `ColonyNetworkClient.lookupRegisteredENSDomain` (`@colony/colony-js-client`)
 
 ## v1.7.1
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -472,7 +472,6 @@ export default class ColonyNetworkClient extends ContractClient {
       output: [['orbitDBAddress', 'string']],
     });
     this.addCaller('lookupRegisteredENSDomain', {
-      functionName: 'lookupUsername',
       input: [['ensAddress', 'address']],
       output: [['domain', 'string']],
     });


### PR DESCRIPTION
## Description

Fix the function called by `ColonyNetworkClient.lookupRegisteredENSDomain`.
