### PR TITLE
Add event log parsing

### DIFF
--- a/packages/colony-js-adapter/index.js
+++ b/packages/colony-js-adapter/index.js
@@ -9,7 +9,11 @@ export type {
   EventCallback,
 } from './interface/EventHandlers';
 export type { Contract as IContract } from './interface/Contract';
-export type { Provider as IProvider } from './interface/Provider';
+export type {
+  Provider as IProvider,
+  Log,
+  LogFilter,
+} from './interface/Provider';
 export type { Signature } from './interface/Signature';
 export type { Transaction } from './interface/Transaction';
 export type { TransactionReceipt } from './interface/TransactionReceipt';

--- a/packages/colony-js-adapter/interface/Contract.js
+++ b/packages/colony-js-adapter/interface/Contract.js
@@ -18,7 +18,7 @@ export interface Contract {
   interface: {
     events: {
       [eventName: string]: {
-        parse(topics: Array<string>, data: Object): Object,
+        parse(topics: Array<string>, data: string): Object,
         topics: Array<string>,
       },
     },

--- a/packages/colony-js-adapter/interface/Provider.js
+++ b/packages/colony-js-adapter/interface/Provider.js
@@ -9,8 +9,8 @@ import type { TransactionReceipt } from './TransactionReceipt';
 export type LogFilter = {
   address?: string,
   fromBlock?: number,
-  toBlock?: 'latest' | number,
-  topics?: string[],
+  toBlock?: 'latest' | 'pending' | number,
+  topics?: Array<string | Array<string>>,
 };
 
 export type Log = { data: string, topics: string[] };

--- a/packages/colony-js-adapter/interface/Provider.js
+++ b/packages/colony-js-adapter/interface/Provider.js
@@ -6,6 +6,15 @@ import type { Block } from './Block';
 import type { Transaction } from './Transaction';
 import type { TransactionReceipt } from './TransactionReceipt';
 
+export type LogFilter = {
+  address?: string,
+  fromBlock?: number,
+  toBlock?: 'latest' | number,
+  topics?: string[],
+};
+
+export type Log = { data: string, topics: string[] };
+
 export interface Provider {
   name: string;
   chainId: string;
@@ -28,5 +37,6 @@ export interface Provider {
   getTransactionReceipt(transactionHash: string): Promise<TransactionReceipt>;
   waitForTransaction(transactionHash: string): Promise<Transaction>;
   lookupAddress(address: string): Promise<string | null>;
+  getLogs(logFilter: LogFilter): Promise<Log[]>;
   resolveName(ensName: string): Promise<string | null>;
 }

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1165,7 +1165,7 @@ export default class ColonyClient extends ContractClient {
       ['oldVersion', 'number'],
       ['newVersion', 'number'],
     ]);
-    this.addEvent('ColonyFounderSet', [
+    this.addEvent('ColonyFounderRoleSet', [
       ['oldFounder', 'address'],
       ['newFounder', 'address'],
     ]);

--- a/packages/colony-js-client/src/__tests__/ColonyClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyClient.test.js
@@ -7,11 +7,45 @@ import ColonyClient from '../ColonyClient';
 import TokenClient from '../TokenClient';
 import ColonyNetworkClient from '../ColonyNetworkClient';
 
+const colonyEvents = [
+  'DomainAdded',
+  'PotAdded',
+  'TaskAdded',
+  'TaskCompleted',
+  'RewardPayoutCycleStarted',
+  'RewardPayoutCycleEnded',
+  'TaskBriefSet',
+  'TaskDueDateSet',
+  'TaskDomainSet',
+  'TaskSkillSet',
+  'TaskRoleUserSet',
+  'TaskPayoutSet',
+  'TaskDeliverableSubmitted',
+  'TaskWorkRatingRevealed',
+  'TaskPayoutClaimed',
+  'TaskFinalized',
+  'TaskCanceled',
+  'ColonyTokenSet',
+  'ColonyInitialised',
+  'ColonyUpgraded',
+  'ColonyFounderSet',
+  'ColonyAdminRoleSet',
+  'ColonyAdminRoleRemoved',
+  'ColonyFundsMovedBetweenFundingPots',
+  'ColonyFundsClaimed',
+  'ColonyRewardInverseSet',
+];
 const contract = {
   interface: {
-    events: {
-      TaskAdded: 'TaskAdded interface',
-    },
+    events: colonyEvents.reduce(
+      (acc, eventName, i) => ({
+        ...acc,
+        [eventName]: {
+          topics: [`0x${i}`],
+        },
+      }),
+      {},
+    ),
   },
 };
 

--- a/packages/colony-js-client/src/__tests__/ColonyClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyClient.test.js
@@ -28,7 +28,7 @@ const colonyEvents = [
   'ColonyTokenSet',
   'ColonyInitialised',
   'ColonyUpgraded',
-  'ColonyFounderSet',
+  'ColonyFounderRoleSet',
   'ColonyAdminRoleSet',
   'ColonyAdminRoleRemoved',
   'ColonyFundsMovedBetweenFundingPots',

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -17,10 +17,34 @@ jest.mock('../TokenClient');
 describe('ColonyNetworkClient', () => {
   const sandbox = createSandbox();
 
+  const colonyNetworkEvents = [
+    'ColonyAdded',
+    'SkillAdded',
+    'AuctionCreated',
+    'UserLabelRegistered',
+    'ColonyLabelRegistered',
+    'ColonyNetworkInitialised',
+    'TokenLockingAddressSet',
+    'MiningCycleResolverSet',
+    'NetworkFeeInverseSet',
+    'ColonyVersionAdded',
+    'MetaColonyCreated',
+    'ReputationMiningInitialised',
+    'ReputationMiningCycleComplete',
+    'ReputationRootHashSet',
+  ];
   const colonyAddress = '0x123 Colony Lane';
   const contract = {
     interface: {
-      events: {},
+      events: colonyNetworkEvents.reduce(
+        (acc, eventName, i) => ({
+          ...acc,
+          [eventName]: {
+            topics: [`0x${i}`],
+          },
+        }),
+        {},
+      ),
     },
   };
   const deployTransaction = {

--- a/packages/colony-js-contract-client/src/__tests__/ContractClient.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractClient.js
@@ -27,6 +27,13 @@ describe('ContractClient', () => {
     callEstimate = sandbox.fn(async () => gasEstimate);
     callTransaction = sandbox.fn(async () => transaction);
     createTransactionData = sandbox.fn(async () => txData);
+    interface = {
+      events: {
+        myEvent: {
+          topics: ['0xabc'],
+        },
+      },
+    };
   }();
   const query = { contractName: 'MyContract' };
   const adapter = {
@@ -160,8 +167,9 @@ describe('ContractClient', () => {
     );
   });
 
-  test('Events can be defined', () => {
+  test('Events can be defined', async () => {
     const client = new ContractClient({ adapter, contract, options });
+    await client.init();
 
     // Define an event on the client
     client.addEvent('myEvent', [['myEventValue', 'number']]);

--- a/packages/colony-js-contract-client/src/__tests__/ContractEvent.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractEvent.js
@@ -24,7 +24,15 @@ describe('ContractEvent', () => {
   beforeEach(async done => {
     sandbox.clear();
 
-    contract = new MockEmittingContract();
+    contract = new class extends MockEmittingContract {
+      interface = {
+        events: {
+          [eventName]: {
+            topics: ['0xabc'],
+          },
+        },
+      };
+    }();
     adapter = { getContract: sandbox.fn(() => contract) };
     client = new ContractClient({ adapter });
     await client.init();

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
@@ -87,8 +87,8 @@ describe('ContractMethodSender', () => {
     },
   };
   const client = new ContractClient({ contract, adapter });
-  client.addEvent('TaskAdded', [['taskId', 'number']]);
   client._contract = contract;
+  client.addEvent('TaskAdded', [['taskId', 'number']]);
 
   beforeEach(() => sandbox.clear());
 

--- a/packages/colony-js-contract-client/src/classes/ContractEvent.js
+++ b/packages/colony-js-contract-client/src/classes/ContractEvent.js
@@ -3,6 +3,7 @@ import type {
   Event,
   EventArgs,
   EventCallback,
+  Log,
 } from '@colony/colony-js-adapter';
 import { makeAssert } from '@colony/colony-js-utils';
 import ContractClient from '../classes/ContractClient';
@@ -66,6 +67,23 @@ export default class ContractEvent<ParamTypes: Object> {
     const parsedArgs = convertOutputValues(args, argsDef);
     validateParams(parsedArgs, argsDef, assertValid);
     return parsedArgs;
+  }
+
+  get interface() {
+    return this.client.contract.interface.events[this.eventName];
+  }
+
+  /*
+   * Given an array of logs, filter matching topics and parse event data from them.
+   */
+  parseLogs(logs: Log[]): Array<Object> {
+    return logs
+      .filter(({ topics }) =>
+        topics.every(topic => this.interface.topics.includes(topic)),
+      )
+      .map(({ data, topics }) =>
+        this.parse(this.interface.parse(topics, data)),
+      );
   }
 
   parse(args: EventArgs) {


### PR DESCRIPTION
## Description

This PR adds historical event log parsing functionality:

* With a `ContractEvent` instance, given an array of logs, filter matching topics and parse event data from them
* Add a `ContractEvent` getter for the underlying event interface
* Add the `getLogs` method to the `Provider` interface
* Fix the event interface `parse` type

## TODO

- [x] Consider adding a `parseLogs` method on `ContractClient`
- [x] Consider adding a `getLogs` method on `ContractClient` (maybe also parsing the logs?)
