### PR TITLE
Update `contractName` to `ColonyAuthority`

### DIFF
--- a/packages/colony-js-client/src/AuthorityClient/index.js
+++ b/packages/colony-js-client/src/AuthorityClient/index.js
@@ -47,7 +47,7 @@ export default class AuthorityClient extends ContractClient {
 
   static get defaultQuery() {
     return {
-      contractName: 'Authority',
+      contractName: 'ColonyAuthority',
     };
   }
 


### PR DESCRIPTION
## Description

Changes `contractName` from `Authority` to `ColonyAuthority` in `AuthorityClient`.

## Resolves

```
Invalid contract definition: abi is missing or invalid
```
