### PR TITLE
Handle invalid UTF8 hex strings

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 <PROJECT_ROOT>/packages/colonyDapp/.*
+<PROJECT_ROOT>/node_modules/oboe/test/json/incomplete.json
 
 [include]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   * `setRecoveryRole`
   * `setStorageSlotRecovery`
 
+**Bug fixes**
+
+* Improved handling of invalid UTF8 hex strings
+
 ## v1.7.5
 
 **Bug fixes**

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -470,7 +470,7 @@ An instance of a `ContractResponse`
 
 ### `setRewardInverse.send({ rewardInverse }, options)`
 
-Set new colony recovery role. Can only be called by the founder role.
+Set the reward inverse to pay out from revenue. e.g. if the fee is 1% (or 0.01), set 100
 
 **Arguments**
 

--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -148,6 +148,8 @@ describe('Parameter types', () => {
     expect(convertOutputValue('a', 'string')).toBe('a');
     expect(convertOutputValue('0x434f4c4e59', 'string')).toBe('COLNY');
     expect(convertOutputValue('0x00', 'string')).toBe(null);
+    const invalidUtf8 = '0x712387612873682176387216312';
+    expect(convertOutputValue(invalidUtf8, 'string')).toBe(invalidUtf8);
 
     // empty strings are cleaned:
     expect(convertOutputValue('', 'string')).toBe(null);

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -91,7 +91,12 @@ const PARAM_TYPE_MAP: {
     },
     convertOutput(value: any) {
       if (isHexStrict(value)) {
-        return isEmptyHexString(value) ? null : hexToUtf8(value);
+        if (isEmptyHexString(value)) return null;
+        try {
+          return hexToUtf8(value);
+        } catch (error) {
+          // ignore error: not a UTF8-encoded value
+        }
       }
       return typeof value === 'string' && value.length ? value : null;
     },

--- a/packages/colony-js-contract-loader/src/ContractLoader.js
+++ b/packages/colony-js-contract-loader/src/ContractLoader.js
@@ -74,7 +74,7 @@ export default class ContractLoader {
     );
     this._transform = transform;
   }
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable class-methods-use-this,no-unused-vars */
   async _load(
     query: Query,
     requiredProps?: RequiredContractProps, // eslint-disable-line no-unused-vars
@@ -83,6 +83,7 @@ export default class ContractLoader {
       'ContractLoader._load() is expected to be defined in a derived class',
     );
   }
+  /* eslint-enable class-methods-use-this,no-unused-vars */
   async load(
     query: Query,
     requiredProps?: RequiredContractProps = DEFAULT_REQUIRED_CONTRACT_PROPS,


### PR DESCRIPTION
## Description

* Handle invalid UTF8 hex strings for the `string` param type (return them as-is)

## Other changes

* Fix an eslint issue
* Fix a flow issue

Resolves #305 
