### PR TITLE
Add new contract methods/events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## v.NEXT
 
+**Maintenance**
+
+* Add `ColonyClient` events:
+  * `ColonyAdminRoleRemoved`
+  * `ColonyAdminRoleSet`
+  * `ColonyFounderRoleSet`
+  * `ColonyFundsClaimed`
+  * `ColonyFundsMovedBetweenFundingPots`
+  * `ColonyInitialised`
+  * `ColonyRewardInverseSet`
+  * `ColonyUpgraded`
+  * `RewardPayoutClaimed`
+* Add `ColonyNetworkClient` events:
+  * `ColonyNetworkInitialised`
+  * `ColonyVersionAdded`
+  * `MetaColonyCreated`
+  * `MiningCycleResolverSet`
+  * `NetworkFeeInverseSet`
+  * `ReputationMiningCycleComplete`
+  * `ReputationMiningInitialised`
+  * `ReputationRootHashSet`
+  * `TokenLockingAddressSet`
+* Add recovery methods to `ColonyNetworkClient`/`ColonyClient`:
+  * `approveExitRecovery`
+  * `enterRecoveryMode`
+  * `exitRecoveryMode`
+  * `getRecoveryRolesCount`
+  * `isInRecoveryMode`
+  * `removeRecoveryRole`
+  * `setRecoveryRole`
+  * `setStorageSlotRecovery`
 
 ## v1.7.5
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -39,6 +39,32 @@ The Colony's [TokenClient](/colonyjs/api-tokenclient/) instance.
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
+### `getRecoveryRolesCount.call()`
+
+Returns the number of recovery roles.
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|count|number|Number of users with the recovery role (excluding owner)|
+
+### `isInRecoveryMode.call()`
+
+Is the colony in recovery mode?
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|inRecoveryMode|boolean|Return true if recovery mode is active, false otherwise|
+
 ### `getAuthority.call()`
 
 Gets the colony's Authority contract address
@@ -64,19 +90,6 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |version|number|The version number.|
-
-### `getRecoveryRolesCount.call()`
-
-Returns the number of recovery roles.
-
-
-**Returns**
-
-A promise which resolves to an object containing the following properties:
-
-|Return value|Type|Description|
-|---|---|---|
-|count|number|Number of users with the recovery role (excluding owner)|
 
 ### `generateSecret.call({ salt, value })`
 
@@ -358,6 +371,19 @@ A promise which resolves to an object containing the following properties:
 |totalTokenAmountForRewardPayout|BigNumber|Total amount of tokens taken aside for reward payout.|
 |totalTokens|BigNumber|Total colony tokens at the time of creation.|
 
+### `getRewardInverse.call()`
+
+Return 1 / the reward to pay out from revenue. e.g. if the fee is 1% (or 0.01), return 100
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|rewardInverse|BigNumber|The inverse of the reward|
+
 ### `getToken.call()`
 
 Gets the address of the colony's official token contract.
