### PR TITLE
Update `setTaskDomain` to multisig sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 
+* Define `ColonyClient.addDomain` as a `MultisigSender` (`@colony/colony-js-client`)
 * Define `ColonyClient.cancelTask` as a `MultisigSender` (`@colony/colony-js-client`)
 
 ## v1.8.0

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -675,27 +675,6 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |user|Address|The removed colony admin user|
 |ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#events-ColonyAdminRoleRemoved)|
 
-### `setTaskDomain.send({ taskId, domainId }, options)`
-
-Every task must belong to a single existing Domain. This can only be called by the manager of the task.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|taskId|number|Integer taskId.|
-|domainId|number|Integer domainId.|
-
-**Returns**
-
-An instance of a `ContractResponse` which will eventually receive the following event data:
-
-|Event data|Type|Description|
-|---|---|---|
-|taskId|number|The task ID.|
-|domainId|number|The task's new domain ID.|
-|TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#events-TaskDomainSet)|
-
 ### `setAllTaskPayouts.send({ taskId, token, managerAmount, evaluatorAmount, workerAmount }, options)`
 
 Set the payouts for the task manager, evaluator and worker in one transaction, for a specific token address. This can only be called by the task manager, and only if the evaluator and worker roles are either unassigned or the same as the manager.
@@ -1075,6 +1054,27 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |specificationHash|string|The IPFS hash of the task's new specification.|
 |TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#events-TaskBriefSet)|
+
+### `setTaskDomain.startOperation({ taskId, domainId })`
+
+Every task must belong to a single existing Domain. This can only be called by the manager of the task.
+
+**Arguments**
+
+|Argument|Type|Description|
+|---|---|---|
+|taskId|number|Integer taskId.|
+|domainId|number|Integer domainId.|
+
+**Returns**
+
+An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
+
+|Event Data|Type|Description|
+|---|---|---|
+|taskId|number|The task ID.|
+|domainId|number|The task's new domain ID.|
+|TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#events-TaskDomainSet)|
 
 ### `setTaskDueDate.startOperation({ taskId, dueDate })`
 

--- a/docs/_Docs_TaskLifecycle.md
+++ b/docs/_Docs_TaskLifecycle.md
@@ -8,28 +8,29 @@ The most useful abstraction within a colony is the `task`. Tasks are used to coo
 
 Tasks have 3 'roles' that may be assigned to addresses: manager, evaluator, and worker. Each role and its permissions are outlined in the table below:
 
-|                          | Manager | Evaluator | Worker |
-|--------------------------|---------|-----------|--------|
-| cancelTask               | X       |           | *      |
-| setTaskBrief             | X       |           | *      |
-| setTaskDomain            | X       |           | *      |
-| setTaskSkill             | X       |           | *      |
-| setTaskDueDate           | X       |           | *      |
-| setTaskManagerPayout     | X       |           | *      |
-| setTaskEvaluatorPayout   | X       | *         |        |
-| setTaskWorkerPayout      | X       |           | *      |
-| setTaskManagerRole       | X       |           |        |
-| setTaskEvaluatorRole     | X       | *         |        |
-| setTaskWorkerRole        | X       |           | *      |
-| removeTaskWorkerRole     | X       |           | *      |
-| removeTaskEvaluatorRole  | X       | *         |        |
-| submitTaskDeliverable    |         |           | X      |
-| submitTaskWorkRating     | X       | X         | X      |
-| revealTaskWorkRating     | X       | X         | X      |
-| claimPayout              | X       | X         | X      |
-| finalizeTask             | X       | X         | X      |
+|                          | Manager | Evaluator | Worker | Other                      |
+|--------------------------|---------|-----------|--------|----------------------------|
+| cancelTask               | *       |           | *      |                            |
+| setTaskBrief             | *       |           | *      |                            |
+| setTaskDomain            | *       |           | *      |                            |
+| setTaskSkill             | *       |           | *      |                            |
+| setTaskDueDate           | *       |           | *      |                            |
+| setTaskManagerPayout     | *       |           | *      |                            |
+| setTaskEvaluatorPayout   | *       | *         |        |                            |
+| setTaskWorkerPayout      | *       |           | *      |                            |
+| setTaskManagerRole       | *       |           |        | * proposed manager (admin) |
+| setTaskEvaluatorRole     | *       | *         |        | * proposed evaluator       |
+| setTaskWorkerRole        | *       |           | *      | * proposed worker          |
+| removeTaskWorkerRole     | *       |           | *      |                            |
+| removeTaskEvaluatorRole  | *       | *         |        |                            |
+| submitTaskDeliverable    |         |           | X      |                            |
+| submitTaskWorkRating     | X       | X         | X      |                            |
+| revealTaskWorkRating     | X       | X         | X      |                            |
+| claimPayout              | X       | X         | X      |                            |
+| finalizeTask             |         |           |        |                            |
 
