### PR TITLE
Fix task payout events to return amounts as BigNumbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v.NEXT
 
+**Bug fixes**
+
+* `TaskPayoutSet` and `TaskPayoutClaimed` now return token amounts as BigNumbers (`@colony/colony-js-client`)
 
 ## v1.9.0
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -700,7 +700,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The task ID.|
 |role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
 ### `submitTaskDeliverable.send({ taskId, deliverableHash }, options)`
@@ -848,7 +848,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The task ID of the task that was finalized.|
 |role|Role|The role of the work rating.|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 |from|Address|Event data indicating the 'from' address.|
 |to|Address|Event data indicating the 'to' address.|
 |value|BigNumber|Event data indicating the amount transferred.|
@@ -1206,7 +1206,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
 ### `setTaskManagerPayout.startOperation({ taskId, token, amount })`
@@ -1230,7 +1230,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
 ### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
@@ -1254,7 +1254,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The task ID.|
 |role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
 ### `removeTaskWorkerRole.startOperation({ taskId })`
@@ -1452,7 +1452,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |taskId|number|The task ID.|
 |role|Role|The role the payout is for|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 
 
 ### `events.TaskDeliverableSubmitted.addListener(({ taskId, deliverableHash }) => { /* ... */ })`
@@ -1502,7 +1502,7 @@ Refer to the `ContractEvent` class [here](/colonyjs/docs-contractclient/#events)
 |taskId|number|The task ID of the task that was finalized.|
 |role|Role|The role of the work rating.|
 |token|Token address|The token address (0x indicates ether).|
-|amount|number|The token amount.|
+|amount|BigNumber|The token amount.|
 
 
 ### `events.TaskCanceled.addListener(({ taskId }) => { /* ... */ })`

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -74,7 +74,7 @@ type TaskPayoutSet = ContractClient.Event<{
   taskId: number, // The task ID.
   role: Role, // The role the payout is for
   token: TokenAddress, // The token address (0x indicates ether).
-  amount: number, // The token amount.
+  amount: BigNumber, // The token amount.
 }>;
 type TaskDeliverableSubmitted = ContractClient.Event<{
   taskId: number, // The task ID.
@@ -92,7 +92,7 @@ type TaskPayoutClaimed = ContractClient.Event<{
   taskId: number, // The task ID of the task that was finalized.
   role: Role, // The role of the work rating.
   token: TokenAddress, // The token address (0x indicates ether).
-  amount: number, // The token amount.
+  amount: BigNumber, // The token amount.
 }>;
 type TaskCanceled = ContractClient.Event<{
   taskId: number, // The task ID of the task that was canceled.
@@ -1138,7 +1138,7 @@ export default class ColonyClient extends ContractClient {
       // $FlowFixMe
       ['role', 'role'],
       ['token', 'tokenAddress'],
-      ['amount', 'number'],
+      ['amount', 'bigNumber'],
     ]);
     this.addEvent('TaskDeliverableSubmitted', [
       ['taskId', 'number'],
@@ -1155,7 +1155,7 @@ export default class ColonyClient extends ContractClient {
       // $FlowFixMe
       ['role', 'role'],
       ['token', 'tokenAddress'],
-      ['amount', 'number'],
+      ['amount', 'bigNumber'],
     ]);
     this.addEvent('TaskFinalized', [['taskId', 'number']]);
     this.addEvent('TaskCanceled', [['taskId', 'number']]);


### PR DESCRIPTION
## Description

The `TaskPayoutSet` and `TaskPayoutClaimed` events previously returned token `amount`s as `number`s, which would cause an error in cases where the value was greater than the JS `MAX_SAFE_INTEGER`. These values are now `BigNumber`s.

