### PR TITLE
Fix links to multisig docs

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -1034,7 +1034,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
   
 ## Task MultiSig
 
-**All MultiSig functions return an instance of a `MultiSigOperation`.** For a reference please check [here](/colonyjs/docs-multisignature-transactions/).
+**All MultiSig functions return an instance of a `MultiSigOperation`.** For a reference please check [here](/colonyjs/docs-multisignature/).
 ### `setTaskBrief.startOperation({ taskId, specificationHash })`
 
 The task brief, or specification, is a description of the tasks work specification. The description is hashed and stored with the task for future reference in ratings or in the event of a dispute.

--- a/docs/_API_ContractMethodMultiSigSender.md
+++ b/docs/_API_ContractMethodMultiSigSender.md
@@ -6,7 +6,7 @@ order: 8
 
 The `ContractMethodMultisigSender` (short `MutlisigSender`) class is a part of the `ContractClient` to create Multisignature transactions. They are usually created for a `ContractClient` class on its initialization (e.g. the [ColonyClient](/colonyjs/api-colonyclient)) and are associated with a method on the smart contract which requires more than one signature to be executed.
 
-For more info see the [Multisignature](/colonyjs/docs-multisignature-transactions/) docs. Please also check out the [MultisigOperation](/colonyjs/api-multisigoperation/) docs for the signature handling API.
+For more info see the [Multisignature](/colonyjs/docs-multisignature/) docs. Please also check out the [MultisigOperation](/colonyjs/api-multisigoperation/) docs for the signature handling API.
 
 ==TOC==
 

--- a/docs/_API_MultisigOperation.md
+++ b/docs/_API_MultisigOperation.md
@@ -6,7 +6,7 @@ order: 9
 
 The `MultisigOperation` class is a part of the `ContractClient` to handle Multisignature transactions. They are usually created by a `MultisigSender` class and are associated with the sender which created them.
 
-For more info see the [`Multisignature` docs](/colonyjs/docs-multisignature-transactions/). Please also check out the [`ContractMethodMultisigSender` API docs](/colonyjs/api-contractmethodmultisigsender/) to see how to create this.
+For more info see the [`Multisignature` docs](/colonyjs/docs-multisignature/). Please also check out the [`ContractMethodMultisigSender` API docs](/colonyjs/api-contractmethodmultisigsender/) to see how to create this.
 
 ==TOC==
 

--- a/docs/_Docs_TaskLifecycle.md
+++ b/docs/_Docs_TaskLifecycle.md
@@ -141,7 +141,7 @@ For more information about how funding works within a colony, check out [Managin
 
 ### Modify Task
 
-Important changes to a task must be approved by multiple "task roles". Most of the methods that modify a task require multiple signatures before the modification will take affect (see [Multisignature](/colonyjs/docs-multisignature-transactions/) for more information).
+Important changes to a task must be approved by multiple "task roles". Most of the methods that modify a task require multiple signatures before the modification will take affect (see [Multisignature](/colonyjs/docs-multisignature/) for more information).
 
 Task modification methods and the required signatures for each are listed below.
 

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -194,7 +194,7 @@ function printMultiSig(multisig, events) {
   return `
 ## Task MultiSig
 
-**All MultiSig functions return an instance of a \`MultiSigOperation\`.** For a reference please check [here](/colonyjs/docs-multisignature-transactions/).` +
+**All MultiSig functions return an instance of a \`MultiSigOperation\`.** For a reference please check [here](/colonyjs/docs-multisignature/).` +
     multisig
       .map(
         ms => `


### PR DESCRIPTION
Currently in colonyjs docs all the links to multisig description are leading to non-existing page, this PR should fix the issue.