### PR TITLE
Misc. `registerUserLabel` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 **Bug fixes**
 
+* Set a default gas limit for `ColonyNetworkClient.registerUserLabel` (`@colony/colony-js-client`)
+* Make the `SendOptions` flow type properties all optional (e.g. `gasLimit`) (`@colony/colony-js-client`, `@colony/colony-js-contract-client`)
+* Do not convert basic string inputs to hex (`@colony/colony-js-client`)
+
+## v1.7.2
+
+**Bug fixes**
+
 * Fix the function called by `ColonyNetworkClient.lookupRegisteredENSDomain` (`@colony/colony-js-client`)
 
 ## v1.7.1

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -513,6 +513,7 @@ export default class ColonyNetworkClient extends ContractClient {
     });
     this.addSender('registerUserLabel', {
       input: [['username', 'string'], ['orbitDBPath', 'string']],
+      defaultGasLimit: 260000,
     });
   }
 

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -158,7 +158,7 @@ describe('Parameter types', () => {
     // Converting input values
     expect(convertInputValue(validAddress, 'string')).toBe(validAddress);
     expect(convertInputValue('not a hex value', 'string')).toBe(
-      '0x6e6f742061206865782076616c7565',
+      'not a hex value',
     );
   });
 

--- a/packages/colony-js-contract-client/src/flowtypes/methods.js
+++ b/packages/colony-js-contract-client/src/flowtypes/methods.js
@@ -18,9 +18,9 @@ export type DefaultValues = {
 };
 
 export type SendOptions = {
-  estimate: boolean,
-  timeoutMs: number,
-  waitForMining: boolean,
+  estimate?: boolean,
+  timeoutMs?: number,
+  waitForMining?: boolean,
 } & TransactionOptions;
 
 export type ContractResponseMeta = {

--- a/packages/colony-js-contract-client/src/mocks/mockValues.js
+++ b/packages/colony-js-contract-client/src/mocks/mockValues.js
@@ -15,7 +15,7 @@ export const inputValues = {
 
 export const parsedInputValues = [
   1,
-  '0x666f6f',
+  'foo',
   2,
   '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
   true,
@@ -25,7 +25,7 @@ export const parsedInputValues = [
 
 export const outputValues = {
   a: 1,
-  b: 'foo',
+  b: '0x666f6f',
   c: 2,
   d: '0xc1912fee45d61c87cc5ea59dae31190fffff232d',
   e: true,

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -2,14 +2,7 @@
 
 import bs58 from 'bs58';
 import BigNumber from 'bn.js';
-import {
-  isHex,
-  isHexStrict,
-  utf8ToHex,
-  hexToBytes,
-  hexToUtf8,
-  toHex,
-} from 'web3-utils';
+import { isHexStrict, hexToBytes, hexToUtf8, toHex } from 'web3-utils';
 import {
   isValidAddress,
   isBigNumber,
@@ -102,10 +95,7 @@ const PARAM_TYPE_MAP: {
       }
       return typeof value === 'string' && value.length ? value : null;
     },
-    convertInput(value: string) {
-      // String values are converted to hex (if they aren't hex already)
-      return isHex(value) ? value : utf8ToHex(value);
-    },
+    convertInput: passThrough,
   },
   ipfsHash: {
     validate(value: any) {


### PR DESCRIPTION
## Description

Fixes some issues found during testing:

* Set a default gas limit for `ColonyNetworkClient.registerUserLabel` (`@colony/colony-js-client`)
* Make the `SendOptions` flow type properties all optional (e.g. `gasLimit`) (`@colony/colony-js-client`, `@colony/colony-js-contract-client`)
* Do not convert basic string inputs to hex (`@colony/colony-js-client`)
