### PR TITLE
Fix `registerColonyLabel` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Add `colonyName` and `orbitDBPath` parameters to `ColonyClient.registerColonyLabel` (`@colony/colony-js-client`)
 
 ## v1.7.3
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -411,6 +411,7 @@ export default class ColonyClient extends ContractClient {
   registerColonyLabel: ColonyClient.Sender<
     {
       colonyName: string, // The label to register
+      orbitDBPath: string, // The path of the orbitDB database associated with the colony name
     },
     { ColonyLabelRegistered: ColonyLabelRegistered },
     ColonyClient,
@@ -1184,7 +1185,7 @@ export default class ColonyClient extends ContractClient {
       input: [['taskId', 'number'], ['role', 'role'], ['secret', 'hexString']],
     });
     this.addSender('registerColonyLabel', {
-      input: [['subnode', 'string']],
+      input: [['colonyName', 'string'], ['orbitDBPath', 'string']],
     });
     this.addSender('exitRecoveryMode', {
       input: [[]],


### PR DESCRIPTION
## Description

Adds `colonyName` and `orbitDBPath` parameters to `ColonyClient.registerColonyLabel`  (renaming `subnode`).