-( * ) - If the task has been assigned to a role already, the operation requires this role's signature.
+( X ) - Only this user can call the method. If there is no X in the row, any user can call the method.
+( * ) - If the task has already been assigned to a role, the operation requires this role's signature.
 
 
 ==TOC==

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -587,7 +587,7 @@ export default class ColonyClient extends ContractClient {
   /*
     Every task must belong to a single existing Domain. This can only be called by the manager of the task.
   */
-  setTaskDomain: ColonyClient.Sender<
+  setTaskDomain: ColonyClient.MultisigSender<
     {
       taskId: number, // Integer taskId.
       domainId: number, // Integer domainId.
@@ -1266,9 +1266,6 @@ export default class ColonyClient extends ContractClient {
         ['salt', 'string'],
       ],
     });
-    this.addSender('setTaskDomain', {
-      input: [['taskId', 'number'], ['domainId', 'number']],
-    });
     this.addSender('setAllTaskPayouts', {
       input: [
         ['taskId', 'number'],
@@ -1345,6 +1342,11 @@ export default class ColonyClient extends ContractClient {
         nonceInput: [['taskId', 'number']],
       });
     makeExecuteTaskChange('cancelTask', [], [MANAGER_ROLE, WORKER_ROLE]);
+    makeExecuteTaskChange(
+      'setTaskDomain',
+      [['domainId', 'number']],
+      [MANAGER_ROLE, WORKER_ROLE],
+    );
     makeExecuteTaskChange(
       'setTaskSkill',
       [['skillId', 'number']],


### PR DESCRIPTION
## Description

Update `setTaskDomain` to multisig sender.

## Other Changes

Clean up and improve task lifecycle roles table:

|                          | Manager | Evaluator | Worker | Other                      |
|--------------------------|---------|-----------|--------|----------------------------|
| cancelTask               | *       |           | *      |                            |
| setTaskBrief             | *       |           | *      |                            |
| setTaskDomain            | *       |           | *      |                            |
| setTaskSkill             | *       |           | *      |                            |
| setTaskDueDate           | *       |           | *      |                            |
| setTaskManagerPayout     | *       |           | *      |                            |
| setTaskEvaluatorPayout   | *       | *         |        |                            |
| setTaskWorkerPayout      | *       |           | *      |                            |
| setTaskManagerRole       | *       |           |        | * proposed manager (admin) |
| setTaskEvaluatorRole     | *       | *         |        | * proposed evaluator       |
| setTaskWorkerRole        | *       |           | *      | * proposed worker          |
| removeTaskWorkerRole     | *       |           | *      |                            |
| removeTaskEvaluatorRole  | *       | *         |        |                            |
| submitTaskDeliverable    |         |           | X      |                            |
| submitTaskWorkRating     | X       | X         | X      |                            |
| revealTaskWorkRating     | X       | X         | X      |                            |
| claimPayout              | X       | X         | X      |                            |
| finalizeTask             |         |           |        |                            |

( X ) - Only this user can call the method. If there is no X in the row, any user can call the method.
( * ) - If the task has already been assigned to a role, the operation requires this role's signature.

## Resolves

```
Runtime Error: revert
Revert reason: colony-not-self
```