@@ -388,6 +414,112 @@ A promise which resolves to an object containing the following properties:
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
+### `approveExitRecovery.send(options)`
+
+Indicate approval to exit recovery mode. Can only be called by user with recovery role.
+
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `enterRecoveryMode.send(options)`
+
+Put the colony into recovery mode. Can only be called by user with a recovery role.
+
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `exitRecoveryMode.send({ newVersion }, options)`
+
+Exit recovery mode. Can be called by anyone if enough whitelist approvals are given.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|newVersion|number|Resolver version to upgrade to (>= current version)|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `setRecoveryRole.send({ user }, options)`
+
+Set new colony recovery role. Can only be called by the founder role.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The user we want to give a recovery role to.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `setRewardInverse.send({ rewardInverse }, options)`
+
+Set new colony recovery role. Can only be called by the founder role.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|rewardInverse|BigNumber|The inverse of the reward|
+
+**Returns**
+
+An instance of a `ContractResponse` which will eventually receive the following event data:
+
+|Event data|Type|Description|
+|---|---|---|
+|rewardInverse|BigNumber|The reward inverse value|
+|ColonyRewardInverseSet|object|Contains the data defined in [ColonyRewardInverseSet](#events-ColonyRewardInverseSet)|
+
+### `removeRecoveryRole.send({ user }, options)`
+
+Remove colony recovery role. Can only be called by the founder role.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The user we want to remove the recovery role from.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `setStorageSlotRecovery.send({ slot, value }, options)`
+
+Update the value of an arbitrary storage variable. This can only be called by a user with the recovery role. Certain critical variables are protected from editing in this function.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|slot|number|Address of storage slot to be updated.|
+|value|Hex string|Word of data to be set.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
 ### `createTask.send({ specificationHash, domainId, skillId, dueDate }, options)`
 
 Creates a new task by invoking `makeTask` on-chain.
@@ -433,33 +565,6 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The task ID.|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#events-TaskCompleted)|
 
-### `enterRecoveryMode.send(options)`
-
-Put the colony into recovery mode. Can only be called by user with a recovery role.
-
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
-
-### `exitRecoveryMode.send({ newVersion }, options)`
-
-Exit recovery mode. Can be called by anyone if enough whitelist approvals are given.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|newVersion|number|Resolver version to upgrade to (>= current version)|
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
-
 ### `registerColonyLabel.send({ colonyName, orbitDBPath }, options)`
 
 Register the colony's ENS label.
@@ -481,21 +586,25 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |label|string|The label registered|
 |ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#events-ColonyLabelRegistered)|
 
-### `setOwnerRole.send({ user }, options)`
+### `setFounderRole.send({ user }, options)`
 
-Set a new colony owner role. There can only be one address assigned to owner role at a time. Whoever calls this function will lose their owner role. Can be called by owner role.
+Set a new colony founder role. There can only be one address assigned to the founder role at a time. Whoever calls this function will lose their founder role. Can be called by founder role.
 
 **Arguments**
 
 |Argument|Type|Description|
 |---|---|---|
-|user|Address|User we want to give an owner role to|
+|user|Address|User we want to give a founder role to|
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|oldFounder|Address|The current founder delegating the role away|
+|newFounder|Address|The user receiving the colony founder role|
+|ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#events-ColonyFounderRoleSet)|
 
 ### `setAdminRole.send({ user }, options)`
 
@@ -509,13 +618,16 @@ Set a new colony admin role. Can be called by an owner or admin role.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|user|Address|The newly-added colony admin user|
+|ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#events-ColonyAdminRoleSet)|
 
 ### `setRecoveryRole.send({ user }, options)`
 
-Set a new colony recovery role. Can be called by an owner role.
+Set a new colony recovery role. Can be called by the founder role.
 
 **Arguments**
 
@@ -531,7 +643,7 @@ An instance of a `ContractResponse`
 
 ### `removeAdminRole.send({ user }, options)`
 
-Remove a colony admin role. Can only be called by an owner role.
+Remove a colony admin role. Can only be called by the founder role.
 
 **Arguments**
 
@@ -541,25 +653,12 @@ Remove a colony admin role. Can only be called by an owner role.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
-
-### `removeRecoveryRole.send({ user }, options)`
-
-Remove a colony recovery role. Can only be called by an owner role.
-
-**Arguments**
-
-|Argument|Type|Description|
+|Event data|Type|Description|
 |---|---|---|
-|user|Address|User we want to remove a recovery role from|
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
+|user|Address|The removed colony admin user|
+|ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#events-ColonyAdminRoleRemoved)|
 
 ### `setTaskDomain.send({ taskId, domainId }, options)`
 
@@ -580,7 +679,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The task ID.|
 |domainId|number|The task's new domain ID.|
-|TaskDomainChanged|object|Contains the data defined in [TaskDomainChanged](#events-TaskDomainChanged)|
+|TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#events-TaskDomainSet)|
 
 ### `setAllTaskPayouts.send({ taskId, token, managerAmount, evaluatorAmount, workerAmount }, options)`
 
@@ -603,9 +702,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Event data|Type|Description|
 |---|---|---|
 |taskId|number|The task ID.|
+|role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
 |amount|number|The token amount.|
-|TaskWorkerPayoutChanged|object|Contains the data defined in [TaskWorkerPayoutChanged](#events-TaskWorkerPayoutChanged)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#events-TaskPayoutSet)|
 
 ### `submitTaskDeliverable.send({ taskId, deliverableHash }, options)`
 
@@ -810,9 +910,14 @@ Move any funds received by the colony for `token` denomination to the top-levl d
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|token|Address|The token address being claimed|
+|fee|BigNumber|The fee deducted for rewards|
+|payoutRemainder|BigNumber|The remaining funds moved to the top-level domain pot|
+|ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#events-ColonyFundsClaimed)|
 
 ### `finalizeRewardPayout.send({ payoutId }, options)`
 
@@ -845,9 +950,15 @@ Move a given amount of `token` funds from one pot to another.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|fromPot|number|The source funding pot|
+|toPot|number|The target funding pot|
+|amount|BigNumber|The amount that was transferred|
+|token|Address|The token address being transferred|
+|ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#events-ColonyFundsMovedBetweenFundingPots)|
 
 ### `mintTokens.send({ amount }, options)`
 
@@ -889,7 +1000,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Event data|Type|Description|
 |---|---|---|
-|payoutId|number|The payout ID logged when a new reward payout cycle has started.|
+|payoutId|number|The reward payout cycle ID logged when a new reward payout cycle has started.|
 |RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#events-RewardPayoutCycleStarted)|
 
 ### `waiveRewardPayouts.send({ numPayouts }, options)`
@@ -901,23 +1012,6 @@ Waive reward payout. This unlocks the sender's tokens and increments the users r
 |Argument|Type|Description|
 |---|---|---|
 |numPayouts|number|Number of payouts to waive.|
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
-
-### `setStorageSlotRecovery.send({ slot, value }, options)`
-
-Update the value of an arbitrary storage variable. This can only be called by a user with the recovery role. Certain critical variables are protected from editing in this function.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|slot|number|Address of storage slot to be updated.|
-|value|Hex string|Word of data to be set.|
 
 **Returns**
 
@@ -953,9 +1047,13 @@ Upgrades the colony to a new Colony contract version. Downgrades are not allowed
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|oldVersion|number|The previous colony version|
+|newVersion|number|The new colony version|
+|ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#events-ColonyUpgraded)|
 
   
 ## Task MultiSig
@@ -980,7 +1078,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The task ID.|
 |specificationHash|string|The IPFS hash of the task's new specification.|
-|TaskBriefChanged|object|Contains the data defined in [TaskBriefChanged](#events-TaskBriefChanged)|
+|TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#events-TaskBriefSet)|
 
 ### `setTaskDueDate.startOperation({ taskId, dueDate })`
 
@@ -1001,7 +1099,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The task ID.|
 |dueDate|Date|The task's new due date.|
-|TaskDueDateChanged|object|Contains the data defined in [TaskDueDateChanged](#events-TaskDueDateChanged)|
+|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#events-TaskDueDateSet)|
 
 ### `setTaskManagerRole.startOperation({ taskId, user })`
 
@@ -1023,7 +1121,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
-|TaskRoleUserChanged|object|Contains the data defined in [TaskRoleUserChanged](#events-TaskRoleUserChanged)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
 
 ### `setTaskWorkerRole.startOperation({ taskId, user })`
 
@@ -1045,7 +1143,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
-|TaskRoleUserChanged|object|Contains the data defined in [TaskRoleUserChanged](#events-TaskRoleUserChanged)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
 
 ### `setTaskEvaluatorRole.startOperation({ taskId, user })`
 
@@ -1067,7 +1165,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
-|TaskRoleUserChanged|object|Contains the data defined in [TaskRoleUserChanged](#events-TaskRoleUserChanged)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
 
 ### `setTaskSkill.startOperation({ taskId, skillId })`
 
@@ -1088,7 +1186,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The task ID.|
 |skillId|number|The task's new skill ID.|
-|TaskSkillChanged|object|Contains the data defined in [TaskSkillChanged](#events-TaskSkillChanged)|
+|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#events-TaskSkillSet)|
 
 ### `setTaskEvaluatorPayout.startOperation({ taskId, token, amount })`
 
@@ -1109,9 +1207,10 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |Event Data|Type|Description|
 |---|---|---|
 |taskId|number|The task ID.|
+|role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
 |amount|number|The token amount.|
-|TaskWorkerPayoutChanged|object|Contains the data defined in [TaskWorkerPayoutChanged](#events-TaskWorkerPayoutChanged)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#events-TaskPayoutSet)|
 
 ### `setTaskManagerPayout.startOperation({ taskId, token, amount })`
 
@@ -1132,9 +1231,10 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |Event Data|Type|Description|
 |---|---|---|
 |taskId|number|The task ID.|
+|role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
 |amount|number|The token amount.|
-|TaskWorkerPayoutChanged|object|Contains the data defined in [TaskWorkerPayoutChanged](#events-TaskWorkerPayoutChanged)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#events-TaskPayoutSet)|
 
 ### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
 
@@ -1155,9 +1255,10 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |Event Data|Type|Description|
 |---|---|---|
 |taskId|number|The task ID.|
+|role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
 |amount|number|The token amount.|
-|TaskWorkerPayoutChanged|object|Contains the data defined in [TaskWorkerPayoutChanged](#events-TaskWorkerPayoutChanged)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#events-TaskPayoutSet)|
 
 ### `removeTaskWorkerRole.startOperation({ taskId })`
 
@@ -1178,7 +1279,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
-|TaskRoleUserChanged|object|Contains the data defined in [TaskRoleUserChanged](#events-TaskRoleUserChanged)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
 
 ### `removeTaskEvaluatorRole.startOperation({ taskId })`
 
@@ -1199,7 +1300,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
-|TaskRoleUserChanged|object|Contains the data defined in [TaskRoleUserChanged](#events-TaskRoleUserChanged)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
 
   
 ## Events
@@ -1252,7 +1353,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |taskId|number|The task ID.|
 
 
-### [events.TaskBriefChanged.addListener(({ taskId, specificationHash }) => { /* ... */ })](#events-TaskBriefChanged)
+### [events.TaskBriefSet.addListener(({ taskId, specificationHash }) => { /* ... */ })](#events-TaskBriefSet)
 
 
 
@@ -1275,7 +1376,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |taskId|number|The task ID.|
 
 
-### [events.TaskDueDateChanged.addListener(({ taskId, dueDate }) => { /* ... */ })](#events-TaskDueDateChanged)
+### [events.TaskDueDateSet.addListener(({ taskId, dueDate }) => { /* ... */ })](#events-TaskDueDateSet)
 
 
 
@@ -1287,7 +1388,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |dueDate|Date|The task's new due date.|
 
 
-### [events.TaskDomainChanged.addListener(({ taskId, domainId }) => { /* ... */ })](#events-TaskDomainChanged)
+### [events.TaskDomainSet.addListener(({ taskId, domainId }) => { /* ... */ })](#events-TaskDomainSet)
 
 
 
@@ -1299,7 +1400,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |domainId|number|The task's new domain ID.|
 
 
-### [events.TaskSkillChanged.addListener(({ taskId, skillId }) => { /* ... */ })](#events-TaskSkillChanged)
+### [events.TaskSkillSet.addListener(({ taskId, skillId }) => { /* ... */ })](#events-TaskSkillSet)
 
 
 
@@ -1311,7 +1412,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |skillId|number|The task's new skill ID.|
 
 
-### [events.TaskRoleUserChanged.addListener(({ taskId, role, user }) => { /* ... */ })](#events-TaskRoleUserChanged)
+### [events.TaskRoleUserSet.addListener(({ taskId, role, user }) => { /* ... */ })](#events-TaskRoleUserSet)
 
 
 
@@ -1324,7 +1425,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |user|Address|The user with the role that changed for the task.|
 
 
-### [events.TaskWorkerPayoutChanged.addListener(({ taskId, token, amount }) => { /* ... */ })](#events-TaskWorkerPayoutChanged)
+### [events.TaskPayoutSet.addListener(({ taskId, role, token, amount }) => { /* ... */ })](#events-TaskPayoutSet)
 
 
 
@@ -1333,6 +1434,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |Argument|Type|Description|
 |---|---|---|
 |taskId|number|The task ID.|
+|role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
 |amount|number|The token amount.|
 
@@ -1406,7 +1508,18 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 
 |Argument|Type|Description|
 |---|---|---|
-|payoutId|number|The payout ID logged when a new reward payout cycle has started.|
+|payoutId|number|The reward payout cycle ID logged when a new reward payout cycle has started.|
+
+
+### [events.RewardPayoutCycleEnded.addListener(({ payoutId }) => { /* ... */ })](#events-RewardPayoutCycleEnded)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|payoutId|number|The reward payout cycle ID logged when a reward payout cycle has ended.|
 
 
 ### [events.ColonyLabelRegistered.addListener(({ colony, label }) => { /* ... */ })](#events-ColonyLabelRegistered)
@@ -1444,3 +1557,112 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |---|---|---|
 |address|Address|The address that initiated the mint event.|
 |amount|BigNumber|Event data indicating the amount of tokens minted.|
+
+
+### [events.ColonyFounderRoleSet.addListener(({ oldFounder, newFounder }) => { /* ... */ })](#events-ColonyFounderRoleSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|oldFounder|Address|The current founder delegating the role away|
+|newFounder|Address|The user receiving the colony founder role|
+
+
+### [events.ColonyAdminRoleSet.addListener(({ user }) => { /* ... */ })](#events-ColonyAdminRoleSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The newly-added colony admin user|
+
+
+### [events.ColonyAdminRoleRemoved.addListener(({ user }) => { /* ... */ })](#events-ColonyAdminRoleRemoved)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The removed colony admin user|
+
+
+### [events.ColonyFundsMovedBetweenFundingPots.addListener(({ fromPot, toPot, amount, token }) => { /* ... */ })](#events-ColonyFundsMovedBetweenFundingPots)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|fromPot|number|The source funding pot|
+|toPot|number|The target funding pot|
+|amount|BigNumber|The amount that was transferred|
+|token|Address|The token address being transferred|
+
+
+### [events.ColonyFundsClaimed.addListener(({ token, fee, payoutRemainder }) => { /* ... */ })](#events-ColonyFundsClaimed)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|token|Address|The token address being claimed|
+|fee|BigNumber|The fee deducted for rewards|
+|payoutRemainder|BigNumber|The remaining funds moved to the top-level domain pot|
+
+
+### [events.RewardPayoutClaimed.addListener(({ rewardPayoutId, user, fee, payoutRemainder }) => { /* ... */ })](#events-RewardPayoutClaimed)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|rewardPayoutId|number|The reward payout cycle ID|
+|user|Address|The user who received the reward payout|
+|fee|BigNumber|The fee deducted from the payout|
+|payoutRemainder|BigNumber|The remaining reward amount paid out to the user|
+
+
+### [events.ColonyRewardInverseSet.addListener(({ rewardInverse }) => { /* ... */ })](#events-ColonyRewardInverseSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|rewardInverse|BigNumber|The reward inverse value|
+
+
+### [events.ColonyInitialised.addListener(({ colonyNetwork }) => { /* ... */ })](#events-ColonyInitialised)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|colonyNetwork|Address|The Colony Network address|
+
+
+### [events.ColonyUpgraded.addListener(({ oldVersion, newVersion }) => { /* ... */ })](#events-ColonyUpgraded)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|oldVersion|number|The previous colony version|
+|newVersion|number|The new colony version|

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -84,6 +84,32 @@ Gets the Meta Colony as an initialized ColonyClient
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
+### `getRecoveryRolesCount.call()`
+
+Returns the number of recovery roles.
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|count|number|Number of users with the recovery role (excluding owner)|
+
+### `isInRecoveryMode.call()`
+
+Is the colony in recovery mode?
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|inRecoveryMode|boolean|Return true if recovery mode is active, false otherwise|
+
 ### `getColony.call({ id })`
 
 Returns the address of a colony when given the ID
@@ -350,6 +376,93 @@ A promise which resolves to an object containing the following properties:
 ## Senders
 
 **All senders return an instance of a `ContractResponse`.** Every `send()` method takes an `options` object as the second argument. For a reference please check [here](/colonyjs/docs-contractclient/#senders).
+### `approveExitRecovery.send(options)`
+
+Indicate approval to exit recovery mode. Can only be called by user with recovery role.
+
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `enterRecoveryMode.send(options)`
+
+Put the colony into recovery mode. Can only be called by user with a recovery role.
+
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `exitRecoveryMode.send({ newVersion }, options)`
+
+Exit recovery mode. Can be called by anyone if enough whitelist approvals are given.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|newVersion|number|Resolver version to upgrade to (>= current version)|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `setRecoveryRole.send({ user }, options)`
+
+Set new colony recovery role. Can only be called by the founder role.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The user we want to give a recovery role to.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `removeRecoveryRole.send({ user }, options)`
+
+Remove colony recovery role. Can only be called by the founder role.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|user|Address|The user we want to remove the recovery role from.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
+### `setStorageSlotRecovery.send({ slot, value }, options)`
+
+Update the value of an arbitrary storage variable. This can only be called by a user with the recovery role. Certain critical variables are protected from editing in this function.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|slot|number|Address of storage slot to be updated.|
+|value|Hex string|Word of data to be set.|
+
+**Returns**
+
+An instance of a `ContractResponse`
+
+
+
 ### `createToken.send({ name, symbol, decimals }, options)`
 
 Deploys a new ERC20 compatible token contract for you to use with your Colony. You can also use your own token when creating a Colony.
@@ -401,9 +514,12 @@ Sets the token locking address.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|tokenLocking|Address|Address of the TokenLocking contract|
+|TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#events-TokenLockingAddressSet)|
 
 ### `createMetaColony.send({ tokenAddress }, options)`
 
@@ -417,9 +533,14 @@ Create the Meta Colony, same as a normal Colony plus the root skill.
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|colonyAddress|number|Address of the Meta Colony|
+|tokenAddress|Address|Address of the associated CLNY token|
+|rootSkillId|number|ID of the root skill of the global skills tree (normally, this is 2)|
+|MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#events-MetaColonyCreated)|
 
 ### `createColony.send({ tokenAddress }, options)`
 
@@ -437,8 +558,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Event data|Type|Description|
 |---|---|---|
-|colonyId|number|ID of the newly-created Colony|
-|colonyAddress|Address|Address of the newly-created Colony|
+|colonyId|number|ID of the newly-created colony|
+|colonyAddress|Address|Address of the newly-created colony|
+|tokenAddress|Address|Address of the associated colony token|
 |ColonyAdded|object|Contains the data defined in [ColonyAdded](#events-ColonyAdded)|
 
 ### `addColonyVersion.send({ version, resolver }, options)`
@@ -454,9 +576,13 @@ Adds a new Colony contract version and the address of associated Resolver contra
 
 **Returns**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse` which will eventually receive the following event data:
 
-
+|Event data|Type|Description|
+|---|---|---|
+|version|number|The new int colony version, e.g. 2, 3, 4, etc|
+|resolver|Address|The new colony contract resolver contract instance|
+|ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#events-ColonyVersionAdded)|
 
 ### `startTokenAuction.send({ tokenAddress }, options)`
 
@@ -524,7 +650,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events) to interact with these events.
 
 
-### [events.ColonyAdded.addListener(({ colonyId, colonyAddress }) => { /* ... */ })](#events-ColonyAdded)
+### [events.ColonyAdded.addListener(({ colonyId, colonyAddress, tokenAddress }) => { /* ... */ })](#events-ColonyAdded)
 
 
 
@@ -532,8 +658,9 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 
 |Argument|Type|Description|
 |---|---|---|
-|colonyId|number|ID of the newly-created Colony|
-|colonyAddress|Address|Address of the newly-created Colony|
+|colonyId|number|ID of the newly-created colony|
+|colonyAddress|Address|Address of the newly-created colony|
+|tokenAddress|Address|Address of the associated colony token|
 
 
 ### [events.SkillAdded.addListener(({ skillId, parentSkillId }) => { /* ... */ })](#events-SkillAdded)
@@ -583,3 +710,109 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |---|---|---|
 |colony|Address|Address of the colony that registered a label|
 |label|string|The label registered|
+
+
+### [events.ReputationMiningInitialised.addListener(({ inactiveReputationMiningCycle }) => { /* ... */ })](#events-ReputationMiningInitialised)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|inactiveReputationMiningCycle|Address|Address of the newly created ReputationMiningCycle used in logging reputation changes|
+
+
+### [events.ReputationMiningCycleComplete.addListener(({ hash, nNodes }) => { /* ... */ })](#events-ReputationMiningCycleComplete)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|hash|Hex string|The root hash of the newly accepted reputation state|
+|nNodes|number|The number of nodes in the reputation state|
+
+
+### [events.ReputationRootHashSet.addListener(({ newHash, newNNodes, stakers, reward }) => { /* ... */ })](#events-ReputationRootHashSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|newHash|Hex string|The reputation root hash|
+|newNNodes|number|The updated nodes count value|
+|stakers|undefined|Array of users who submitted or backed the hash accepted|
+|reward|undefined|Amount of CLNY distributed as reward to miners|
+
+
+### [events.TokenLockingAddressSet.addListener(({ tokenLocking }) => { /* ... */ })](#events-TokenLockingAddressSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|tokenLocking|Address|Address of the TokenLocking contract|
+
+
+### [events.ColonyNetworkInitialised.addListener(({ resolver }) => { /* ... */ })](#events-ColonyNetworkInitialised)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|resolver|Address|The Resolver contract address used by the Colony version 1|
+
+
+### [events.MiningCycleResolverSet.addListener(({ miningCycleResolver }) => { /* ... */ })](#events-MiningCycleResolverSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|miningCycleResolver|Address|Resolver address for the ReputationMiningCycle contract|
+
+
+### [events.NetworkFeeInverseSet.addListener(({ feeInverse }) => { /* ... */ })](#events-NetworkFeeInverseSet)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|feeInverse|BigNumber|The network fee inverse value|
+
+
+### [events.ColonyVersionAdded.addListener(({ version, resolver }) => { /* ... */ })](#events-ColonyVersionAdded)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|version|number|The new int colony version, e.g. 2, 3, 4, etc|
+|resolver|Address|The new colony contract resolver contract instance|
+
+
+### [events.MetaColonyCreated.addListener(({ colonyAddress, tokenAddress, rootSkillId }) => { /* ... */ })](#events-MetaColonyCreated)
+
+
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|colonyAddress|number|Address of the Meta Colony|
+|tokenAddress|Address|Address of the associated CLNY token|
+|rootSkillId|number|ID of the root skill of the global skills tree (normally, this is 2)|

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -187,7 +187,7 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Set new colony recovery role. Can only be called by the founder role.
+    Set the reward inverse to pay out from revenue. e.g. if the fee is 1% (or 0.01), set 100
    */
   setRewardInverse: ColonyClient.Sender<
     {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -14,6 +14,7 @@ import TokenClient from '../TokenClient/index';
 import AuthorityClient from '../AuthorityClient/index';
 import GetTask from './callers/GetTask';
 import CreateTask from './senders/CreateTask';
+import addRecoveryMethods from '../addRecoveryMethods';
 import {
   ROLES,
   ADMIN_ROLE,
@@ -44,32 +45,33 @@ type SkillAdded = ContractClient.Event<{
 type TaskAdded = ContractClient.Event<{
   taskId: number, // The task ID.
 }>;
-type TaskBriefChanged = ContractClient.Event<{
+type TaskBriefSet = ContractClient.Event<{
   taskId: number, // The task ID.
   specificationHash: string, // The IPFS hash of the task's new specification.
 }>;
 type TaskCompleted = ContractClient.Event<{
   taskId: number, // The task ID.
 }>;
-type TaskDueDateChanged = ContractClient.Event<{
+type TaskDueDateSet = ContractClient.Event<{
   taskId: number, // The task ID.
   dueDate: Date, // The task's new due date.
 }>;
-type TaskDomainChanged = ContractClient.Event<{
+type TaskDomainSet = ContractClient.Event<{
   taskId: number, // The task ID.
   domainId: number, // The task's new domain ID.
 }>;
-type TaskSkillChanged = ContractClient.Event<{
+type TaskSkillSet = ContractClient.Event<{
   taskId: number, // The task ID.
   skillId: number, // The task's new skill ID.
 }>;
-type TaskRoleUserChanged = ContractClient.Event<{
+type TaskRoleUserSet = ContractClient.Event<{
   taskId: number, // The task ID.
   role: number, // The role that changed for the task.
   user: Address, // The user with the role that changed for the task.
 }>;
-type TaskWorkerPayoutChanged = ContractClient.Event<{
+type TaskPayoutSet = ContractClient.Event<{
   taskId: number, // The task ID.
+  role: Role, // The role the payout is for
   token: TokenAddress, // The token address (0x indicates ether).
   amount: number, // The token amount.
 }>;
@@ -95,7 +97,10 @@ type TaskCanceled = ContractClient.Event<{
   taskId: number, // The task ID of the task that was canceled.
 }>;
 type RewardPayoutCycleStarted = ContractClient.Event<{
-  payoutId: number, // The payout ID logged when a new reward payout cycle has started.
+  payoutId: number, // The reward payout cycle ID logged when a new reward payout cycle has started.
+}>;
+type RewardPayoutCycleEnded = ContractClient.Event<{
+  payoutId: number, // The reward payout cycle ID logged when a reward payout cycle has ended.
 }>;
 type ColonyLabelRegistered = ContractClient.Event<{
   colony: Address, // Address of the colony that registered a label
@@ -110,11 +115,128 @@ type Mint = ContractClient.Event<{
   address: Address, // The address that initiated the mint event.
   amount: BigNumber, // Event data indicating the amount of tokens minted.
 }>;
+type ColonyFounderRoleSet = ContractClient.Event<{
+  oldFounder: Address, // The current founder delegating the role away
+  newFounder: Address, // The user receiving the colony founder role
+}>;
+type ColonyAdminRoleSet = ContractClient.Event<{
+  user: Address, // The newly-added colony admin user
+}>;
+type ColonyAdminRoleRemoved = ContractClient.Event<{
+  user: Address, // The removed colony admin user
+}>;
+type ColonyFundsMovedBetweenFundingPots = ContractClient.Event<{
+  fromPot: number, // The source funding pot
+  toPot: number, // The target funding pot
+  amount: BigNumber, // The amount that was transferred
+  token: Address, // The token address being transferred
+}>;
+type ColonyFundsClaimed = ContractClient.Event<{
+  token: Address, // The token address being claimed
+  fee: BigNumber, // The fee deducted for rewards
+  payoutRemainder: BigNumber, // The remaining funds moved to the top-level domain pot
+}>;
+type RewardPayoutClaimed = ContractClient.Event<{
+  rewardPayoutId: number, // The reward payout cycle ID
+  user: Address, // The user who received the reward payout
+  fee: BigNumber, // The fee deducted from the payout
+  payoutRemainder: BigNumber, // The remaining reward amount paid out to the user
+}>;
+type ColonyRewardInverseSet = ContractClient.Event<{
+  rewardInverse: BigNumber, // The reward inverse value
+}>;
+type ColonyInitialised = ContractClient.Event<{
+  colonyNetwork: Address, // The Colony Network address
+}>;
+type ColonyUpgraded = ContractClient.Event<{
+  oldVersion: number, // The previous colony version
+  newVersion: number, // The new colony version
+}>;
 
 export default class ColonyClient extends ContractClient {
   networkClient: ColonyNetworkClient;
   token: TokenClient;
   authority: AuthorityClient;
+
+  /*
+    Indicate approval to exit recovery mode. Can only be called by user with recovery role.
+   */
+  approveExitRecovery: ColonyClient.Sender<{}, {}, ColonyClient>;
+  /*
+    Put the colony into recovery mode. Can only be called by user with a recovery role.
+   */
+  enterRecoveryMode: ColonyClient.Sender<{}, {}, ColonyClient>;
+  /*
+    Exit recovery mode. Can be called by anyone if enough whitelist approvals are given.
+   */
+  exitRecoveryMode: ColonyClient.Sender<
+    {
+      newVersion: number, // Resolver version to upgrade to (>= current version)
+    },
+    {},
+    ColonyClient,
+  >;
+  /*
+    Set new colony recovery role. Can only be called by the founder role.
+   */
+  setRecoveryRole: ColonyClient.Sender<
+    {
+      user: Address, // The user we want to give a recovery role to.
+    },
+    {},
+    ColonyClient,
+  >;
+  /*
+    Set new colony recovery role. Can only be called by the founder role.
+   */
+  setRewardInverse: ColonyClient.Sender<
+    {
+      rewardInverse: BigNumber, // The inverse of the reward
+    },
+    { ColonyRewardInverseSet: ColonyRewardInverseSet },
+    ColonyClient,
+  >;
+  /*
+    Remove colony recovery role. Can only be called by the founder role.
+   */
+  removeRecoveryRole: ColonyClient.Sender<
+    {
+      user: Address, // The user we want to remove the recovery role from.
+    },
+    {},
+    ColonyClient,
+  >;
+  /*
+    Returns the number of recovery roles.
+  */
+  getRecoveryRolesCount: ColonyClient.Caller<
+    {},
+    {
+      count: number, // Number of users with the recovery role (excluding owner)
+    },
+    ColonyClient,
+  >;
+  /*
+    Is the colony in recovery mode?
+  */
+  isInRecoveryMode: ColonyClient.Caller<
+    {},
+    {
+      inRecoveryMode: boolean, // Return true if recovery mode is active, false otherwise
+    },
+    ColonyClient,
+  >;
+  /*
+    Update the value of an arbitrary storage variable. This can only be called by a user with the recovery role. Certain critical variables are protected from editing in this function.
+  */
+  setStorageSlotRecovery: ColonyClient.Sender<
+    {
+      slot: number, // Address of storage slot to be updated.
+      value: HexString, // Word of data to be set.
+    },
+    {},
+    ColonyClient,
+  >;
 
   /*
     Gets the colony's Authority contract address
@@ -133,16 +255,6 @@ export default class ColonyClient extends ContractClient {
     {},
     {
       version: number, // The version number.
-    },
-    ColonyClient,
-  >;
-  /*
-    Returns the number of recovery roles.
-  */
-  getRecoveryRolesCount: ColonyClient.Caller<
-    {},
-    {
-      count: number, // Number of users with the recovery role (excluding owner)
     },
     ColonyClient,
   >;
@@ -344,6 +456,16 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
+    Return 1 / the reward to pay out from revenue. e.g. if the fee is 1% (or 0.01), return 100
+  */
+  getRewardInverse: ColonyClient.Caller<
+    {},
+    {
+      rewardInverse: BigNumber, // The inverse of the reward
+    },
+    ColonyClient,
+  >;
+  /*
     Gets the address of the colony's official token contract.
   */
   getToken: ColonyClient.Caller<
@@ -394,21 +516,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       specificationHash: IPFSHash, // digest of the task's hashed specification.
     },
-    { TaskBriefChanged: TaskBriefChanged },
-    ColonyClient,
-  >;
-  /*
-    Put the colony into recovery mode. Can only be called by user with a recovery role.
-   */
-  enterRecoveryMode: ColonyClient.Sender<{}, {}, ColonyClient>;
-  /*
-    Exit recovery mode. Can be called by anyone if enough whitelist approvals are given.
-   */
-  exitRecoveryMode: ColonyClient.Sender<
-    {
-      newVersion: number, // Resolver version to upgrade to (>= current version)
-    },
-    {},
+    { TaskBriefSet: TaskBriefSet },
     ColonyClient,
   >;
   /*
@@ -423,13 +531,13 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Set a new colony owner role. There can only be one address assigned to owner role at a time. Whoever calls this function will lose their owner role. Can be called by owner role.
+    Set a new colony founder role. There can only be one address assigned to the founder role at a time. Whoever calls this function will lose their founder role. Can be called by founder role.
   */
-  setOwnerRole: ColonyClient.Sender<
+  setFounderRole: ColonyClient.Sender<
     {
-      user: Address, // User we want to give an owner role to
+      user: Address, // User we want to give a founder role to
     },
-    {},
+    { ColonyFounderRoleSet: ColonyFounderRoleSet },
     ColonyClient,
   >;
   /*
@@ -439,11 +547,11 @@ export default class ColonyClient extends ContractClient {
     {
       user: Address, // User we want to give an admin role to
     },
-    {},
+    { ColonyAdminRoleSet: ColonyAdminRoleSet },
     ColonyClient,
   >;
   /*
-    Set a new colony recovery role. Can be called by an owner role.
+    Set a new colony recovery role. Can be called by the founder role.
   */
   setRecoveryRole: ColonyClient.Sender<
     {
@@ -453,23 +561,13 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
   >;
   /*
-    Remove a colony admin role. Can only be called by an owner role.
+    Remove a colony admin role. Can only be called by the founder role.
   */
   removeAdminRole: ColonyClient.Sender<
     {
       user: Address, // User we want to remove an admin role from
     },
-    {},
-    ColonyClient,
-  >;
-  /*
-    Remove a colony recovery role. Can only be called by an owner role.
-  */
-  removeRecoveryRole: ColonyClient.Sender<
-    {
-      user: Address, // User we want to remove a recovery role from
-    },
-    {},
+    { ColonyAdminRoleRemoved: ColonyAdminRoleRemoved },
     ColonyClient,
   >;
   /*
@@ -480,7 +578,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       domainId: number, // Integer domainId.
     },
-    { TaskDomainChanged: TaskDomainChanged },
+    { TaskDomainSet: TaskDomainSet },
     ColonyClient,
   >;
   /*
@@ -491,7 +589,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       dueDate: Date, // Due date.
     },
-    { TaskDueDateChanged: TaskDueDateChanged },
+    { TaskDueDateSet: TaskDueDateSet },
     ColonyClient,
   >;
   /*
@@ -502,7 +600,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       user: Address, // address of the user.
     },
-    { TaskRoleUserChanged: TaskRoleUserChanged },
+    { TaskRoleUserSet: TaskRoleUserSet },
     ColonyClient,
   >;
   /*
@@ -513,7 +611,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       user: Address, // address of the user.
     },
-    { TaskRoleUserChanged: TaskRoleUserChanged },
+    { TaskRoleUserSet: TaskRoleUserSet },
     ColonyClient,
   >;
   /*
@@ -524,7 +622,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       user: Address, // address of the user.
     },
-    { TaskRoleUserChanged: TaskRoleUserChanged },
+    { TaskRoleUserSet: TaskRoleUserSet },
     ColonyClient,
   >;
   /*
@@ -535,7 +633,7 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // Integer taskId.
       skillId: number, // Integer skillId.
     },
-    { TaskSkillChanged: TaskSkillChanged },
+    { TaskSkillSet: TaskSkillSet },
     ColonyClient,
   >;
   /*
@@ -550,7 +648,7 @@ export default class ColonyClient extends ContractClient {
       workerAmount: BigNumber, // Payout amount for the worker.
     },
     {
-      TaskWorkerPayoutChanged: TaskWorkerPayoutChanged,
+      TaskPayoutSet: TaskPayoutSet,
     },
     ColonyClient,
   >;
@@ -563,7 +661,7 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
-    { TaskWorkerPayoutChanged: TaskWorkerPayoutChanged },
+    { TaskPayoutSet: TaskPayoutSet },
     ColonyClient,
   >;
   /*
@@ -575,7 +673,7 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
-    { TaskWorkerPayoutChanged: TaskWorkerPayoutChanged },
+    { TaskPayoutSet: TaskPayoutSet },
     ColonyClient,
   >;
   /*
@@ -587,7 +685,7 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // Address to send funds from, e.g. the token's contract address, or empty address (`0x0` for Ether)
       amount: BigNumber, // Amount to be paid.
     },
-    { TaskWorkerPayoutChanged: TaskWorkerPayoutChanged },
+    { TaskPayoutSet: TaskPayoutSet },
     ColonyClient,
   >;
   /*
@@ -597,7 +695,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId.
     },
-    { TaskRoleUserChanged: TaskRoleUserChanged },
+    { TaskRoleUserSet: TaskRoleUserSet },
     ColonyClient,
   >;
   /*
@@ -607,7 +705,7 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // Integer taskId.
     },
-    { TaskRoleUserChanged: TaskRoleUserChanged },
+    { TaskRoleUserSet: TaskRoleUserSet },
     ColonyClient,
   >;
   /*
@@ -726,7 +824,7 @@ export default class ColonyClient extends ContractClient {
     {
       token: TokenAddress, // Address to claim funds from; empty address (`0x0` for Ether)
     },
-    {},
+    { ColonyFundsClaimed: ColonyFundsClaimed },
     ColonyClient,
   >;
   /*
@@ -749,7 +847,7 @@ export default class ColonyClient extends ContractClient {
       amount: BigNumber, // Amount of funds to move.
       token: TokenAddress, // Address of the token contract (`0x0` value indicates Ether).
     },
-    {},
+    { ColonyFundsMovedBetweenFundingPots: ColonyFundsMovedBetweenFundingPots },
     ColonyClient,
   >;
   /*
@@ -785,18 +883,6 @@ export default class ColonyClient extends ContractClient {
     {},
     ColonyClient,
   >;
-
-  /*
-    Update the value of an arbitrary storage variable. This can only be called by a user with the recovery role. Certain critical variables are protected from editing in this function.
-  */
-  setStorageSlotRecovery: ColonyClient.Sender<
-    {
-      slot: number, // Address of storage slot to be updated.
-      value: HexString, // Word of data to be set.
-    },
-    {},
-    ColonyClient,
-  >;
   /*
     Set the colony token. Secured function to authorised members. Note that if the `mint` functionality is to be controlled through the colony, control has to be transferred to the colony after this call.
   */
@@ -814,29 +900,37 @@ export default class ColonyClient extends ContractClient {
     {
       newVersion: number,
     },
-    {},
+    { ColonyUpgraded: ColonyUpgraded },
     ColonyClient,
   >;
 
   events: {
+    ColonyAdminRoleRemoved: ColonyAdminRoleRemoved,
+    ColonyFundsClaimed: ColonyFundsClaimed,
+    ColonyFundsMovedBetweenFundingPots: ColonyFundsMovedBetweenFundingPots,
+    ColonyInitialised: ColonyInitialised,
     ColonyLabelRegistered: ColonyLabelRegistered,
+    ColonyRewardInverseSet: ColonyRewardInverseSet,
+    ColonyUpgraded: ColonyUpgraded,
     DomainAdded: DomainAdded,
     Mint: Mint,
     PotAdded: PotAdded,
+    RewardPayoutClaimed: RewardPayoutClaimed,
+    RewardPayoutCycleEnded: RewardPayoutCycleEnded,
     RewardPayoutCycleStarted: RewardPayoutCycleStarted,
     SkillAdded: SkillAdded,
     TaskAdded: TaskAdded,
-    TaskBriefChanged: TaskBriefChanged,
+    TaskBriefSet: TaskBriefSet,
     TaskCanceled: TaskCanceled,
     TaskCompleted: TaskCompleted,
     TaskDeliverableSubmitted: TaskDeliverableSubmitted,
-    TaskDomainChanged: TaskDomainChanged,
-    TaskDueDateChanged: TaskDueDateChanged,
+    TaskDomainSet: TaskDomainSet,
+    TaskDueDateSet: TaskDueDateSet,
     TaskFinalized: TaskFinalized,
     TaskPayoutClaimed: TaskPayoutClaimed,
-    TaskRoleUserChanged: TaskRoleUserChanged,
-    TaskSkillChanged: TaskSkillChanged,
-    TaskWorkerPayoutChanged: TaskWorkerPayoutChanged,
+    TaskPayoutSet: TaskPayoutSet,
+    TaskRoleUserSet: TaskRoleUserSet,
+    TaskSkillSet: TaskSkillSet,
     TaskWorkRatingRevealed: TaskWorkRatingRevealed,
     Transfer: Transfer,
   };
@@ -898,6 +992,8 @@ export default class ColonyClient extends ContractClient {
   }
 
   initializeContractMethods() {
+    addRecoveryMethods(this);
+
     this.getTask = new GetTask({ client: this });
 
     const makeTaskCaller = (
@@ -950,10 +1046,6 @@ export default class ColonyClient extends ContractClient {
       functionName: 'version',
       output: [['version', 'number']],
     });
-    this.addCaller('getRecoveryRolesCount', {
-      functionName: 'numRecoveryRoles',
-      output: [['count', 'number']],
-    });
     this.addCaller('generateSecret', {
       input: [['salt', 'string'], ['value', 'number']],
       output: [['secret', 'hexString']],
@@ -997,6 +1089,9 @@ export default class ColonyClient extends ContractClient {
         ['blockNumber', 'number'],
       ],
     });
+    this.addCaller('getRewardInverse', {
+      output: [['rewardInverse', 'bigNumber']],
+    });
     this.addCaller('getTaskCount', {
       output: [['count', 'number']],
     });
@@ -1010,29 +1105,32 @@ export default class ColonyClient extends ContractClient {
     this.addEvent('TaskAdded', [['taskId', 'number']]);
     this.addEvent('TaskCompleted', [['taskId', 'number']]);
     this.addEvent('RewardPayoutCycleStarted', [['payoutId', 'number']]);
-    this.addEvent('TaskBriefChanged', [
+    this.addEvent('RewardPayoutCycleEnded', [['payoutId', 'number']]);
+    this.addEvent('TaskBriefSet', [
       ['taskId', 'number'],
       ['specificationHash', 'ipfsHash'],
     ]);
-    this.addEvent('TaskDueDateChanged', [
+    this.addEvent('TaskDueDateSet', [
       ['taskId', 'number'],
       ['dueDate', 'date'],
     ]);
-    this.addEvent('TaskDomainChanged', [
+    this.addEvent('TaskDomainSet', [
       ['taskId', 'number'],
       ['domainId', 'number'],
     ]);
-    this.addEvent('TaskSkillChanged', [
+    this.addEvent('TaskSkillSet', [
       ['taskId', 'number'],
       ['skillId', 'number'],
     ]);
-    this.addEvent('TaskRoleUserChanged', [
+    this.addEvent('TaskRoleUserSet', [
       ['taskId', 'number'],
       ['role', 'number'],
       ['user', 'tokenAddress'], // XXX because 0x0 is valid
     ]);
-    this.addEvent('TaskWorkerPayoutChanged', [
+    this.addEvent('TaskPayoutSet', [
       ['taskId', 'number'],
+      // $FlowFixMe
+      ['role', 'role'],
       ['token', 'tokenAddress'],
       ['amount', 'number'],
     ]);
@@ -1055,6 +1153,30 @@ export default class ColonyClient extends ContractClient {
     ]);
     this.addEvent('TaskFinalized', [['taskId', 'number']]);
     this.addEvent('TaskCanceled', [['taskId', 'number']]);
+    this.addEvent('ColonyTokenSet', [['token', 'tokenAddress']]);
+    this.addEvent('ColonyInitialised', [['colonyNetwork', 'address']]);
+    this.addEvent('ColonyUpgraded', [
+      ['oldVersion', 'number'],
+      ['newVersion', 'number'],
+    ]);
+    this.addEvent('ColonyFounderSet', [
+      ['oldFounder', 'address'],
+      ['newFounder', 'address'],
+    ]);
+    this.addEvent('ColonyAdminRoleSet', [['user', 'address']]);
+    this.addEvent('ColonyAdminRoleRemoved', [['user', 'address']]);
+    this.addEvent('ColonyFundsMovedBetweenFundingPots', [
+      ['fromPot', 'number'],
+      ['toPot', 'number'],
+      ['amount', 'bigNumber'],
+      ['token', 'tokenAddress'],
+    ]);
+    this.addEvent('ColonyFundsClaimed', [
+      ['token', 'tokenAddress'],
+      ['fee', 'bigNumber'],
+      ['payoutRemainder', 'bigNumber'],
+    ]);
+    this.addEvent('ColonyRewardInverseSet', [['rewardInverse', 'bigNumber']]);
 
     // XXX The SkillAdded/ColonyLabelRegistered events (and their underlying
     // interfaces) are defined on the network client, but methods like
@@ -1153,9 +1275,6 @@ export default class ColonyClient extends ContractClient {
         ['workerAmount', 'bigNumber'],
       ],
     });
-    this.addSender('setStorageSlotRecovery', {
-      input: [['slot', 'number'], ['value', 'hexString']],
-    });
     this.addSender('setToken', {
       input: [['token', 'tokenAddress']],
     });
@@ -1181,28 +1300,21 @@ export default class ColonyClient extends ContractClient {
     this.addSender('registerColonyLabel', {
       input: [['colonyName', 'string'], ['orbitDBPath', 'string']],
     });
-    this.addSender('exitRecoveryMode', {
-      input: [[]],
-    });
-    this.addSender('approveExitRecovery', {});
-    this.addSender('enterRecoveryMode', {});
-    this.addSender('setOwnerRole', {
+    this.addSender('setFounderRole', {
       input: [['user', 'address']],
     });
     this.addSender('setAdminRole', {
       input: [['user', 'address']],
     });
-    this.addSender('setRecoveryRole', {
-      input: [['user', 'address']],
-    });
     this.addSender('removeAdminRole', {
-      input: [['user', 'address']],
-    });
-    this.addSender('removeRecoveryRole', {
       input: [['user', 'address']],
     });
     this.addSender('upgrade', {
       input: [['newVersion', 'number']],
+    });
+    this.addSender('initialise', {
+      functionName: 'initialiseColony',
+      input: [['colonyNetwork', 'address']],
     });
 
     // Remove duplicate/invalid signees and normalise lowercase

--- a/packages/colony-js-client/src/addRecoveryMethods.js
+++ b/packages/colony-js-client/src/addRecoveryMethods.js
@@ -1,0 +1,33 @@
+/* @flow */
+
+import ContractClient from '@colony/colony-js-contract-client';
+
+/*
+ * Add methods from `IRecovery.sol` to a given `ContractClient`.
+ */
+const addRecoveryMethods = (client: ContractClient) => {
+  client.addCaller('getRecoveryRolesCount', {
+    functionName: 'numRecoveryRoles',
+    output: [['count', 'number']],
+  });
+  client.addCaller('isInRecoveryMode', {
+    output: [['inRecoveryMode', 'boolean']],
+  });
+
+  client.addSender('approveExitRecovery', {});
+  client.addSender('enterRecoveryMode', {});
+  client.addSender('exitRecoveryMode', {
+    input: [[]],
+  });
+  client.addSender('removeRecoveryRole', {
+    input: [['user', 'address']],
+  });
+  client.addSender('setRecoveryRole', {
+    input: [['user', 'address']],
+  });
+  client.addSender('setStorageSlotRecovery', {
+    input: [['slot', 'number'], ['value', 'hexString']],
+  });
+};
+
+export default addRecoveryMethods;


### PR DESCRIPTION
## Description

* Add `ColonyClient` events:
  * `ColonyAdminRoleRemoved`
  * `ColonyAdminRoleSet`
  * `ColonyFounderRoleSet`
  * `ColonyFundsClaimed`
  * `ColonyFundsMovedBetweenFundingPots`
  * `ColonyInitialised`
  * `ColonyRewardInverseSet`
  * `ColonyUpgraded`
  * `RewardPayoutClaimed`
* Add `ColonyNetworkClient` events:
  * `ColonyNetworkInitialised`
  * `ColonyVersionAdded`
  * `MetaColonyCreated`
  * `MiningCycleResolverSet`
  * `NetworkFeeInverseSet`
  * `ReputationMiningCycleComplete`
  * `ReputationMiningInitialised`
  * `ReputationRootHashSet`
  * `TokenLockingAddressSet`
* Add recovery methods to `ColonyNetworkClient`/`ColonyClient`:
  * `approveExitRecovery`
  * `enterRecoveryMode`
  * `exitRecoveryMode`
  * `getRecoveryRolesCount`
  * `isInRecoveryMode`
  * `removeRecoveryRole`
  * `setRecoveryRole`
  * `setStorageSlotRecovery`
* Rename old events from e.g. `TaskBriefChanged` to `TaskBriefSet`

