### PR TITLE
Refactor ContractClient.getLogs, split parsing into getEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* The `ColonyFounderRoleSet` event is now named correctly (`@colony/colony-js-client`)
+
 **New features**
 
 * Add `getAccounts` method to `TrufflepigLoader` (`@colony/colony-js-contract-loader-http`)
+* Add event log parsing with `ContractEvent.parseLogs` (`@colony/colony-js-contract-client`)
+* Add historical log fetching with `ContractClient.getLogs`, and optionally also parsing with `.getEvents` (`@colony/colony-js-contract-client`)
 
 ## v1.8.1
 

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -123,7 +123,17 @@ export default class ContractClient {
   }
 
   /**
-   * Get logs from the contract with filter, return parsed event logs.
+   * Get logs with filter, and return parsed event logs.
+   */
+  async getEvents(
+    filter?: LogFilter & { eventNames?: Array<string> } = {},
+  ): Promise<Array<Object>> {
+    const logs = await this.getLogs(filter);
+    return this.parseLogs(logs);
+  }
+
+  /**
+   * Get logs from the contract with filter.
    */
   async getLogs(
     filter?: LogFilter & { eventNames?: Array<string> } = {},
@@ -147,11 +157,10 @@ export default class ContractClient {
     }
 
     // Fetch the logs and parse
-    const logs = await this.adapter.provider.getLogs({
+    return this.adapter.provider.getLogs({
       ...filter,
       topics,
     });
-    return this.parseLogs(logs);
   }
 
   /**


### PR DESCRIPTION
## Description

The `ContractClient.getLogs` method has been refactored with a new `getEvents` method. The former only fetches the relevant logs and does not parse them, useful for if you need access to values from the raw logs (you can then parse with `parseLogs`). The latter also parses the logs and returns events.

## Other changes

* Add changelogs for previous missed fixes
