### PR TITLE
Update token name and symbol param type

### DIFF
--- a/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
+++ b/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
@@ -18,8 +18,8 @@ export default class GetTokenInfo extends ContractClient.Caller<
       functionName: 'getTokenInfo',
       input: [],
       output: [
-        ['name', 'string'],
-        ['symbol', 'string'],
+        ['name', 'hexString'],
+        ['symbol', 'hexString'],
         ['decimals', 'number'],
       ],
       ...params,


### PR DESCRIPTION
## Description

This pull request updates the token `name` and `symbol` param type to `hexString`, which resolves the `Invalid UTF-8 detected` error when attempting to use the `getTokenInfo` method.

## TODO

- [ ] Maybe convert the `hexString`

## Resolves

#305
