### PR TITLE
Update `cancelTask` to multisig sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* Define `ColonyClient.cancelTask` as a `MultisigSender` (`@colony/colony-js-client`)
+
+## v1.8.0
+
 **Maintenance**
 
 * Add `ColonyClient` events:

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -827,25 +827,6 @@ An instance of a `ContractResponse`
 
 
 
-### `cancelTask.send({ taskId }, options)`
-
-Cancels a task.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|taskId|number|Integer taskId.|
-
-**Returns**
-
-An instance of a `ContractResponse` which will eventually receive the following event data:
-
-|Event data|Type|Description|
-|---|---|---|
-|taskId|number|The task ID of the task that was canceled.|
-|TaskCanceled|object|Contains the data defined in [TaskCanceled](#events-TaskCanceled)|
-
 ### `finalizeTask.send({ taskId }, options)`
 
 Finalizes a task, allowing roles to claim payouts and prohibiting all further changes to the task.
@@ -1316,6 +1297,25 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|number|The role that changed for the task.|
 |user|Address|The user with the role that changed for the task.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#events-TaskRoleUserSet)|
+
+### `cancelTask.startOperation({ taskId })`
+
+Cancels a task.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|taskId|number|Integer taskId.|
+
+**Returns**
+
+An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
+
+|Event Data|Type|Description|
+|---|---|---|
+|taskId|number|The task ID of the task that was canceled.|
+|TaskCanceled|object|Contains the data defined in [TaskCanceled](#events-TaskCanceled)|
 
   
 ## Events

--- a/docs/_Docs_TaskLifecycle.md
+++ b/docs/_Docs_TaskLifecycle.md
@@ -23,7 +23,7 @@ Tasks have 3 'roles' that may be assigned to addresses: manager, evaluator, and 
 | removeTaskWorkerRole     | X       |           | *      |
 | removeTaskEvaluatorRole  | X       | *         |        |
 | submitTaskDeliverable    |         |           | X      |
-| cancelTask               | X       |           |        |
+| cancelTask               | X       |           | *      |
 | finalizeTask             | X       | X         | X      |
 
 ( * ) - If the task has been assigned to a role already, the operation requires this role's signature.
@@ -49,12 +49,6 @@ Once a task has been created, it can be examined:
 
 ```js
 await colonyClient.getTask.call({ taskId });
-```
-
-At any time before a task is finalized, the task can be canceled, which allows any funding to be returned to the colony and halts any further modification of the task.
-
-```js
-await colonyClient.cancelTask.send({ taskId });
 ```
 
 ## Modification
@@ -189,6 +183,15 @@ await colonyClient.claimPayout.send({
   token,
 });
 ```
+
+## Cancel
+
+At any time before a task is finalized, the task can be canceled, which allows any funding to be returned to the colony and halts any further modification of the task. Cancelling a task must be approved by the manager and the worker.
+
+```js
+await colonyClient.cancelTask.startOperation({ taskId });
+```
+
 
 ## Using IPFS for a Task Specification
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -789,7 +789,7 @@ export default class ColonyClient extends ContractClient {
   /*
     Cancels a task.
   */
-  cancelTask: ColonyClient.Sender<
+  cancelTask: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
     },
@@ -1212,9 +1212,6 @@ export default class ColonyClient extends ContractClient {
     this.addSender('assignWorkRating', {
       input: [['taskId', 'number']],
     });
-    this.addSender('cancelTask', {
-      input: [['taskId', 'number']],
-    });
     this.addSender('claimColonyFunds', {
       input: [['token', 'tokenAddress']],
     });
@@ -1347,6 +1344,7 @@ export default class ColonyClient extends ContractClient {
         nonceFunctionName: 'getTaskChangeNonce',
         nonceInput: [['taskId', 'number']],
       });
+    makeExecuteTaskChange('cancelTask', [], [MANAGER_ROLE, WORKER_ROLE]);
     makeExecuteTaskChange(
       'setTaskSkill',
       [['skillId', 'number']],


### PR DESCRIPTION
## Description

Update `cancelTask` to multisig sender.

## Resolves

```
Runtime Error: revert
Revert reason: colony-not-self
```
