### PR TITLE
Update corresponding event for claimPayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 **Bug fixes**
 
-* Update `contractName` for `AuthoriyClient` from `Authority` to `ColonyAuthority`
-* Add `MetaColonyClient` and move corresponding methods over from `ColonyClient`
-* Fix expected `Buffer` type when converting the output for param type `ipfsHash`
-* Update the event for `claimPayout` from `Transfer` to `TaskPayoutClaimed`
-* Add missing `Transfer` event to the `mintTokens` sender method
+* Update `contractName` for `AuthorityClient` from `Authority` to `ColonyAuthority` (`@colony/colony-js-client`)
+* Add `MetaColonyClient` and move corresponding methods over from `ColonyClient` (`@colony/colony-js-client`)
+* Fix expected `Buffer` type when converting the output for param type `ipfsHash` (`@colony/colony-js-client`)
+* Add the event `TaskPayoutClaimed` to the `claimPayout` method (`@colony/colony-js-client`)
+* Add missing `Transfer` event to the `mintTokens` method (`@colony/colony-js-client`)
 
 ## v1.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Update `contractName` for `AuthoriyClient` from `Authority` to `ColonyAuthority`
+* Add `MetaColonyClient` and move corresponding methods over from `ColonyClient`
+* Fix expected `Buffer` type when converting the output for param type `ipfsHash`
+* Update the event for `claimPayout` from `Transfer` to `TaskPayoutClaimed`
+* Add missing `Transfer` event to the `mintTokens` sender method
 
 ## v1.7.4
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -768,9 +768,14 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Event data|Type|Description|
 |---|---|---|
+|taskId|number|The task ID of the task that was finalized.|
+|role|Role|The role of the work rating.|
+|token|Token address|The token address (0x indicates ether).|
+|amount|number|The token amount.|
 |from|Address|Event data indicating the 'from' address.|
 |to|Address|Event data indicating the 'to' address.|
 |value|BigNumber|Event data indicating the amount transferred.|
+|TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#events-TaskPayoutClaimed)|
 |Transfer|object|Contains the data defined in [Transfer](#events-Transfer)|
 
 ### `addDomain.send({ parentSkillId }, options)`
@@ -862,7 +867,11 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|Address|The address that initiated the mint event.|
 |amount|BigNumber|Event data indicating the amount of tokens minted.|
+|from|Address|Event data indicating the 'from' address.|
+|to|Address|Event data indicating the 'to' address.|
+|value|BigNumber|Event data indicating the amount transferred.|
 |Mint|object|Contains the data defined in [Mint](#events-Mint)|
+|Transfer|object|Contains the data defined in [Transfer](#events-Transfer)|
 
 ### `startNextRewardPayout.send({ token }, options)`
 
@@ -1362,6 +1371,20 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|The task ID of the task that was finalized.|
+
+
+### [events.TaskPayoutClaimed.addListener(({ taskId, role, token, amount }) => { /* ... */ })](#events-TaskPayoutClaimed)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|taskId|number|The task ID of the task that was finalized.|
+|role|Role|The role of the work rating.|
+|token|Token address|The token address (0x indicates ether).|
+|amount|number|The token amount.|
 
 
 ### [events.TaskCanceled.addListener(({ taskId }) => { /* ... */ })](#events-TaskCanceled)

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -85,6 +85,12 @@ type TaskWorkRatingRevealed = ContractClient.Event<{
 type TaskFinalized = ContractClient.Event<{
   taskId: number, // The task ID of the task that was finalized.
 }>;
+type TaskPayoutClaimed = ContractClient.Event<{
+  taskId: number, // The task ID of the task that was finalized.
+  role: Role, // The role of the work rating.
+  token: TokenAddress, // The token address (0x indicates ether).
+  amount: number, // The token amount.
+}>;
 type TaskCanceled = ContractClient.Event<{
   taskId: number, // The task ID of the task that was canceled.
 }>;
@@ -697,7 +703,10 @@ export default class ColonyClient extends ContractClient {
       role: Role, // Role of the contributor claiming the payout: MANAGER, EVALUATOR, or WORKER
       token: TokenAddress, // Address to claim funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
     },
-    { Transfer: Transfer },
+    {
+      TaskPayoutClaimed: TaskPayoutClaimed,
+      Transfer: Transfer,
+    },
     ColonyClient,
   >;
   /*
@@ -750,7 +759,10 @@ export default class ColonyClient extends ContractClient {
     {
       amount: BigNumber, // Amount of new tokens to be minted.
     },
-    { Mint: Mint },
+    {
+      Mint: Mint,
+      Transfer: Transfer,
+    },
     ColonyClient,
   >;
   /*
@@ -821,6 +833,7 @@ export default class ColonyClient extends ContractClient {
     TaskDomainChanged: TaskDomainChanged,
     TaskDueDateChanged: TaskDueDateChanged,
     TaskFinalized: TaskFinalized,
+    TaskPayoutClaimed: TaskPayoutClaimed,
     TaskRoleUserChanged: TaskRoleUserChanged,
     TaskSkillChanged: TaskSkillChanged,
     TaskWorkerPayoutChanged: TaskWorkerPayoutChanged,
@@ -1032,6 +1045,13 @@ export default class ColonyClient extends ContractClient {
       // $FlowFixMe
       ['role', 'role'],
       ['rating', 'number'],
+    ]);
+    this.addEvent('TaskPayoutClaimed', [
+      ['taskId', 'number'],
+      // $FlowFixMe
+      ['role', 'role'],
+      ['token', 'tokenAddress'],
+      ['amount', 'number'],
     ]);
     this.addEvent('TaskFinalized', [['taskId', 'number']]);
     this.addEvent('TaskCanceled', [['taskId', 'number']]);


### PR DESCRIPTION
## Description

This pull request updates the event for `claimPayout` from `Transfer` to `TaskPayoutClaimed`.

## Other Changes

Added missing `Transfer` event to `mintTokens` sender method.

Updated changelog.

## Resolves

```
Error: Event TaskPayoutClaimed not found
```
