### PR TITLE
Add MetaColonyClient and update ColonyClient

### DIFF
--- a/docs/_API_AuthorityClient.md
+++ b/docs/_API_AuthorityClient.md
@@ -1,7 +1,7 @@
 ---
 title: AuthorityClient
 section: API
-order: 4
+order: 7
 ---
 
 The `AuthorityClient` is a standard interface for interactions with functions and events described in `Authority.sol`.

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -789,26 +789,6 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |parentSkillId|number|The parent skill id.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#events-SkillAdded)|
 
-### `addGlobalSkill.send({ parentSkillId }, options)`
-
-Adds a global skill under a given parent SkillId. This can only be called from the Meta Colony, and only by the Meta Colony owners.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|parentSkillId|number|Integer id of the parent skill.|
-
-**Returns**
-
-An instance of a `ContractResponse` which will eventually receive the following event data:
-
-|Event data|Type|Description|
-|---|---|---|
-|skillId|number|A skillId for this domain.|
-|parentSkillId|number|The parent skill id.|
-|SkillAdded|object|Contains the data defined in [SkillAdded](#events-SkillAdded)|
-
 ### `claimColonyFunds.send({ token }, options)`
 
 Move any funds received by the colony for `token` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
@@ -863,26 +843,6 @@ An instance of a `ContractResponse`
 ### `mintTokens.send({ amount }, options)`
 
 The owner of a Colony may mint new tokens.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|amount|BigNumber|Amount of new tokens to be minted.|
-
-**Returns**
-
-An instance of a `ContractResponse` which will eventually receive the following event data:
-
-|Event data|Type|Description|
-|---|---|---|
-|address|Address|The address that initiated the mint event.|
-|amount|BigNumber|Event data indicating the amount of tokens minted.|
-|Mint|object|Contains the data defined in [Mint](#events-Mint)|
-
-### `mintTokensForColonyNetwork.send({ amount }, options)`
-
-In the case of the Colony Network, only the Meta Colony may mint new tokens.
 
 **Arguments**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -22,6 +22,10 @@ const colonyClient = await networkClient.getColonyClient(colonyId); // This is a
 
 ## Instance properties
 
+### `networkClient`
+
+The Colony's [ColonyNetworkClient](/colonyjs/api-colonynetworkclient/) instance.
+
 ### `authority`
 
 The Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -1,0 +1,156 @@
+---
+title: MetaColonyClient
+section: API
+order: 5
+---
+
+The `MetaColonyClient` class is a standard interface for interactions with the on-chain functions and events described in `IMetaColony.sol`.
+
+These interactions are generally concerned with functions and events internal to the Meta Colony, such as adding global skills.
+
+For functions and events that concern the colonyNetwork as a whole, refer to the [ColonyNetworkClient API](/colonyjs/api-colonynetworkclient/)
+
+==TOC==
+
+## Creating a new instance
+
+You _could_ create a MetaColonyClient by using an adapter and a query: `new MetaColonyClient({ adapter, query })` and then `.init()` it but it is advised to ask the network client for a new instance:
+
+```javascript
+const metaColonyClient = await networkClient.getMetaColonyClient(colonyId); // This is already initialised
+```
+
+## Instance properties
+
+### `networkClient`
+
+The Meta Colony's [ColonyNetworkClient](/colonyjs/api-colonynetworkclient/) instance.
+
+### `authority`
+
+The Meta Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.
+
+### `token`
+
+The Meta Colony's [TokenClient](/colonyjs/api-tokenclient/) instance.
+
+  
+## Callers
+
+**All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
+
+### `getAuthority.call()`
+
+Gets the colony's Authority contract address
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|address|Address|The colony's Authority contract address|
+
+### `getToken.call()`
+
+Gets the address of the colony's official token contract.
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|address|Address|The address of the colony's official deployed token contract|
+
+  
+## Senders
+
+**All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
+### `addGlobalSkill.send({ parentSkillId }, options)`
+
+Adds a global skill under a given parent SkillId. This can only be called from the Meta Colony, and only by the Meta Colony owners.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|parentSkillId|number|Integer id of the parent skill.|
+
+**Returns**
+
+An instance of a `ContractResponse` which will eventually receive the following event data:
+
+|Event data|Type|Description|
+|---|---|---|
+|skillId|number|A skillId for this domain.|
+|parentSkillId|number|The parent skill id.|
+|SkillAdded|object|Contains the data defined in [SkillAdded](#events-SkillAdded)|
+
+### `mintTokensForColonyNetwork.send({ amount }, options)`
+
+In the case of the Colony Network, only the Meta Colony may mint new tokens.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|amount|BigNumber|Amount of new tokens to be minted.|
+
+**Returns**
+
+An instance of a `ContractResponse` which will eventually receive the following event data:
+
+|Event data|Type|Description|
+|---|---|---|
+|address|Address|The address that initiated the mint event.|
+|amount|BigNumber|Event data indicating the amount of tokens minted.|
+|Mint|object|Contains the data defined in [Mint](#events-Mint)|
+
+### `setNetworkFeeInverse.send({ feeInverse }, options)`
+
+Set the Colony Network fee inverse amount. This can only be called from the Meta Colony, and only by the Meta Colony owners.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|feeInverse|number|Integer id of the parent skill.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+  
+  
+## Events
+
+Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events) to interact with these events.
+
+
+### [events.SkillAdded.addListener(({ skillId, parentSkillId }) => { /* ... */ })](#events-SkillAdded)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|skillId|number|A skillId for this domain.|
+|parentSkillId|number|The parent skill id.|
+
+
+### [events.Mint.addListener(({ address, amount }) => { /* ... */ })](#events-Mint)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|address|Address|The address that initiated the mint event.|
+|amount|BigNumber|Event data indicating the amount of tokens minted.|

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -1,14 +1,14 @@
 ---
 title: TokenClient
 section: API
-order: 3
+order: 6
 ---
 
 The `TokenClient` is a standard interface for interactions with functions and events described in `Token.sol`.
 
 Upon creation, new colonies can either create or import existing token contracts. These contracts are expected to conform to the ERC20 or ERC20Extended token standard interface, the latter allowing for `mint` and `burn` functions. The token client is intended to help keep interactions with a colony's token straightforward.
 
-Most functions are fairly self-explanatory and mirror their on-chain counterparts, but in some cases the function will return values passed from event data, rather than simple boolean expressions (which are returned from the contract on-chain). 
+Most functions are fairly self-explanatory and mirror their on-chain counterparts, but in some cases the function will return values passed from event data, rather than simple boolean expressions (which are returned from the contract on-chain).
 
 ==TOC==
 

--- a/packages/colony-js-client/docs/_API_AuthorityClient.template.md
+++ b/packages/colony-js-client/docs/_API_AuthorityClient.template.md
@@ -1,7 +1,7 @@
 ---
 title: AuthorityClient
 section: API
-order: 4
+order: 7
 ---
 
 The `AuthorityClient` is a standard interface for interactions with functions and events described in `Authority.sol`.

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -22,6 +22,10 @@ const colonyClient = await networkClient.getColonyClient(colonyId); // This is a
 
 ## Instance properties
 
+### `networkClient`
+
+The Colony's [ColonyNetworkClient](/colonyjs/api-colonynetworkclient/) instance.
+
 ### `authority`
 
 The Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.

--- a/packages/colony-js-client/docs/_API_MetaColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_MetaColonyClient.template.md
@@ -1,0 +1,35 @@
+---
+title: MetaColonyClient
+section: API
+order: 5
+---
+
+The `MetaColonyClient` class is a standard interface for interactions with the on-chain functions and events described in `IMetaColony.sol`.
+
+These interactions are generally concerned with functions and events internal to the Meta Colony, such as adding global skills.
+
+For functions and events that concern the colonyNetwork as a whole, refer to the [ColonyNetworkClient API](/colonyjs/api-colonynetworkclient/)
+
+==TOC==
+
+## Creating a new instance
+
+You _could_ create a MetaColonyClient by using an adapter and a query: `new MetaColonyClient({ adapter, query })` and then `.init()` it but it is advised to ask the network client for a new instance:
+
+```javascript
+const metaColonyClient = await networkClient.getMetaColonyClient(colonyId); // This is already initialised
+```
+
+## Instance properties
+
+### `networkClient`
+
+The Meta Colony's [ColonyNetworkClient](/colonyjs/api-colonynetworkclient/) instance.
+
+### `authority`
+
+The Meta Colony's [AuthorityClient](/colonyjs/api-authorityclient/) instance.
+
+### `token`
+
+The Meta Colony's [TokenClient](/colonyjs/api-tokenclient/) instance.

--- a/packages/colony-js-client/docs/_API_TokenClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenClient.template.md
@@ -1,13 +1,13 @@
 ---
 title: TokenClient
 section: API
-order: 3
+order: 6
 ---
 
 The `TokenClient` is a standard interface for interactions with functions and events described in `Token.sol`.
 
 Upon creation, new colonies can either create or import existing token contracts. These contracts are expected to conform to the ERC20 or ERC20Extended token standard interface, the latter allowing for `mint` and `burn` functions. The token client is intended to help keep interactions with a colony's token straightforward.
 
-Most functions are fairly self-explanatory and mirror their on-chain counterparts, but in some cases the function will return values passed from event data, rather than simple boolean expressions (which are returned from the contract on-chain). 
+Most functions are fairly self-explanatory and mirror their on-chain counterparts, but in some cases the function will return values passed from event data, rather than simple boolean expressions (which are returned from the contract on-chain).
 
 ==TOC==

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -18,6 +18,11 @@ const CONTRACT_CLIENTS = [
     output: path.resolve(__dirname, '..', '..', '..', 'docs', '_API_ColonyNetworkClient.md'),
   },
   {
+    file: path.resolve(__dirname, '..', 'src', 'MetaColonyClient', 'index.js'),
+    templateFile: path.resolve(__dirname, '..', 'docs', '_API_MetaColonyClient.template.md'),
+    output: path.resolve(__dirname, '..', '..', '..', 'docs', '_API_MetaColonyClient.md'),
+  },
+  {
     file: path.resolve(__dirname, '..', 'src', 'TokenClient', 'index.js'),
     templateFile: path.resolve(__dirname, '..', 'docs', '_API_TokenClient.template.md'),
     output: path.resolve(__dirname, '..', '..', '..', 'docs', '_API_TokenClient.md'),

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -711,16 +711,6 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Adds a global skill under a given parent SkillId. This can only be called from the Meta Colony, and only by the Meta Colony owners.
-  */
-  addGlobalSkill: ColonyClient.Sender<
-    {
-      parentSkillId: number, // Integer id of the parent skill.
-    },
-    { SkillAdded: SkillAdded },
-    ColonyClient,
-  >;
-  /*
     Move any funds received by the colony for `token` denomination to the top-levl domain pot, siphoning off a small amount to the rewards pot. No fee is taken if called against a colony's own token.
   */
   claimColonyFunds: ColonyClient.Sender<
@@ -757,16 +747,6 @@ export default class ColonyClient extends ContractClient {
     The owner of a Colony may mint new tokens.
   */
   mintTokens: ColonyClient.Sender<
-    {
-      amount: BigNumber, // Amount of new tokens to be minted.
-    },
-    { Mint: Mint },
-    ColonyClient,
-  >;
-  /*
-    In the case of the Colony Network, only the Meta Colony may mint new tokens.
-  */
-  mintTokensForColonyNetwork: ColonyClient.Sender<
     {
       amount: BigNumber, // Amount of new tokens to be minted.
     },
@@ -1081,9 +1061,6 @@ export default class ColonyClient extends ContractClient {
     this.addSender('addDomain', {
       input: [['parentSkillId', 'number']],
     });
-    this.addSender('addGlobalSkill', {
-      input: [['parentSkillId', 'number']],
-    });
     this.addSender('assignWorkRating', {
       input: [['taskId', 'number']],
     });
@@ -1126,9 +1103,6 @@ export default class ColonyClient extends ContractClient {
       input: [['payoutId', 'number']],
     });
     this.addSender('mintTokens', {
-      input: [['amount', 'bigNumber']],
-    });
-    this.addSender('mintTokensForColonyNetwork', {
       input: [['amount', 'bigNumber']],
     });
     this.addSender('moveFundsBetweenPots', {

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -8,6 +8,7 @@ import 'isomorphic-fetch';
 import ContractClient from '@colony/colony-js-contract-client';
 
 import ColonyClient from '../ColonyClient/index';
+import MetaColonyClient from '../MetaColonyClient/index';
 import TokenClient from '../TokenClient/index';
 import AuthorityClient from '../AuthorityClient/index';
 import CreateToken from './senders/CreateToken';
@@ -339,6 +340,10 @@ export default class ColonyNetworkClient extends ContractClient {
     return ColonyClient;
   }
 
+  static get MetaColonyClient(): * {
+    return MetaColonyClient;
+  }
+
   static get TokenClient(): * {
     return TokenClient;
   }
@@ -380,6 +385,17 @@ export default class ColonyNetworkClient extends ContractClient {
     return address;
   }
   /*
+  Returns an initialized ColonyClient for the contract at address `contractAddress`
+  */
+  async getMetaColonyClientByAddress(contractAddress: Address) {
+    const metaColonyClient = new this.constructor.MetaColonyClient({
+      adapter: this.adapter,
+      networkClient: this,
+      query: { contractAddress },
+    });
+    return metaColonyClient.init();
+  }
+  /*
   Gets the Meta Colony as an initialized ColonyClient
    */
   async getMetaColonyClient() {
@@ -388,7 +404,7 @@ export default class ColonyNetworkClient extends ContractClient {
     if (!isValidAddress(address))
       throw new Error(`Meta Colony could not be found`);
 
-    return this.getColonyClientByAddress(address);
+    return this.getMetaColonyClientByAddress(address);
   }
   initializeContractMethods() {
     // Events

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -1,0 +1,201 @@
+/* @flow */
+
+import assert from 'assert';
+
+import type BigNumber from 'bn.js';
+
+import ContractClient from '@colony/colony-js-contract-client';
+import { isValidAddress } from '@colony/colony-js-utils';
+// eslint-disable-next-line max-len
+import type { ContractClientConstructorArgs } from '@colony/colony-js-contract-client';
+
+import ColonyNetworkClient from '../ColonyNetworkClient/index';
+import TokenClient from '../TokenClient/index';
+import AuthorityClient from '../AuthorityClient/index';
+
+type Address = string;
+
+type SkillAdded = ContractClient.Event<{
+  skillId: number, // A skillId for this domain.
+  parentSkillId: number, // The parent skill id.
+}>;
+type Mint = ContractClient.Event<{
+  address: Address, // The address that initiated the mint event.
+  amount: BigNumber, // Event data indicating the amount of tokens minted.
+}>;
+
+export default class MetaColonyClient extends ContractClient {
+  networkClient: ColonyNetworkClient;
+  token: TokenClient;
+  authority: AuthorityClient;
+
+  /*
+    Gets the colony's Authority contract address
+  */
+  getAuthority: MetaColonyClient.Caller<
+    {},
+    {
+      address: Address, // The colony's Authority contract address
+    },
+    MetaColonyClient,
+  >;
+  /*
+    Gets the address of the colony's official token contract.
+  */
+  getToken: MetaColonyClient.Caller<
+    {},
+    {
+      address: Address, // The address of the colony's official deployed token contract
+    },
+    MetaColonyClient,
+  >;
+  /*
+    Adds a global skill under a given parent SkillId. This can only be called from the Meta Colony, and only by the Meta Colony owners.
+  */
+  addGlobalSkill: MetaColonyClient.Sender<
+    {
+      parentSkillId: number, // Integer id of the parent skill.
+    },
+    { SkillAdded: SkillAdded },
+    MetaColonyClient,
+  >;
+  /*
+    In the case of the Colony Network, only the Meta Colony may mint new tokens.
+  */
+  mintTokensForColonyNetwork: MetaColonyClient.Sender<
+    {
+      amount: BigNumber, // Amount of new tokens to be minted.
+    },
+    { Mint: Mint },
+    MetaColonyClient,
+  >;
+  /*
+  Set the Colony Network fee inverse amount. This can only be called from the Meta Colony, and only by the Meta Colony owners.
+  */
+  setNetworkFeeInverse: MetaColonyClient.Sender<
+    {
+      feeInverse: number, // Integer id of the parent skill.
+    },
+    {},
+    MetaColonyClient,
+  >;
+
+  events: {
+    Mint: Mint,
+    SkillAdded: SkillAdded,
+  };
+
+  static get defaultQuery() {
+    return {
+      contractName: 'IMetaColony',
+    };
+  }
+
+  constructor({
+    adapter,
+    authority,
+    networkClient,
+    query,
+    token,
+  }: {
+    authority?: AuthorityClient,
+    networkClient?: ColonyNetworkClient,
+    token?: TokenClient,
+  } & ContractClientConstructorArgs) {
+    super({ adapter, query });
+
+    if (!(networkClient instanceof ColonyNetworkClient))
+      throw new Error(
+        'A `networkClient` property must be supplied ' +
+          '(an instance of `ColonyNetworkClient`)',
+      );
+
+    this.networkClient = networkClient;
+    if (token) this.token = token;
+    if (authority) this.authority = authority;
+
+    return this;
+  }
+
+  async init() {
+    await super.init();
+
+    const { address: tokenAddress } = await this.getToken.call();
+    if (!(this.token instanceof TokenClient)) {
+      this.token = new TokenClient({
+        adapter: this.adapter,
+        query: { contractAddress: tokenAddress },
+      });
+      await this.token.init();
+    }
+
+    const { address: authorityAddress } = await this.getAuthority.call();
+    if (!(this.authority instanceof AuthorityClient)) {
+      this.authority = new AuthorityClient({
+        adapter: this.adapter,
+        query: { contractAddress: authorityAddress },
+      });
+      await this.authority.init();
+    }
+
+    return this;
+  }
+
+  initializeContractMethods() {
+    // XXX The SkillAdded event (and its underlying interface) are defined on
+    // the network client. `MetaColonyClient.addGlobalSkill` will cause the
+    // event to be logged; this workaround copies the event definition here so
+    // that it can be parsed correctly.
+    /* eslint-disable max-len */
+    this.events.SkillAdded = this.networkClient.events.SkillAdded;
+    this.contract.interface.events.SkillAdded = this.networkClient.contract.interface.events.SkillAdded;
+
+    // XXX Similarly, the `Mint` event from the token contract need to be
+    // defined here, since it is emitted from various methods.
+    if (this.token) {
+      this.events.Mint = this.token.events.Mint;
+      this.contract.interface.events.Mint = this.token.contract.interface.events.Mint;
+    }
+    /* eslint-enable max-len */
+
+    // Callers
+    this.addCaller('getAuthority', {
+      functionName: 'authority',
+      output: [['address', 'address']],
+    });
+    this.addCaller('getToken', {
+      output: [['address', 'address']],
+    });
+
+    // Senders
+    this.addSender('addGlobalSkill', {
+      input: [['parentSkillId', 'number']],
+    });
+    this.addSender('mintTokensForColonyNetwork', {
+      input: [['amount', 'bigNumber']],
+    });
+  }
+
+  async getReputation({
+    skillId = 1,
+    user,
+  }: {
+    skillId: number,
+    user: Address,
+  } = {}) {
+    assert(Number.isFinite(skillId), 'skillId must be a number');
+    assert(isValidAddress(user), 'user must be an address');
+
+    if (this.network !== 'rinkeby')
+      throw new Error(
+        'Reputation is currently only supported for contracts on Rinkeby',
+      );
+
+    const response = await fetch(
+      `https://colony.io/reputation/${this.network}/${
+        this.contract.address
+      }]/${skillId}/${user}`,
+    );
+    return response.json();
+  }
+}

--- a/packages/colony-js-client/src/index.js
+++ b/packages/colony-js-client/src/index.js
@@ -10,13 +10,21 @@ import type {
 import './paramTypes';
 
 import ColonyNetworkClient from './ColonyNetworkClient/index';
+import AuthorityClient from './AuthorityClient/index';
+import ColonyClient from './ColonyClient/index';
+import MetaColonyClient from './MetaColonyClient/index';
+import TokenClient from './TokenClient/index';
 
 export type {
+  AuthorityClient,
+  ColonyClient,
   ColonyNetworkClient,
   ContractClientConstructorArgs,
   ContractResponse,
+  MetaColonyClient,
   MultisigOperationConstructorArgs,
   SendOptions,
+  TokenClient,
 };
 
 export {


### PR DESCRIPTION
## Description

This pull request adds `MetaColonyClient` to the `colony-js-client` package based on the addition of the `IMetaColony` contract introduced in [7d989bd](https://github.com/JoinColony/colonyNetwork/commit/7d989bd86a45995d13c932d7dea230927535065b).


## Other changes

* Export all client types from `@colony/colony-js-client`

## TODO

- [x] Update tests
- [x] Add document generator

## Resolves

```
TypeError: Function addGlobalSkill not found on contract
```
