### PR TITLE
Add `getAccounts` method to TrufflepigLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**New features**
+
+* Add `getAccounts` method to `TrufflepigLoader` (`@colony/colony-js-contract-loader-http`)
 
 ## v1.8.1
 

--- a/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
@@ -20,9 +20,13 @@ export default class TrufflepigLoader extends HttpLoader {
     this._host = host;
   }
 
-  async getAccount(index: number) {
+  async getAccounts() {
     const response = await fetch(`${this._host}/accounts`);
-    const accounts = await response.json();
+    return response.json();
+  }
+
+  async getAccount(index: number) {
+    const accounts = await this.getAccounts();
 
     const addresses = Object.keys(accounts);
     if (!addresses[index])


### PR DESCRIPTION
## Description

This PR adds a public `getAccounts` method in `TrufflepigLoader`, which is also used internally by `getAccount`.
