### PR TITLE
Add contract info and update client methods

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -495,27 +495,6 @@ A promise which resolves to an object containing the following properties:
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
-### `getTransactionCount.call()`
-
-Get the total number of transactions that the colony has made. The total number of transactions is equal to the ID of the last transaction.
-
-
-**Returns**
-
-A promise which resolves to an object containing the following properties:
-
-|Return value|Type|Description|
-|---|---|---|
-|count|number|The total number of transactions that the colony has made.|
-
-**Contract Information**
-
-
-  
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  
-
 ### `getUserRewardPayoutCount.call({ user })`
 
 Get the total number of claimed and waived reward payout cycles for a given user in the colony.

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -81,7 +81,7 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `authority`
-  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/auth.sol)
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -56,6 +56,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|Hex string|A keccak256 hash that keeps the task rating hidden.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getAuthority.call()`
 
 Get the authority contract address associated with the colony.
@@ -68,6 +77,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |address|Address|The address of the authority contract associated with the colony.|
+
+**Network Information**
+
+
+  - Name: `authority`
+  - Contract: `dappsys/auth.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getDomain.call({ domainId })`
 
@@ -88,6 +106,15 @@ A promise which resolves to an object containing the following properties:
 |localSkillId|number|The numeric ID of the local skill.|
 |potId|number|The numeric ID of the funding pot.|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getDomainCount.call()`
 
 Get the total number of domains in the colony. The return value is also the numeric ID of the last domain created.
@@ -101,6 +128,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of domains.|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getGlobalRewardPayoutCount.call()`
 
 Get the total number of claimed and waived reward payout cycles in the colony.
@@ -113,6 +149,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |count|number|The total number of reward payout cycles.|
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `getNonRewardPotsTotal.call({ token })`
 
@@ -131,6 +176,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |total|BigNumber|The total amount of funds that are not in the colony rewards pot.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getPotBalance.call({ potId, token })`
 
@@ -151,6 +205,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |balance|BigNumber|The balance of tokens (or Ether) in the funding pot.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getRecoveryRolesCount.call()`
 
 Get the total number of users that are assigned a colony recovery role.
@@ -164,6 +227,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getRewardInverse.call()`
 
 Get the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100.
@@ -176,6 +248,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |rewardInverse|BigNumber|The inverse amount of the reward.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getRewardPayoutInfo.call({ payoutId })`
 
@@ -199,6 +280,15 @@ A promise which resolves to an object containing the following properties:
 |token|Token address|The address of the token contract (an empty address if Ether).|
 |totalTokenAmountForRewardPayout|BigNumber|The total amount of tokens set aside for the reward payout cycle.|
 |totalTokens|BigNumber|The total amount of tokens at the time the reward payout cycle started.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getTask.call({ taskId })`
 
@@ -227,6 +317,15 @@ A promise which resolves to an object containing the following properties:
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 |status|undefined|The task status (`ACTIVE`, `CANCELLED` or `FINALIZED`).|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getTaskCount.call()`
 
 Get the total number of tasks in the colony. The return value is also the numeric ID of the last task created.
@@ -239,6 +338,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |count|number|The total number of tasks.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getTaskPayout.call({ taskId, role, token })`
 
@@ -259,6 +367,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |amount|BigNumber|The amount of tokens (or Ether) assigned to the task role as a payout.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getTaskRole.call({ taskId, role })`
 
@@ -281,6 +398,15 @@ A promise which resolves to an object containing the following properties:
 |rateFail|boolean|A boolean indicating whether or not the user failed to rate their counterpart.|
 |rating|number|The rating that the user received (`1`, `2`, or `3`).|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getTaskWorkRatings.call({ taskId })`
 
 Get information about the ratings of a task.
@@ -299,6 +425,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of submitted ratings for a task.|
 |date|Date|The date that the last rating was submitted.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getTaskWorkRatingSecret.call({ taskId, role })`
 
@@ -319,6 +454,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|Hex string|A keccak256 hash that keeps the task rating hidden.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getToken.call()`
 
 Get the address of the ERC20 token contract that is the native token assigned to the colony. The native token is the token used to calculate reputation scores, i.e. `1` token earned for completing a task with an adequate rating (`2`) will result in `1` reputation point earned.
@@ -331,6 +475,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |address|Address|The address of the ERC20 token contract.|
+
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `getTotalTaskPayout.call({ taskId, token })`
 
@@ -351,6 +504,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The total amount of tokens (or Ether) assigned to all task roles as payouts.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getTransactionCount.call()`
 
 Get the total number of transactions that the colony has made. The total number of transactions is equal to the ID of the last transaction.
@@ -363,6 +525,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |count|number|The total number of transactions that the colony has made.|
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `getUserRewardPayoutCount.call({ user })`
 
@@ -382,6 +553,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of reward payout cycles.|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getVersion.call()`
 
 Get the version number of the colony contract. The version number starts at `1` and is incremented by `1` with every new version.
@@ -394,6 +574,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |version|number|The version number of the colony contract.|
+
+**Network Information**
+
+
+  - Name: `version`
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `hasUserRole.call({ user, role })`
 
@@ -414,6 +603,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |hasRole|boolean|A boolean indicating whether or not the user has the authority role.|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `isInRecoveryMode.call()`
 
 Check whether or not the colony is in recovery mode.
@@ -426,6 +624,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the colony is in recovery mode.|
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
   
 ## Senders
@@ -450,6 +657,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |domainId|number|The numeric ID of the domain that was added.|
 |DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainaddedaddlistener-domainid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `approveExitRecovery.send(options)`
 
 Indicate approval to exit colony recovery mode. This function can only be called by a user with a recovery role.
@@ -460,6 +676,15 @@ Indicate approval to exit colony recovery mode. This function can only be called
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `assignWorkRating.send({ taskId }, options)`
 
@@ -476,6 +701,15 @@ Assign the work rating for any task roles that did not receive a rating. In the 
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `bootstrapColony.send({ users, amounts }, options)`
 
@@ -498,6 +732,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amounts|undefined|The array of corresponding token and reputation amounts each user recieved.|
 |ColonyBootstrapped|object|Contains the data defined in [ColonyBootstrapped](#eventscolonybootstrappedaddlistener-users-amounts-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `claimColonyFunds.send({ token }, options)`
 
 Claim funds that the colony has received by adding them to the funding pot of the root domain. A small fee is deducted from the funds claimed and added to the colony rewards pot. No fee is deducted when tokens native to the colony are claimed.
@@ -518,6 +761,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |fee|BigNumber|The fee deducted from the claim and added to the colony rewards pot.|
 |payoutRemainder|BigNumber|The remaining funds (after the fee) moved to the top-level domain pot.|
 |ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimedaddlistener-token-fee-payoutremainder-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `claimPayout.send({ taskId, role, token }, options)`
 
@@ -547,6 +799,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `completeTask.send({ taskId }, options)`
 
 Mark a task as complete. If the user assigned the `WORKER` task role fails to submit the task deliverable by the due date, this function must be called by the user assigned the `MANAGER` task role. This allows the task work to be rated and the task to be finalized.
@@ -565,6 +826,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The numeric ID of the task that was completed.|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `createTask.send({ specificationHash, domainId, skillId, dueDate }, options)`
 
@@ -592,6 +862,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |PotAdded|object|Contains the data defined in [PotAdded](#eventspotaddedaddlistener-potid-------)|
 |DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainaddedaddlistener-domainid-------)|
 
+**Network Information**
+
+
+  - Name: `makeTask`
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `enterRecoveryMode.send(options)`
 
 Enter colony recovery mode. This function can only be called by a user with a recovery role.
@@ -603,6 +882,15 @@ An instance of a `ContractResponse`
 
 
 
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
+
 ### `exitRecoveryMode.send(options)`
 
 Exit colony recovery mode. This function can be called by anyone if enough whitelist approvals are given.
@@ -613,6 +901,15 @@ Exit colony recovery mode. This function can be called by anyone if enough white
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `finalizeRewardPayout.send({ payoutId }, options)`
 
@@ -629,6 +926,15 @@ Finalize the reward payout cycle. This function can only be called when the rewa
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `finalizeTask.send({ taskId }, options)`
 
@@ -648,6 +954,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The numeric ID of the task that was finalized.|
 |TaskFinalized|object|Contains the data defined in [TaskFinalized](#eventstaskfinalizedaddlistener-taskid-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `mintTokens.send({ amount }, options)`
 
@@ -672,6 +987,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |value|BigNumber|The amount of tokens that were transferred.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `moveFundsBetweenPots.send({ fromPot, toPot, amount, token }, options)`
 
@@ -698,6 +1022,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|Address|The address of the token contract (an empty address if Ether).|
 |ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpotsaddlistener-frompot-topot-amount-token-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `registerColonyLabel.send({ colonyName, orbitDBPath }, options)`
 
 Register an ENS label for the colony.
@@ -719,6 +1052,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |label|string|The label that was registered for the colony.|
 |ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregisteredaddlistener-colony-label-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `removeAdminRole.send({ user }, options)`
 
 Remove the `ADMIN` authority role from a user. This function can only be called by the user assigned the `FOUNDER` authroity role.
@@ -738,6 +1080,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |user|Address|The address that was unassigned the `ADMIN` authority role.|
 |ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#eventscolonyadminroleremovedaddlistener-user-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `removeRecoveryRole.send({ user }, options)`
 
 Remove the colony recovery role from a user. This function can only be called by the `FOUNDER` authority role.
@@ -753,6 +1104,15 @@ Remove the colony recovery role from a user. This function can only be called by
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `revealTaskWorkRating.send({ taskId, role, rating, salt }, options)`
 
@@ -778,6 +1138,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |rating|number|The value of the rating that was revealed (`1`, `2`, or `3`).|
 |TaskWorkRatingRevealed|object|Contains the data defined in [TaskWorkRatingRevealed](#eventstaskworkratingrevealedaddlistener-taskid-role-rating-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setAdminRole.send({ user }, options)`
 
 Assign the `ADMIN` authority role to a user. This function can only be called by the user assigned the `FOUNDER` authority role or a user assigned the `ADMIN` authority role. There is no limit to the number of users that can be assigned the `ADMIN` authority role.
@@ -796,6 +1165,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |user|Address|The address that was assigned the `ADMIN` authority role.|
 |ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#eventscolonyadminrolesetaddlistener-user-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setAllTaskPayouts.send({ taskId, token, managerAmount, evaluatorAmount, workerAmount }, options)`
 
@@ -823,6 +1201,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setFounderRole.send({ user }, options)`
 
 Assign the `FOUNDER` authority role to a user. This function can only be called by the user currently assigned the `FOUNDER` authority role. There can only be one address assigned to the `FOUNDER` authority role, therefore, the user currently assigned will forfeit their role.
@@ -843,6 +1230,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |newFounder|Address|The address that was assigned the `FOUNDER` authority role (the new founder).|
 |ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#eventscolonyfounderrolesetaddlistener-oldfounder-newfounder-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setRecoveryRole.send({ user }, options)`
 
 Assign a colony recovery role to a user. This function can only be called by the `FOUNDER` authority role.
@@ -858,6 +1254,15 @@ Assign a colony recovery role to a user. This function can only be called by the
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
 
@@ -876,6 +1281,15 @@ An instance of a `ContractResponse`
 
 
 
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
+
 ### `setToken.send({ token }, options)`
 
 Set the native token for the colony. This function can only be called by the user assigned the `FOUNDER` authority role.
@@ -891,6 +1305,15 @@ Set the native token for the colony. This function can only be called by the use
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `startNextRewardPayout.send({ token }, options)`
 
@@ -910,6 +1333,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |payoutId|number|The numeric ID of the payout cycle that started.|
 |RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#eventsrewardpayoutcyclestartedaddlistener-payoutid-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `submitTaskDeliverable.send({ taskId, deliverableHash }, options)`
 
@@ -933,6 +1365,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `submitTaskDeliverableAndRating.send({ taskId, deliverableHash, secret }, options)`
 
@@ -958,6 +1399,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `submitTaskWorkRating.send({ taskId, role, secret }, options)`
 
 Submit a work rating for a task. This function can only be called by the user assigned the `EVALUATOR` task role, who is submitting a rating for the user assigned the `WORKER` task role, or the user assigned the `WORKER` task role, who is submitting a rating for the user assigned the `MANAGER` task role. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
@@ -975,6 +1425,15 @@ Submit a work rating for a task. This function can only be called by the user as
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `upgrade.send({ newVersion }, options)`
 
@@ -996,6 +1455,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |newVersion|number|The new version number of the colony.|
 |ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#eventscolonyupgradedaddlistener-oldversion-newversion-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `waiveRewardPayouts.send({ numPayouts }, options)`
 
 Waive reward payout cycles. This unlocks tokens for a given number of reward payout cycles.
@@ -1011,6 +1479,15 @@ Waive reward payout cycles. This unlocks tokens for a given number of reward pay
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
   
 ## Task MultiSig
@@ -1035,6 +1512,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The numeric ID of the task that was canceled.|
 |TaskCanceled|object|Contains the data defined in [TaskCanceled](#eventstaskcanceledaddlistener-taskid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `removeTaskEvaluatorRole.startOperation({ taskId })`
 
 Remove the `EVALUATOR` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
@@ -1055,6 +1541,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|Role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `removeTaskWorkerRole.startOperation({ taskId })`
 
@@ -1077,6 +1572,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskBrief.startOperation({ taskId, specificationHash })`
 
 Set the task specification. The task specification, or "task brief", is a description of the work that must be completed for the task. The description is hashed and stored with the task for future reference during the rating process or in the event of a dispute.
@@ -1097,6 +1601,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The numeric ID of the task that was modified.|
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
 |TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#eventstaskbriefsetaddlistener-taskid-specificationhash-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setTaskDomain.startOperation({ taskId, domainId })`
 
@@ -1119,6 +1632,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |domainId|number|The numeric ID of the domain that was set.|
 |TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#eventstaskdomainsetaddlistener-taskid-domainid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskDueDate.startOperation({ taskId, dueDate })`
 
 Set the due date of a task. The due date is the last day that the user assigned the `WORKER` task role can submit the task deliverable.
@@ -1139,6 +1661,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The numeric ID of the task that was modified.|
 |dueDate|Date|The due date that was set.|
 |TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setTaskEvaluatorRole.startOperation({ taskId, user })`
 
@@ -1162,6 +1693,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskManagerRole.startOperation({ taskId, user })`
 
 Assign the `MANAGER` task role to a user. This function can only be called before the task is finalized. The user currently assigned the `MANAGER` task role and the user being assigned the `MANAGER` task role must both sign the transaction before it can be executed.
@@ -1184,6 +1724,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskSkill.startOperation({ taskId, skillId })`
 
 Set the skill of a task. Only one skill can be assigned per task. The user assigned the `MANAGER` task role and the user assigned the `WORKER` task role must both sign this transaction before it can be executed.
@@ -1204,6 +1753,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The numeric ID of the task that was modified.|
 |skillId|number|The numeric ID of the skill that was set.|
 |TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setTaskWorkerRole.startOperation({ taskId, user })`
 
@@ -1226,6 +1784,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|Role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyTask.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setTaskManagerPayout.startOperation({ taskId, token, amount })`
 
@@ -1251,6 +1818,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskEvaluatorPayout.startOperation({ taskId, token, amount })`
 
 Set the payout amount for the `EVALUATOR` task role.
@@ -1275,6 +1851,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
 
 Set the payout amount for the `WORKER` task role.
@@ -1298,6 +1883,15 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |token|Token address|The address of the token contract (an empty address if Ether).|
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyFunding.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
   
 ## Events

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -61,7 +61,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getAuthority.call()`
@@ -81,8 +81,8 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `authority`
-  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getDomain.call({ domainId })`
@@ -109,7 +109,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getDomainCount.call()`
@@ -130,7 +130,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getGlobalRewardPayoutCount.call()`
@@ -177,7 +177,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getPotBalance.call({ potId, token })`
@@ -204,7 +204,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getRecoveryRolesCount.call()`
@@ -246,7 +246,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getRewardPayoutInfo.call({ payoutId })`
@@ -277,7 +277,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTask.call({ taskId })`
@@ -312,7 +312,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTaskCount.call()`
@@ -333,7 +333,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTaskPayout.call({ taskId, role, token })`
@@ -361,7 +361,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTaskRole.call({ taskId, role })`
@@ -390,7 +390,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTaskWorkRatings.call({ taskId })`
@@ -417,7 +417,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTaskWorkRatingSecret.call({ taskId, role })`
@@ -444,7 +444,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getToken.call()`
@@ -465,7 +465,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTotalTaskPayout.call({ taskId, token })`
@@ -492,7 +492,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getTransactionCount.call()`
@@ -560,7 +560,7 @@ A promise which resolves to an object containing the following properties:
 
   - Name: `version`
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `hasUserRole.call({ user, role })`
@@ -587,7 +587,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `isInRecoveryMode.call()`
@@ -608,7 +608,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
   
@@ -639,7 +639,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `approveExitRecovery.send(options)`
@@ -658,7 +658,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `assignWorkRating.send({ taskId }, options)`
@@ -682,7 +682,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `bootstrapColony.send({ users, amounts }, options)`
@@ -711,7 +711,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `claimColonyFunds.send({ token }, options)`
@@ -740,7 +740,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `claimPayout.send({ taskId, role, token }, options)`
@@ -776,7 +776,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `completeTask.send({ taskId }, options)`
@@ -803,7 +803,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `createTask.send({ specificationHash, domainId, skillId, dueDate }, options)`
@@ -837,7 +837,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   - Name: `makeTask`
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `enterRecoveryMode.send(options)`
@@ -856,7 +856,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `exitRecoveryMode.send(options)`
@@ -875,7 +875,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `finalizeRewardPayout.send({ payoutId }, options)`
@@ -899,7 +899,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `finalizeTask.send({ taskId }, options)`
@@ -926,7 +926,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `mintTokens.send({ amount }, options)`
@@ -958,7 +958,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `moveFundsBetweenPots.send({ fromPot, toPot, amount, token }, options)`
@@ -991,7 +991,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `registerColonyLabel.send({ colonyName, orbitDBPath }, options)`
@@ -1020,7 +1020,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `removeAdminRole.send({ user }, options)`
@@ -1047,7 +1047,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `removeRecoveryRole.send({ user }, options)`
@@ -1071,7 +1071,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `revealTaskWorkRating.send({ taskId, role, rating, salt }, options)`
@@ -1103,7 +1103,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setAdminRole.send({ user }, options)`
@@ -1130,7 +1130,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setAllTaskPayouts.send({ taskId, token, managerAmount, evaluatorAmount, workerAmount }, options)`
@@ -1164,7 +1164,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setFounderRole.send({ user }, options)`
@@ -1192,7 +1192,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setRecoveryRole.send({ user }, options)`
@@ -1216,7 +1216,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
@@ -1241,7 +1241,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `setToken.send({ token }, options)`
@@ -1292,7 +1292,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `submitTaskDeliverable.send({ taskId, deliverableHash }, options)`
@@ -1323,7 +1323,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `submitTaskDeliverableAndRating.send({ taskId, deliverableHash, secret }, options)`
@@ -1355,7 +1355,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `submitTaskWorkRating.send({ taskId, role, secret }, options)`
@@ -1381,7 +1381,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `upgrade.send({ newVersion }, options)`
@@ -1409,7 +1409,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `waiveRewardPayouts.send({ numPayouts }, options)`
@@ -1464,7 +1464,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `removeTaskEvaluatorRole.startOperation({ taskId })`
@@ -1493,7 +1493,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `removeTaskWorkerRole.startOperation({ taskId })`
@@ -1522,7 +1522,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskBrief.startOperation({ taskId, specificationHash })`
@@ -1551,7 +1551,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskDomain.startOperation({ taskId, domainId })`
@@ -1580,7 +1580,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskDueDate.startOperation({ taskId, dueDate })`
@@ -1609,7 +1609,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskEvaluatorRole.startOperation({ taskId, user })`
@@ -1639,7 +1639,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskManagerRole.startOperation({ taskId, user })`
@@ -1669,7 +1669,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskSkill.startOperation({ taskId, skillId })`
@@ -1698,7 +1698,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskWorkerRole.startOperation({ taskId, user })`
@@ -1728,7 +1728,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskManagerPayout.startOperation({ taskId, token, amount })`
@@ -1760,7 +1760,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskEvaluatorPayout.startOperation({ taskId, token, amount })`
@@ -1792,7 +1792,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
@@ -1824,7 +1824,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 
   
   - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
   

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -202,9 +202,9 @@ A promise which resolves to an object containing the following properties:
 **Contract Information**
 
 
-  
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Name: `numRecoveryRoles`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `getRewardInverse.call()`

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -56,13 +56,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|Hex string|A keccak256 hash that keeps the task rating hidden.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getAuthority.call()`
@@ -78,13 +77,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the authority contract associated with the colony.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `authority`
-  - Contract: `dappsys/auth.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
   
 
 ### `getDomain.call({ domainId })`
@@ -106,13 +104,12 @@ A promise which resolves to an object containing the following properties:
 |localSkillId|number|The numeric ID of the local skill.|
 |potId|number|The numeric ID of the funding pot.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `getDomainCount.call()`
@@ -128,13 +125,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of domains.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `getGlobalRewardPayoutCount.call()`
@@ -150,13 +146,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of reward payout cycles.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getNonRewardPotsTotal.call({ token })`
@@ -177,13 +172,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |total|BigNumber|The total amount of funds that are not in the colony rewards pot.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getPotBalance.call({ potId, token })`
@@ -205,13 +199,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |balance|BigNumber|The balance of tokens (or Ether) in the funding pot.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getRecoveryRolesCount.call()`
@@ -227,13 +220,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getRewardInverse.call()`
@@ -249,13 +241,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |rewardInverse|BigNumber|The inverse amount of the reward.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getRewardPayoutInfo.call({ payoutId })`
@@ -281,13 +272,12 @@ A promise which resolves to an object containing the following properties:
 |totalTokenAmountForRewardPayout|BigNumber|The total amount of tokens set aside for the reward payout cycle.|
 |totalTokens|BigNumber|The total amount of tokens at the time the reward payout cycle started.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getTask.call({ taskId })`
@@ -317,13 +307,12 @@ A promise which resolves to an object containing the following properties:
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 |status|undefined|The task status (`ACTIVE`, `CANCELLED` or `FINALIZED`).|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getTaskCount.call()`
@@ -339,13 +328,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of tasks.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getTaskPayout.call({ taskId, role, token })`
@@ -368,13 +356,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The amount of tokens (or Ether) assigned to the task role as a payout.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getTaskRole.call({ taskId, role })`
@@ -398,13 +385,12 @@ A promise which resolves to an object containing the following properties:
 |rateFail|boolean|A boolean indicating whether or not the user failed to rate their counterpart.|
 |rating|number|The rating that the user received (`1`, `2`, or `3`).|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getTaskWorkRatings.call({ taskId })`
@@ -426,13 +412,12 @@ A promise which resolves to an object containing the following properties:
 |count|number|The total number of submitted ratings for a task.|
 |date|Date|The date that the last rating was submitted.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getTaskWorkRatingSecret.call({ taskId, role })`
@@ -454,13 +439,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |secret|Hex string|A keccak256 hash that keeps the task rating hidden.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `getToken.call()`
@@ -476,13 +460,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the ERC20 token contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `getTotalTaskPayout.call({ taskId, token })`
@@ -504,13 +487,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The total amount of tokens (or Ether) assigned to all task roles as payouts.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `getTransactionCount.call()`
@@ -526,13 +508,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of transactions that the colony has made.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getUserRewardPayoutCount.call({ user })`
@@ -553,13 +534,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of reward payout cycles.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getVersion.call()`
@@ -575,13 +555,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |version|number|The version number of the colony contract.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `version`
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `hasUserRole.call({ user, role })`
@@ -603,13 +582,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |hasRole|boolean|A boolean indicating whether or not the user has the authority role.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `isInRecoveryMode.call()`
@@ -625,13 +603,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the colony is in recovery mode.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
   
@@ -657,13 +634,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |domainId|number|The numeric ID of the domain that was added.|
 |DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainaddedaddlistener-domainid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `approveExitRecovery.send(options)`
@@ -677,13 +653,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `assignWorkRating.send({ taskId }, options)`
@@ -702,13 +677,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `bootstrapColony.send({ users, amounts }, options)`
@@ -732,13 +706,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amounts|undefined|The array of corresponding token and reputation amounts each user recieved.|
 |ColonyBootstrapped|object|Contains the data defined in [ColonyBootstrapped](#eventscolonybootstrappedaddlistener-users-amounts-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `claimColonyFunds.send({ token }, options)`
@@ -762,13 +735,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |payoutRemainder|BigNumber|The remaining funds (after the fee) moved to the top-level domain pot.|
 |ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimedaddlistener-token-fee-payoutremainder-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `claimPayout.send({ taskId, role, token }, options)`
@@ -799,13 +771,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `completeTask.send({ taskId }, options)`
@@ -827,13 +798,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The numeric ID of the task that was completed.|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `createTask.send({ specificationHash, domainId, skillId, dueDate }, options)`
@@ -862,13 +832,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |PotAdded|object|Contains the data defined in [PotAdded](#eventspotaddedaddlistener-potid-------)|
 |DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainaddedaddlistener-domainid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `makeTask`
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `enterRecoveryMode.send(options)`
@@ -882,13 +851,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `exitRecoveryMode.send(options)`
@@ -902,13 +870,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `finalizeRewardPayout.send({ payoutId }, options)`
@@ -927,13 +894,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `finalizeTask.send({ taskId }, options)`
@@ -955,13 +921,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The numeric ID of the task that was finalized.|
 |TaskFinalized|object|Contains the data defined in [TaskFinalized](#eventstaskfinalizedaddlistener-taskid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `mintTokens.send({ amount }, options)`
@@ -988,13 +953,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `moveFundsBetweenPots.send({ fromPot, toPot, amount, token }, options)`
@@ -1022,13 +986,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|Address|The address of the token contract (an empty address if Ether).|
 |ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpotsaddlistener-frompot-topot-amount-token-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `registerColonyLabel.send({ colonyName, orbitDBPath }, options)`
@@ -1052,13 +1015,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |label|string|The label that was registered for the colony.|
 |ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregisteredaddlistener-colony-label-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `removeAdminRole.send({ user }, options)`
@@ -1080,13 +1042,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |user|Address|The address that was unassigned the `ADMIN` authority role.|
 |ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#eventscolonyadminroleremovedaddlistener-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `removeRecoveryRole.send({ user }, options)`
@@ -1105,13 +1066,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `revealTaskWorkRating.send({ taskId, role, rating, salt }, options)`
@@ -1138,13 +1098,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |rating|number|The value of the rating that was revealed (`1`, `2`, or `3`).|
 |TaskWorkRatingRevealed|object|Contains the data defined in [TaskWorkRatingRevealed](#eventstaskworkratingrevealedaddlistener-taskid-role-rating-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setAdminRole.send({ user }, options)`
@@ -1166,13 +1125,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |user|Address|The address that was assigned the `ADMIN` authority role.|
 |ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#eventscolonyadminrolesetaddlistener-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `setAllTaskPayouts.send({ taskId, token, managerAmount, evaluatorAmount, workerAmount }, options)`
@@ -1201,13 +1159,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `setFounderRole.send({ user }, options)`
@@ -1230,13 +1187,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |newFounder|Address|The address that was assigned the `FOUNDER` authority role (the new founder).|
 |ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#eventscolonyfounderrolesetaddlistener-oldfounder-newfounder-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `setRecoveryRole.send({ user }, options)`
@@ -1255,13 +1211,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
@@ -1281,13 +1236,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `setToken.send({ token }, options)`
@@ -1306,13 +1260,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `startNextRewardPayout.send({ token }, options)`
@@ -1334,13 +1287,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |payoutId|number|The numeric ID of the payout cycle that started.|
 |RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#eventsrewardpayoutcyclestartedaddlistener-payoutid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `submitTaskDeliverable.send({ taskId, deliverableHash }, options)`
@@ -1366,13 +1318,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `submitTaskDeliverableAndRating.send({ taskId, deliverableHash, secret }, options)`
@@ -1399,13 +1350,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `submitTaskWorkRating.send({ taskId, role, secret }, options)`
@@ -1426,13 +1376,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `upgrade.send({ newVersion }, options)`
@@ -1455,13 +1404,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |newVersion|number|The new version number of the colony.|
 |ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#eventscolonyupgradedaddlistener-oldversion-newversion-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `waiveRewardPayouts.send({ numPayouts }, options)`
@@ -1480,13 +1428,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
   
@@ -1512,13 +1459,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The numeric ID of the task that was canceled.|
 |TaskCanceled|object|Contains the data defined in [TaskCanceled](#eventstaskcanceledaddlistener-taskid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `removeTaskEvaluatorRole.startOperation({ taskId })`
@@ -1542,13 +1488,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `removeTaskWorkerRole.startOperation({ taskId })`
@@ -1572,13 +1517,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskBrief.startOperation({ taskId, specificationHash })`
@@ -1602,13 +1546,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
 |TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#eventstaskbriefsetaddlistener-taskid-specificationhash-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskDomain.startOperation({ taskId, domainId })`
@@ -1632,13 +1575,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |domainId|number|The numeric ID of the domain that was set.|
 |TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#eventstaskdomainsetaddlistener-taskid-domainid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskDueDate.startOperation({ taskId, dueDate })`
@@ -1662,13 +1604,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |dueDate|Date|The due date that was set.|
 |TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskEvaluatorRole.startOperation({ taskId, user })`
@@ -1693,13 +1634,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskManagerRole.startOperation({ taskId, user })`
@@ -1724,13 +1664,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskSkill.startOperation({ taskId, skillId })`
@@ -1754,13 +1693,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |skillId|number|The numeric ID of the skill that was set.|
 |TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskWorkerRole.startOperation({ taskId, user })`
@@ -1785,13 +1723,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |user|Address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyTask.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
   
 
 ### `setTaskManagerPayout.startOperation({ taskId, token, amount })`
@@ -1818,13 +1755,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `setTaskEvaluatorPayout.startOperation({ taskId, token, amount })`
@@ -1851,13 +1787,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
 ### `setTaskWorkerPayout.startOperation({ taskId, token, amount })`
@@ -1884,13 +1819,12 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|BigNumber|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyFunding.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyFunding.sol)
   
 
   

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -495,9 +495,9 @@ A promise which resolves to an object containing the following properties:
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
-### `getUserRewardPayoutCount.call({ user })`
+### `getUserLock.call({ user })`
 
-Get the total number of claimed and waived reward payout cycles for a given user in the colony.
+Get the total number of locked tokens for a given user in the colony.
 
 **Arguments**
 
@@ -511,14 +511,14 @@ A promise which resolves to an object containing the following properties:
 
 |Return value|Type|Description|
 |---|---|---|
-|count|number|The total number of reward payout cycles.|
+|count|number|The total number of locked tokens.|
 
 **Contract Information**
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [TokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/TokenLocking.sol)
+  - Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ITokenLocking.sol)
   
 
 ### `getVersion.call()`

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -1201,7 +1201,7 @@ An instance of a `ContractResponse`
 
 ### `startNextRewardPayout.send({ token }, options)`
 
-Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have either waived the reward payout cycle using `waiveRewardPayouts`, which means they forfeit a given number of reward payout cycles and unlock their share of tokens for those payout cycles, or reputation holders have claimed their rewards payout using `claimRewardPayout`, which means the payout was claimed and the tokens were transferred to their account.
+Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have claimed their rewards payout using `claimRewardPayout`. Reputation holders can also waive their reward payout and unlock their tokens for past reward payout cycles by using `incrementLockCounterTo`.
 
 **Arguments**
 
@@ -1343,15 +1343,16 @@ An instance of a `ContractResponse` which will eventually receive the following 
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
-### `waiveRewardPayouts.send({ numPayouts }, options)`
+### `incrementLockCounterTo.send({ token, lockId }, options)`
 
-Waive reward payout cycles. This unlocks tokens for a given number of reward payout cycles.
+Increment the token lock counter. This method allows users to waive reward payouts for past reward payout cycles, unlocking the tokens that were locked in previous reward payout cycles.
 
 **Arguments**
 
 |Argument|Type|Description|
 |---|---|---|
-|numPayouts|number|The number of reward payout cycles that will be waived.|
+|token|Token address|The address of the token contract (an empty address if Ether).|
+|lockId|number|The numeric ID of the lock count that will be set.|
 
 **Returns**
 
@@ -1363,8 +1364,8 @@ An instance of a `ContractResponse`
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [TokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/TokenLocking.sol)
+  - Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ITokenLocking.sol)
   
 
   

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -133,27 +133,6 @@ A promise which resolves to an object containing the following properties:
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
-### `getGlobalRewardPayoutCount.call()`
-
-Get the total number of claimed and waived reward payout cycles in the colony.
-
-
-**Returns**
-
-A promise which resolves to an object containing the following properties:
-
-|Return value|Type|Description|
-|---|---|---|
-|count|number|The total number of reward payout cycles.|
-
-**Contract Information**
-
-
-  
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  
-
 ### `getNonRewardPotsTotal.call({ token })`
 
 Get the total amount of funds that are not in the colony rewards pot. The total amount of funds that are not in the colony rewards pot is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
@@ -466,6 +445,27 @@ A promise which resolves to an object containing the following properties:
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
+  
+
+### `getTotalLockCount.call()`
+
+Get the total number of locked tokens in the colony.
+
+
+**Returns**
+
+A promise which resolves to an object containing the following properties:
+
+|Return value|Type|Description|
+|---|---|---|
+|count|number|The total number of locked tokens in the colony.|
+
+**Contract Information**
+
+
+  
+  - Contract: [TokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/TokenLocking.sol)
+  - Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ITokenLocking.sol)
   
 
 ### `getTotalTaskPayout.call({ taskId, token })`

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -661,30 +661,6 @@ An instance of a `ContractResponse`
   - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
-### `assignWorkRating.send({ taskId }, options)`
-
-Assign the work rating for any task roles that did not receive a rating. In the event of a user not committing or revealing a work rating within the 10-day rating window (5-day maximum commit period and 5-day maximum reveal period), their counterpart is given the highest work rating possible (`3`) and the user who failed to commit or reveal their work rating will receive a reputation penalty.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|taskId|number|The numeric ID of the task.|
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
-
-**Contract Information**
-
-
-  
-  - Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyTask.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  
-
 ### `bootstrapColony.send({ users, amounts }, options)`
 
 Bootstrap the colony by giving an initial amount of tokens and reputation to selected users. This function can only be called by the user assigned the `FOUNDER` authority role when the `taskCount` for the colony is equal to `0`.

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -1199,30 +1199,6 @@ An instance of a `ContractResponse`
   - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
-### `setToken.send({ token }, options)`
-
-Set the native token for the colony. This function can only be called by the user assigned the `FOUNDER` authority role.
-
-**Arguments**
-
-|Argument|Type|Description|
-|---|---|---|
-|token|Address|The address of the token contract.|
-
-**Returns**
-
-An instance of a `ContractResponse`
-
-
-
-**Contract Information**
-
-
-  
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  
-
 ### `startNextRewardPayout.send({ token }, options)`
 
 Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have either waived the reward payout cycle using `waiveRewardPayouts`, which means they forfeit a given number of reward payout cycles and unlock their share of tokens for those payout cycles, or reputation holders have claimed their rewards payout using `claimRewardPayout`, which means the payout was claimed and the tokens were transferred to their account.

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -105,13 +105,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |isSupported|boolean|A boolean indicating whether or not the contract interface is supported.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `supportsInterface`
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
 ### `getAddressForENSHash.call({ nameHash })`
@@ -132,13 +131,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |ensAddress|Address|The address associated with the ENS label.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `addr`
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
 ### `getChildSkillId.call({ skillId, childSkillIndex })`
@@ -160,13 +158,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |childSkillId|number|The numeric ID of the child skill.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getColony.call({ id })`
@@ -187,13 +184,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the colony contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getColonyCount.call()`
@@ -209,13 +205,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of colonies.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getColonyVersionResolver.call({ version })`
@@ -236,13 +231,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the resolver contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getCurrentColonyVersion.call()`
@@ -258,13 +252,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |version|number|The version number of the latest colony contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getMetaColonyAddress.call()`
@@ -280,13 +273,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the Meta Colony contract.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `getMetaColony`
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getParentSkillId.call({ skillId, parentSkillIndex })`
@@ -308,13 +300,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |parentSkillId|number|The numeric ID of the parent skill.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getProfileDBAddress.call({ nameHash })`
@@ -335,13 +326,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |orbitDBAddress|string|The path of the OrbitDB database associated with the user profile.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
 ### `getRecoveryRolesCount.call()`
@@ -357,13 +347,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getRootGlobalSkillId.call()`
@@ -379,13 +368,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |skillId|number|The numeric ID of the root global skill.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getSkill.call({ skillId })`
@@ -408,13 +396,12 @@ A promise which resolves to an object containing the following properties:
 |nChildren|number|The total number of child skills.|
 |isGlobalSkill|boolean|A boolean indicating whether or not the skill is a global skill.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getSkillCount.call()`
@@ -430,13 +417,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of global and local skills in the network.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `getTokenLocking.call()`
@@ -452,13 +438,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |lockingAddress|Address|The address of the token locking contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `isColony.call({ colony })`
@@ -479,13 +464,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |isColony|boolean|A boolean indicating whether or not an address is a colony contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `isInRecoveryMode.call()`
@@ -501,13 +485,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the network is in recovery mode.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `lookupRegisteredENSDomain.call({ ensAddress })`
@@ -528,13 +511,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |domain|string|The ENS label associated with the address.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
   
@@ -562,13 +544,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |resolver|Address|The address of the resolver contract.|
 |ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#eventscolonyversionaddedaddlistener-version-resolver-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `addSkill.send({ parentSkillId, globalSkill }, options)`
@@ -592,13 +573,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |parentSkillId|number|The numeric ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `approveExitRecovery.send(options)`
@@ -612,13 +592,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `createColony.send({ tokenAddress }, options)`
@@ -642,13 +621,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |tokenAddress|Address|The address of the token contract that was assigned.|
 |ColonyAdded|object|Contains the data defined in [ColonyAdded](#eventscolonyaddedaddlistener-colonyid-colonyaddress-tokenaddress-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `createMetaColony.send({ tokenAddress }, options)`
@@ -672,13 +650,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |rootSkillId|number|The numeric ID of the root skill.|
 |MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#eventsmetacolonycreatedaddlistener-colonyaddress-tokenaddress-rootskillid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `createToken.send({ name, symbol, decimals }, options)`
@@ -699,13 +676,12 @@ An instance of a `ContractResponse` which will receive a receipt with a `contrac
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `enterRecoveryMode.send(options)`
@@ -719,13 +695,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `exitRecoveryMode.send(options)`
@@ -739,13 +714,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `registerUserLabel.send({ username, orbitDBPath }, options)`
@@ -769,13 +743,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |label|string|The ENS label that was registered for the user.|
 |UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#eventsuserlabelregisteredaddlistener-user-label-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
 ### `removeRecoveryRole.send({ user }, options)`
@@ -794,13 +767,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `setRecoveryRole.send({ user }, options)`
@@ -819,13 +791,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
@@ -845,13 +816,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ContractRecovery.sol`
-  - Interface: `IRecovery.sol`
-  - Version: `0`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
   
 
 ### `setTokenLocking.send({ tokenLockingAddress }, options)`
@@ -873,13 +843,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |tokenLocking|Address|The address of the token locking contract.|
 |TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#eventstokenlockingaddresssetaddlistener-tokenlocking-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetwork.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
   
 
 ### `setupRegistrar.send({ ens, rootNode }, options)`
@@ -899,13 +868,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetworkENS.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
   
 
 ### `startTokenAuction.send({ tokenAddress }, options)`
@@ -929,13 +897,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |quantity|BigNumber|The amount of tokens available for the auction.|
 |AuctionCreated|object|Contains the data defined in [AuctionCreated](#eventsauctioncreatedaddlistener-auction-token-quantity-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ColonyNetworkAuction.sol`
-  - Interface: `IColonyNetwork.sol`
-  - Version: `0`
+  - Contract: [ColonyNetworkAuction.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkAuction.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkAuction.sol)
   
 
   

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -105,6 +105,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |isSupported|boolean|A boolean indicating whether or not the contract interface is supported.|
 
+**Network Information**
+
+
+  - Name: `supportsInterface`
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getAddressForENSHash.call({ nameHash })`
 
 Get the address of a registered ENS label. This function will return an empty address if an ENS label has not been registered.
@@ -122,6 +131,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |ensAddress|Address|The address associated with the ENS label.|
+
+**Network Information**
+
+
+  - Name: `addr`
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `getChildSkillId.call({ skillId, childSkillIndex })`
 
@@ -142,6 +160,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |childSkillId|number|The numeric ID of the child skill.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getColony.call({ id })`
 
 Get the colony contract address for a colony.
@@ -160,6 +187,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the colony contract.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getColonyCount.call()`
 
 Get the total number of colonies on the network. The return value is also the numeric ID of the last colony created.
@@ -172,6 +208,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |count|number|The total number of colonies.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `getColonyVersionResolver.call({ version })`
 
@@ -191,6 +236,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the resolver contract.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getCurrentColonyVersion.call()`
 
 Get the latest colony contract version. This is the version used to create all new colonies.
@@ -204,6 +258,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |version|number|The version number of the latest colony contract.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getMetaColonyAddress.call()`
 
 Get the Meta Colony contract address.
@@ -216,6 +279,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |address|Address|The address of the Meta Colony contract.|
+
+**Network Information**
+
+
+  - Name: `getMetaColony`
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `getParentSkillId.call({ skillId, parentSkillIndex })`
 
@@ -236,6 +308,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |parentSkillId|number|The numeric ID of the parent skill.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getProfileDBAddress.call({ nameHash })`
 
 Get the address of the OrbitDB database associaated with a user profile.
@@ -254,6 +335,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |orbitDBAddress|string|The path of the OrbitDB database associated with the user profile.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getRecoveryRolesCount.call()`
 
 Get the total number of users that are assigned a network recovery role.
@@ -267,6 +357,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getRootGlobalSkillId.call()`
 
 Get the ID of the root global skill.
@@ -279,6 +378,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |skillId|number|The numeric ID of the root global skill.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `getSkill.call({ skillId })`
 
@@ -300,6 +408,15 @@ A promise which resolves to an object containing the following properties:
 |nChildren|number|The total number of child skills.|
 |isGlobalSkill|boolean|A boolean indicating whether or not the skill is a global skill.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getSkillCount.call()`
 
 Get the total number of global and local skills in the network.
@@ -313,6 +430,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |count|number|The total number of global and local skills in the network.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `getTokenLocking.call()`
 
 Get the token locking contract address.
@@ -325,6 +451,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |lockingAddress|Address|The address of the token locking contract.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `isColony.call({ colony })`
 
@@ -344,6 +479,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |isColony|boolean|A boolean indicating whether or not an address is a colony contract.|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `isInRecoveryMode.call()`
 
 Check whether or not the network is in recovery mode.
@@ -356,6 +500,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the network is in recovery mode.|
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `lookupRegisteredENSDomain.call({ ensAddress })`
 
@@ -374,6 +527,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |domain|string|The ENS label associated with the address.|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
   
 ## Senders
@@ -400,6 +562,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |resolver|Address|The address of the resolver contract.|
 |ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#eventscolonyversionaddedaddlistener-version-resolver-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `addSkill.send({ parentSkillId, globalSkill }, options)`
 
 Add a new global or local skill to the skills tree.
@@ -421,6 +592,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |parentSkillId|number|The numeric ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `approveExitRecovery.send(options)`
 
 Indicate approval to exit network recovery mode. This function can only be called by a user with a recovery role.
@@ -431,6 +611,15 @@ Indicate approval to exit network recovery mode. This function can only be calle
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `createColony.send({ tokenAddress }, options)`
 
@@ -453,6 +642,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |tokenAddress|Address|The address of the token contract that was assigned.|
 |ColonyAdded|object|Contains the data defined in [ColonyAdded](#eventscolonyaddedaddlistener-colonyid-colonyaddress-tokenaddress-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `createMetaColony.send({ tokenAddress }, options)`
 
 Create the Meta Colony.
@@ -474,6 +672,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |rootSkillId|number|The numeric ID of the root skill.|
 |MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#eventsmetacolonycreatedaddlistener-colonyaddress-tokenaddress-rootskillid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `createToken.send({ name, symbol, decimals }, options)`
 
 Create a new ERC20 token contract.
@@ -492,6 +699,15 @@ An instance of a `ContractResponse` which will receive a receipt with a `contrac
 
 
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `enterRecoveryMode.send(options)`
 
 Enter network recovery mode. This function can only be called by a user with a recovery role.
@@ -503,6 +719,15 @@ An instance of a `ContractResponse`
 
 
 
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
+
 ### `exitRecoveryMode.send(options)`
 
 Exit network recovery mode. This function can be called by anyone if enough whitelist approvals are given.
@@ -513,6 +738,15 @@ Exit network recovery mode. This function can be called by anyone if enough whit
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `registerUserLabel.send({ username, orbitDBPath }, options)`
 
@@ -535,6 +769,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |label|string|The ENS label that was registered for the user.|
 |UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#eventsuserlabelregisteredaddlistener-user-label-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `removeRecoveryRole.send({ user }, options)`
 
 Remove the network recovery role from a user. This function can only be called by the `FOUNDER` authority role.
@@ -550,6 +793,15 @@ Remove the network recovery role from a user. This function can only be called b
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `setRecoveryRole.send({ user }, options)`
 
@@ -567,6 +819,15 @@ An instance of a `ContractResponse`
 
 
 
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
+
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
 
 Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
@@ -583,6 +844,15 @@ Set the value for a storage slot while in recovery mode. This can only be called
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ContractRecovery.sol`
+  - Interface: `IRecovery.sol`
+  - Version: `0`
+  
 
 ### `setTokenLocking.send({ tokenLockingAddress }, options)`
 
@@ -603,6 +873,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |tokenLocking|Address|The address of the token locking contract.|
 |TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#eventstokenlockingaddresssetaddlistener-tokenlocking-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetwork.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
+
 ### `setupRegistrar.send({ ens, rootNode }, options)`
 
 Set up the registrar.
@@ -619,6 +898,15 @@ Set up the registrar.
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetworkENS.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
 ### `startTokenAuction.send({ tokenAddress }, options)`
 
@@ -640,6 +928,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|Address|The address of the token contract that was assigned.|
 |quantity|BigNumber|The amount of tokens available for the auction.|
 |AuctionCreated|object|Contains the data defined in [AuctionCreated](#eventsauctioncreatedaddlistener-auction-token-quantity-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ColonyNetworkAuction.sol`
+  - Interface: `IColonyNetwork.sol`
+  - Version: `0`
+  
 
   
   

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -110,7 +110,7 @@ A promise which resolves to an object containing the following properties:
 
   - Name: `supportsInterface`
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getAddressForENSHash.call({ nameHash })`
@@ -136,7 +136,7 @@ A promise which resolves to an object containing the following properties:
 
   - Name: `addr`
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getChildSkillId.call({ skillId, childSkillIndex })`
@@ -163,7 +163,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getColony.call({ id })`
@@ -189,7 +189,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getColonyCount.call()`
@@ -210,7 +210,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getColonyVersionResolver.call({ version })`
@@ -236,7 +236,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getCurrentColonyVersion.call()`
@@ -257,7 +257,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getMetaColonyAddress.call()`
@@ -278,7 +278,7 @@ A promise which resolves to an object containing the following properties:
 
   - Name: `getMetaColony`
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getParentSkillId.call({ skillId, parentSkillIndex })`
@@ -305,7 +305,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getProfileDBAddress.call({ nameHash })`
@@ -331,7 +331,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getRecoveryRolesCount.call()`
@@ -373,7 +373,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getSkill.call({ skillId })`
@@ -401,7 +401,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getSkillCount.call()`
@@ -422,7 +422,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `getTokenLocking.call()`
@@ -443,7 +443,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `isColony.call({ colony })`
@@ -469,7 +469,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `isInRecoveryMode.call()`
@@ -490,7 +490,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `lookupRegisteredENSDomain.call({ ensAddress })`
@@ -516,7 +516,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
   
@@ -549,7 +549,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `addSkill.send({ parentSkillId, globalSkill }, options)`
@@ -578,7 +578,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `approveExitRecovery.send(options)`
@@ -597,7 +597,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `createColony.send({ tokenAddress }, options)`
@@ -626,7 +626,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `createMetaColony.send({ tokenAddress }, options)`
@@ -655,7 +655,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `createToken.send({ name, symbol, decimals }, options)`
@@ -700,7 +700,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `exitRecoveryMode.send(options)`
@@ -719,7 +719,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `registerUserLabel.send({ username, orbitDBPath }, options)`
@@ -748,7 +748,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `removeRecoveryRole.send({ user }, options)`
@@ -772,7 +772,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `setRecoveryRole.send({ user }, options)`
@@ -796,7 +796,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `setStorageSlotRecovery.send({ slot, value }, options)`
@@ -821,7 +821,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
-  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `setTokenLocking.send({ tokenLockingAddress }, options)`
@@ -848,7 +848,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetwork.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `setupRegistrar.send({ ens, rootNode }, options)`
@@ -873,7 +873,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkENS.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
 ### `startTokenAuction.send({ tokenAddress }, options)`
@@ -902,7 +902,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ColonyNetworkAuction.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkAuction.sol)
-  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ColonyNetworkAuction.sol)
+  - Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColonyNetwork.sol)
   
 
   

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -350,9 +350,9 @@ A promise which resolves to an object containing the following properties:
 **Contract Information**
 
 
-  
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Name: `numRecoveryRoles`
+  - Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ContractRecovery.sol)
+  - Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IRecovery.sol)
   
 
 ### `getRootGlobalSkillId.call()`

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -680,8 +680,8 @@ An instance of a `ContractResponse` which will receive a receipt with a `contrac
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/Token.sol)
+  
   
 
 ### `enterRecoveryMode.send(options)`

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -54,8 +54,8 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `authority`
-  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `getToken.call()`
@@ -76,7 +76,7 @@ A promise which resolves to an object containing the following properties:
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
   
@@ -108,7 +108,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IMetaColony.sol)
   
 
 ### `mintTokensForColonyNetwork.send({ amount }, options)`
@@ -136,7 +136,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IMetaColony.sol)
   
 
 ### `setNetworkFeeInverse.send({ feeInverse }, options)`
@@ -160,7 +160,7 @@ An instance of a `ContractResponse`
 
   
   - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
-  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IMetaColony.sol)
   
 
   

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -54,7 +54,7 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `authority`
-  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/auth.sol)
   - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -37,27 +37,6 @@ await metaColonyClient.init();
 
 **All callers return promises which resolve to an object containing the given return values.** For a reference please check [here](/colonyjs/docs-contractclient/#callers).
 
-### `getAuthority.call()`
-
-Get the authority contract address associated with the colony.
-
-
-**Returns**
-
-A promise which resolves to an object containing the following properties:
-
-|Return value|Type|Description|
-|---|---|---|
-|address|Address|The address of the authority contract associated with the colony.|
-
-**Contract Information**
-
-
-  - Name: `authority`
-  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/auth.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
-  
-
 ### `getToken.call()`
 
 Get the address of the ERC20 token contract that is the native token assigned to the Meta Colony.

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -50,13 +50,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the authority contract associated with the colony.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `authority`
-  - Contract: `dappsys/auth.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
   
 
 ### `getToken.call()`
@@ -72,13 +71,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the ERC20 token contract.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
   
@@ -105,13 +103,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |parentSkillId|number|The numeric ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IMetaColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `mintTokensForColonyNetwork.send({ amount }, options)`
@@ -134,13 +131,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IMetaColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
 ### `setNetworkFeeInverse.send({ feeInverse }, options)`
@@ -159,13 +155,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `Colony.sol`
-  - Interface: `IMetaColony.sol`
-  - Version: `0`
+  - Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
+  - Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/Colony.sol)
   
 
   

--- a/docs/_API_MetaColonyClient.md
+++ b/docs/_API_MetaColonyClient.md
@@ -50,6 +50,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |address|Address|The address of the authority contract associated with the colony.|
 
+**Network Information**
+
+
+  - Name: `authority`
+  - Contract: `dappsys/auth.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
+
 ### `getToken.call()`
 
 Get the address of the ERC20 token contract that is the native token assigned to the Meta Colony.
@@ -62,6 +71,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |address|Address|The address of the ERC20 token contract.|
+
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
   
 ## Senders
@@ -87,6 +105,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |parentSkillId|number|The numeric ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IMetaColony.sol`
+  - Version: `0`
+  
+
 ### `mintTokensForColonyNetwork.send({ amount }, options)`
 
 Mint tokens for the Colony Network. This can only be called from the Meta Colony, and only by the user assigned the `FOUNDER` role.
@@ -107,6 +134,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IMetaColony.sol`
+  - Version: `0`
+  
+
 ### `setNetworkFeeInverse.send({ feeInverse }, options)`
 
 Set the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100. This can only be called from the Meta Colony, and only by the user assigned the `FOUNDER` role.
@@ -122,6 +158,15 @@ Set the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse am
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `Colony.sol`
+  - Interface: `IMetaColony.sol`
+  - Version: `0`
+  
 
   
   

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -56,6 +56,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The amount of tokens that were approved (the amount `allowed`).|
 
+**Network Information**
+
+
+  - Name: `allowance`
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getBalanceOf.call({ sourceAddress })`
 
 Get the the token balance of an address.
@@ -74,6 +83,15 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The balance of tokens for the address.|
 
+**Network Information**
+
+
+  - Name: `balanceOf`
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getTokenInfo.call()`
 
 Get information about the token.
@@ -89,6 +107,15 @@ A promise which resolves to an object containing the following properties:
 |symbol|string|The symbol of the token.|
 |decimals|number|The number of decimals.|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `getTotalSupply.call()`
 
 Get the total supply of the token.
@@ -101,6 +128,15 @@ A promise which resolves to an object containing the following properties:
 |Return value|Type|Description|
 |---|---|---|
 |amount|BigNumber|The total supply of the token.|
+
+**Network Information**
+
+
+  - Name: `totalSupply`
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
   
 ## Senders
@@ -128,6 +164,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |value|BigNumber|The amount of tokens that were approved (the amount `allowed`).|
 |Approval|object|Contains the data defined in [Approval](#eventsapprovaladdlistener-owner-spender-value-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `burn.send({ amount }, options)`
 
 Burn tokens. This is an `ERC20Extended` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
@@ -147,6 +192,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |address|Address|The address that initiated the burn event.|
 |amount|BigNumber|The amount of tokens that were burned.|
 |Burn|object|Contains the data defined in [Burn](#eventsburnaddlistener-address-amount-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `ERC20Extended.sol`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `mint.send({ amount }, options)`
 
@@ -168,6 +222,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `ERC20Extended.sol`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `setAuthority.send({ authority }, options)`
 
 Assign an account the `ADMIN` authority role within a colony.
@@ -186,6 +249,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |authority|Address|The address that was assigned an authority role.|
 |LogSetAuthority|object|Contains the data defined in [LogSetAuthority](#eventslogsetauthorityaddlistener-authority-------)|
+
+**Network Information**
+
+
+  - Name: `authority`
+  - Contract: `dappsys/auth.sol`
+  - Interface: `IColony.sol`
+  - Version: `0`
+  
 
 ### `setOwner.send({ owner }, options)`
 
@@ -206,6 +278,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |owner|Address|The address that was assigned as the new owner.|
 |LogSetOwner|object|Contains the data defined in [LogSetOwner](#eventslogsetowneraddlistener-owner-------)|
 
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
+
 ### `transfer.send({ destinationAddress, amount }, options)`
 
 Transfer tokens from the address calling the function to another address. The current address must have a sufficient token balance.
@@ -222,6 +303,15 @@ Transfer tokens from the address calling the function to another address. The cu
 An instance of a `ContractResponse`
 
 
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
 ### `transferFrom.send({ sourceAddress, destinationAddress, amount }, options)`
 
@@ -245,6 +335,15 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |to|Address|The address that received the tokens.|
 |value|BigNumber|The amount of tokens that were transferred.|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+
+**Network Information**
+
+
+  
+  - Contract: `?`
+  - Interface: `?`
+  - Version: `0`
+  
 
   
   

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -60,8 +60,8 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `allowance`
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/erc20.sol)
+  
   
 
 ### `getBalanceOf.call({ sourceAddress })`
@@ -86,8 +86,8 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `balanceOf`
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/erc20.sol)
+  
   
 
 ### `getTokenInfo.call()`
@@ -109,8 +109,8 @@ A promise which resolves to an object containing the following properties:
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [name, symbol, decimals](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/name, symbol, decimals)
+  
   
 
 ### `getTotalSupply.call()`
@@ -130,8 +130,8 @@ A promise which resolves to an object containing the following properties:
 
 
   - Name: `totalSupply`
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/erc20.sol)
+  
   
 
   
@@ -164,8 +164,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/erc20.sol)
+  
   
 
 ### `burn.send({ amount }, options)`
@@ -192,8 +192,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   
-  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/ERC20Extended.sol)
+  
   
 
 ### `mint.send({ amount }, options)`
@@ -220,8 +220,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   
-  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/ERC20Extended.sol)
+  
   
 
 ### `setAuthority.send({ authority }, options)`
@@ -246,9 +246,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 **Contract Information**
 
 
-  - Name: `authority`
-  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
+  
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/auth.sol)
+  
   
 
 ### `setOwner.send({ owner }, options)`
@@ -274,8 +274,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/auth.sol)
+  
   
 
 ### `transfer.send({ destinationAddress, amount }, options)`
@@ -299,8 +299,8 @@ An instance of a `ContractResponse`
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/erc20.sol)
+  
   
 
 ### `transferFrom.send({ sourceAddress, destinationAddress, amount }, options)`
@@ -330,8 +330,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   
-  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/Token.sol)
+  
   
 
   

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -109,7 +109,7 @@ A promise which resolves to an object containing the following properties:
 
 
   
-  - Contract: [name, symbol, decimals](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/name, symbol, decimals)
+  - Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts/Token.sol)
   
   
 

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -193,7 +193,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `mint.send({ amount }, options)`
@@ -221,7 +221,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
   
   - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
-  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `setAuthority.send({ authority }, options)`
@@ -247,8 +247,8 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 
   - Name: `authority`
-  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
-  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626//auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/IColony.sol)
   
 
 ### `setOwner.send({ owner }, options)`

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -56,13 +56,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The amount of tokens that were approved (the amount `allowed`).|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `allowance`
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getBalanceOf.call({ sourceAddress })`
@@ -83,13 +82,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The balance of tokens for the address.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `balanceOf`
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getTokenInfo.call()`
@@ -107,13 +105,12 @@ A promise which resolves to an object containing the following properties:
 |symbol|string|The symbol of the token.|
 |decimals|number|The number of decimals.|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `getTotalSupply.call()`
@@ -129,13 +126,12 @@ A promise which resolves to an object containing the following properties:
 |---|---|---|
 |amount|BigNumber|The total supply of the token.|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `totalSupply`
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
   
@@ -164,13 +160,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |value|BigNumber|The amount of tokens that were approved (the amount `allowed`).|
 |Approval|object|Contains the data defined in [Approval](#eventsapprovaladdlistener-owner-spender-value-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `burn.send({ amount }, options)`
@@ -193,13 +188,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The amount of tokens that were burned.|
 |Burn|object|Contains the data defined in [Burn](#eventsburnaddlistener-address-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ERC20Extended.sol`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
   
 
 ### `mint.send({ amount }, options)`
@@ -222,13 +216,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|BigNumber|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `ERC20Extended.sol`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [ERC20Extended.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/ERC20Extended.sol)
   
 
 ### `setAuthority.send({ authority }, options)`
@@ -250,13 +243,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |authority|Address|The address that was assigned an authority role.|
 |LogSetAuthority|object|Contains the data defined in [LogSetAuthority](#eventslogsetauthorityaddlistener-authority-------)|
 
-**Network Information**
+**Contract Information**
 
 
   - Name: `authority`
-  - Contract: `dappsys/auth.sol`
-  - Interface: `IColony.sol`
-  - Version: `0`
+  - Contract: [dappsys/auth.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
+  - Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/dappsys/auth.sol)
   
 
 ### `setOwner.send({ owner }, options)`
@@ -278,13 +270,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |owner|Address|The address that was assigned as the new owner.|
 |LogSetOwner|object|Contains the data defined in [LogSetOwner](#eventslogsetowneraddlistener-owner-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `transfer.send({ destinationAddress, amount }, options)`
@@ -304,13 +295,12 @@ An instance of a `ContractResponse`
 
 
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
 ### `transferFrom.send({ sourceAddress, destinationAddress, amount }, options)`
@@ -336,13 +326,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |value|BigNumber|The amount of tokens that were transferred.|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-**Network Information**
+**Contract Information**
 
 
   
-  - Contract: `?`
-  - Interface: `?`
-  - Version: `0`
+  - Contract: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
+  - Interface: [?](https://github.com/JoinColony/colonyNetwork/tree/f73dc84a41f5fc1962c999a24e13b15ba491b8a6/contracts/?)
   
 
   

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -229,10 +229,12 @@ ${printContractData(ms.network)}
 }
 
 function printContractData(data) {
+  const colonyPath = `https://github.com/JoinColony/colonyNetwork/tree/${data.version}/contracts`
+  const contractPath = data.contractPath ? data.contractPath : colonyPath;
   return `
-  ${data.name ? '- Name: `' + data.name + '`': ''}
-  - Contract: [${data.contract}](https://github.com/JoinColony/colonyNetwork/tree/${data.version}/contracts/${data.contract})
-  - Interface: [${data.interface}](https://github.com/JoinColony/colonyNetwork/tree/${data.version}/contracts/${data.contract})
+  ${data.name ? `- Name: \`${data.name}\`` : ''}
+  ${data.contract ? `- Contract: [${data.contract}](${contractPath}/${data.contract})` : ''}
+  ${data.interface ? `- Interface: [${data.interface}](${colonyPath}/${data.interface})` : ''}
   `
 }
 

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -61,7 +61,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           returns: mapObjectProps(ast, params[1]),
-          network: getContractData(params[3]),
+          contractData: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'Sender') {
@@ -72,7 +72,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
-          network: getContractData(params[3]),
+          contractData: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'MultisigSender') {
@@ -83,7 +83,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
-          network: getContractData(params[3]),
+          contractData: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'Event') {
@@ -138,7 +138,7 @@ ${printProps('Return value', caller.returns)}
 
 **Contract Information**
 
-${printContractData(caller.network)}
+${printContractData(caller.contractData)}
 `,
     )
     .join('');
@@ -176,7 +176,7 @@ ${printProps('Event data', getEventProps(events, sender.events))}
 
 **Contract Information**
 
-${printContractData(sender.network)}
+${printContractData(sender.contractData)}
 `,
     )
     .join('');
@@ -222,7 +222,7 @@ ${printProps('Event Data', getEventProps(events, ms.events))}
 
 **Contract Information**
 
-${printContractData(ms.network)}
+${printContractData(ms.contractData)}
 `,
     )
     .join('');

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -61,6 +61,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           returns: mapObjectProps(ast, params[1]),
+          network: getNetworkData(params[3]),
         });
       }
       else if (p.value.id.name === 'Sender') {
@@ -71,6 +72,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
+          network: getNetworkData(params[3]),
         });
       }
       else if (p.value.id.name === 'MultisigSender') {
@@ -81,6 +83,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
+          network: getNetworkData(params[3]),
         });
       }
       else if (p.value.id.name === 'Event') {
@@ -132,6 +135,10 @@ ${caller.args && caller.args.length ? '\n**Arguments**\n\n' : ''}${printProps('A
 A promise which resolves to an object containing the following properties:
 
 ${printProps('Return value', caller.returns)}
+
+**Network Information**
+
+${printNetworkData(caller.network)}
 `,
     )
     .join('');
@@ -166,6 +173,10 @@ An instance of a \`ContractResponse\`${
 }
 
 ${printProps('Event data', getEventProps(events, sender.events))}
+
+**Network Information**
+
+${printNetworkData(sender.network)}
 `,
     )
     .join('');
@@ -208,9 +219,22 @@ ${ms.args && ms.args.length ? '\n**Arguments**\n\n' : ''}${printProps('Argument'
 An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose sender will eventually receive the following event data:' : ''}
 
 ${printProps('Event Data', getEventProps(events, ms.events))}
+
+**Network Information**
+
+${printNetworkData(ms.network)}
 `,
     )
     .join('');
+}
+
+function printNetworkData(data) {
+  return `
+  ${data.name ? '- Name: `' + data.name + '`': ''}
+  - Contract: \`${data.contract}\`
+  - Interface: \`${data.interface}\`
+  - Version: \`${data.version}\`
+  `
 }
 
 function printProps(title, props) {
@@ -269,6 +293,12 @@ function mapObjectProps(ast, param) {
 
 function getName(p) {
   return p.parent.parent.parent.value.key.name;
+}
+
+function getNetworkData(param) {
+  return param.properties.reduce((obj, item) => {
+    return (obj[item.key.name] = item.value.value, obj);
+  }, {});
 }
 
 function getDescription(ast, p) {

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -61,7 +61,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           returns: mapObjectProps(ast, params[1]),
-          network: getNetworkData(params[3]),
+          network: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'Sender') {
@@ -72,7 +72,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
-          network: getNetworkData(params[3]),
+          network: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'MultisigSender') {
@@ -83,7 +83,7 @@ const generateMarkdown = ({ file, templateFile, output }) => {
           description: getDescription(ast, p),
           args: mapObjectProps(ast, params[0]),
           events: mapObjectProps(ast, params[1]),
-          network: getNetworkData(params[3]),
+          network: getContractData(params[3]),
         });
       }
       else if (p.value.id.name === 'Event') {
@@ -136,9 +136,9 @@ A promise which resolves to an object containing the following properties:
 
 ${printProps('Return value', caller.returns)}
 
-**Network Information**
+**Contract Information**
 
-${printNetworkData(caller.network)}
+${printContractData(caller.network)}
 `,
     )
     .join('');
@@ -174,9 +174,9 @@ An instance of a \`ContractResponse\`${
 
 ${printProps('Event data', getEventProps(events, sender.events))}
 
-**Network Information**
+**Contract Information**
 
-${printNetworkData(sender.network)}
+${printContractData(sender.network)}
 `,
     )
     .join('');
@@ -220,20 +220,19 @@ An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose 
 
 ${printProps('Event Data', getEventProps(events, ms.events))}
 
-**Network Information**
+**Contract Information**
 
-${printNetworkData(ms.network)}
+${printContractData(ms.network)}
 `,
     )
     .join('');
 }
 
-function printNetworkData(data) {
+function printContractData(data) {
   return `
   ${data.name ? '- Name: `' + data.name + '`': ''}
-  - Contract: \`${data.contract}\`
-  - Interface: \`${data.interface}\`
-  - Version: \`${data.version}\`
+  - Contract: [${data.contract}](https://github.com/JoinColony/colonyNetwork/tree/${data.version}/contracts/${data.contract})
+  - Interface: [${data.interface}](https://github.com/JoinColony/colonyNetwork/tree/${data.version}/contracts/${data.contract})
   `
 }
 
@@ -295,7 +294,7 @@ function getName(p) {
   return p.parent.parent.parent.value.key.name;
 }
 
-function getNetworkData(param) {
+function getContractData(param) {
   return param.properties.reduce((obj, item) => {
     return (obj[item.key.name] = item.value.value, obj);
   }, {});

--- a/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
+++ b/packages/colony-js-client/src/ColonyClient/callers/GetTask.js
@@ -28,6 +28,7 @@ export default class GetTask extends ContractClient.Caller<
   // OutputValues generic pass through for now; it's overspecified
   *,
   ColonyClient,
+  *,
 > {
   constructor(params: *) {
     super({

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -717,19 +717,19 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Get the total number of claimed and waived reward payout cycles for a given user in the colony.
+  Get the total number of locked tokens for a given user in the colony.
   */
-  getUserRewardPayoutCount: ColonyClient.Caller<
+  getUserLock: ColonyClient.Caller<
     {
       user: Address, // The address of the user.
     },
     {
-      count: number, // The total number of reward payout cycles.
+      count: number, // The total number of locked tokens.
     },
     ColonyClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'TokenLocking.sol',
+      interface: 'ITokenLocking.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -1431,10 +1431,6 @@ export default class ColonyClient extends ContractClient {
       },
     });
     this.addCaller('getDomainCount', {
-      output: [['count', 'number']],
-    });
-    this.addCaller('getUserRewardPayoutCount', {
-      input: [['user', 'address']],
       output: [['count', 'number']],
     });
     this.addCaller('getNonRewardPotsTotal', {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1192,21 +1192,6 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Set the native token for the colony. This function can only be called by the user assigned the `FOUNDER` authority role.
-  */
-  setToken: ColonyClient.Sender<
-    {
-      token: Address, // The address of the token contract.
-    },
-    {},
-    ColonyClient,
-    {
-      contract: '?',
-      interface: '?',
-      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
-    },
-  >;
-  /*
   Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have either waived the reward payout cycle using `waiveRewardPayouts`, which means they forfeit a given number of reward payout cycles and unlock their share of tokens for those payout cycles, or reputation holders have claimed their rewards payout using `claimRewardPayout`, which means the payout was claimed and the tokens were transferred to their account.
   */
   startNextRewardPayout: ColonyClient.Sender<
@@ -1633,9 +1618,6 @@ export default class ColonyClient extends ContractClient {
         ['evaluatorAmount', 'bigNumber'],
         ['workerAmount', 'bigNumber'],
       ],
-    });
-    this.addSender('setToken', {
-      input: [['token', 'tokenAddress']],
     });
     this.addSender('submitTaskDeliverable', {
       input: [['taskId', 'number'], ['deliverableHash', 'ipfsHash']],

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -225,21 +225,6 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Assign the work rating for any task roles that did not receive a rating. In the event of a user not committing or revealing a work rating within the 10-day rating window (5-day maximum commit period and 5-day maximum reveal period), their counterpart is given the highest work rating possible (`3`) and the user who failed to commit or reveal their work rating will receive a reputation penalty.
-  */
-  assignWorkRating: ColonyClient.Sender<
-    {
-      taskId: number, // The numeric ID of the task.
-    },
-    {},
-    ColonyClient,
-    {
-      contract: 'ColonyTask.sol',
-      interface: '?',
-      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
-    },
-  >;
-  /*
   Bootstrap the colony by giving an initial amount of tokens and reputation to selected users. This function can only be called by the user assigned the `FOUNDER` authority role when the `taskCount` for the colony is equal to `0`.
    */
   bootstrapColony: ColonyClient.Sender<
@@ -1604,9 +1589,6 @@ export default class ColonyClient extends ContractClient {
     // Senders
     this.addSender('addDomain', {
       input: [['parentDomainId', 'number']],
-    });
-    this.addSender('assignWorkRating', {
-      input: [['taskId', 'number']],
     });
     this.addSender('claimColonyFunds', {
       input: [['token', 'tokenAddress']],

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -717,21 +717,6 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Get the total number of transactions that the colony has made. The total number of transactions is equal to the ID of the last transaction.
-  */
-  getTransactionCount: ColonyClient.Caller<
-    {},
-    {
-      count: number, // The total number of transactions that the colony has made.
-    },
-    ColonyClient,
-    {
-      contract: '?',
-      interface: '?',
-      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
-    },
-  >;
-  /*
   Get the total number of claimed and waived reward payout cycles for a given user in the colony.
   */
   getUserRewardPayoutCount: ColonyClient.Caller<

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1654,10 +1654,6 @@ export default class ColonyClient extends ContractClient {
     this.addSender('upgrade', {
       input: [['newVersion', 'number']],
     });
-    this.addSender('initialise', {
-      functionName: 'initialiseColony',
-      input: [['colonyNetwork', 'address']],
-    });
 
     // Remove duplicate/invalid signees and normalise lowercase
     const filterRequiredSignees = (signees: Array<Address>) =>

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -208,7 +208,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -221,7 +221,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -236,7 +236,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -254,7 +254,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -271,7 +271,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -288,7 +288,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -308,7 +308,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -325,7 +325,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -348,7 +348,7 @@ export default class ColonyClient extends ContractClient {
       name: 'makeTask',
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -361,7 +361,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -374,7 +374,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -389,7 +389,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -406,7 +406,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -424,7 +424,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -440,7 +440,7 @@ export default class ColonyClient extends ContractClient {
       name: 'authority',
       contract: 'dappsys/auth.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -458,7 +458,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -473,7 +473,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -488,7 +488,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -505,7 +505,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -523,7 +523,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -538,7 +538,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -553,7 +553,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -575,7 +575,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -601,7 +601,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -616,7 +616,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -635,7 +635,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -655,7 +655,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -673,7 +673,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -691,7 +691,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -706,7 +706,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -724,7 +724,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -739,7 +739,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -756,7 +756,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -772,7 +772,7 @@ export default class ColonyClient extends ContractClient {
       name: 'version',
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -790,7 +790,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -805,7 +805,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -823,7 +823,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -841,7 +841,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -859,7 +859,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -876,7 +876,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -891,7 +891,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -908,7 +908,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -925,7 +925,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -945,7 +945,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -962,7 +962,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -983,7 +983,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1000,7 +1000,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1015,7 +1015,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1031,7 +1031,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1049,7 +1049,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1067,7 +1067,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1085,7 +1085,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1103,7 +1103,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1121,7 +1121,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1139,7 +1139,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1157,7 +1157,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1176,7 +1176,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1195,7 +1195,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1214,7 +1214,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1229,7 +1229,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1246,7 +1246,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyFunding.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1265,7 +1265,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1285,7 +1285,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1302,7 +1302,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'ColonyTask.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1319,7 +1319,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -1334,7 +1334,7 @@ export default class ColonyClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -14,6 +14,7 @@ import TokenClient from '../TokenClient/index';
 import GetTask from './callers/GetTask';
 import CreateTask from './senders/CreateTask';
 import addRecoveryMethods from '../addRecoveryMethods';
+import addTokenLockingMethods from '../addTokenLockingMethods';
 import {
   ROLES,
   ADMIN_ROLE,
@@ -464,21 +465,6 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Get the total number of claimed and waived reward payout cycles in the colony.
-  */
-  getGlobalRewardPayoutCount: ColonyClient.Caller<
-    {},
-    {
-      count: number, // The total number of reward payout cycles.
-    },
-    ColonyClient,
-    {
-      contract: '?',
-      interface: '?',
-      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
-    },
-  >;
-  /*
   Get the total amount of funds that are not in the colony rewards pot. The total amount of funds that are not in the colony rewards pot is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
   */
   getNonRewardPotsTotal: ColonyClient.Caller<
@@ -693,6 +679,21 @@ export default class ColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
+    },
+  >;
+  /*
+  Get the total number of locked tokens in the colony.
+  */
+  getTotalLockCount: ColonyClient.Caller<
+    {},
+    {
+      count: number, // The total number of locked tokens in the colony.
+    },
+    ColonyClient,
+    {
+      contract: 'TokenLocking.sol',
+      interface: 'ITokenLocking.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -1371,6 +1372,7 @@ export default class ColonyClient extends ContractClient {
 
   initializeContractMethods() {
     addRecoveryMethods(this);
+    addTokenLockingMethods(this);
 
     this.getTask = new GetTask({ client: this });
 
@@ -1443,9 +1445,6 @@ export default class ColonyClient extends ContractClient {
       },
     });
     this.addCaller('getDomainCount', {
-      output: [['count', 'number']],
-    });
-    this.addCaller('getGlobalRewardPayoutCount', {
       output: [['count', 'number']],
     });
     this.addCaller('getUserRewardPayoutCount', {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -440,7 +440,7 @@ export default class ColonyClient extends ContractClient {
       name: 'authority',
       contract: 'auth.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       interface: 'IColony.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1192,7 +1192,7 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have either waived the reward payout cycle using `waiveRewardPayouts`, which means they forfeit a given number of reward payout cycles and unlock their share of tokens for those payout cycles, or reputation holders have claimed their rewards payout using `claimRewardPayout`, which means the payout was claimed and the tokens were transferred to their account.
+  Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have claimed their rewards payout using `claimRewardPayout`. Reputation holders can also waive their reward payout and unlock their tokens for past reward payout cycles by using `incrementLockCounterTo`.
   */
   startNextRewardPayout: ColonyClient.Sender<
     {
@@ -1282,17 +1282,18 @@ export default class ColonyClient extends ContractClient {
     },
   >;
   /*
-  Waive reward payout cycles. This unlocks tokens for a given number of reward payout cycles.
+  Increment the token lock counter. This method allows users to waive reward payouts for past reward payout cycles, unlocking the tokens that were locked in previous reward payout cycles.
   */
-  waiveRewardPayouts: ColonyClient.Sender<
+  incrementLockCounterTo: ColonyClient.Sender<
     {
-      numPayouts: number, // The number of reward payout cycles that will be waived.
+      token: TokenAddress, // The address of the token contract (an empty address if Ether).
+      lockId: number, // The numeric ID of the lock count that will be set.
     },
     {},
     ColonyClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'TokenLocking.sol',
+      interface: 'ITokenLocking.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -1631,9 +1632,6 @@ export default class ColonyClient extends ContractClient {
     });
     this.addSender('startNextRewardPayout', {
       input: [['token', 'tokenAddress']],
-    });
-    this.addSender('waiveRewardPayouts', {
-      input: [['numPayouts', 'number']],
     });
     this.addSender('submitTaskWorkRating', {
       input: [['taskId', 'number'], ['role', 'role'], ['secret', 'hexString']],

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -509,8 +509,9 @@ export default class ColonyClient extends ContractClient {
     },
     ColonyClient,
     {
-      contract: '?',
-      interface: '?',
+      name: 'numRecoveryRoles',
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -201,13 +201,29 @@ export default class ColonyClient extends ContractClient {
     {
       parentDomainId: number, // The numeric ID of the parent domain.
     },
-    { DomainAdded: DomainAdded },
+    {
+      DomainAdded: DomainAdded,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Indicate approval to exit colony recovery mode. This function can only be called by a user with a recovery role.
   */
-  approveExitRecovery: ColonyClient.Sender<{}, {}, ColonyClient>;
+  approveExitRecovery: ColonyClient.Sender<
+    {},
+    {},
+    ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Assign the work rating for any task roles that did not receive a rating. In the event of a user not committing or revealing a work rating within the 10-day rating window (5-day maximum commit period and 5-day maximum reveal period), their counterpart is given the highest work rating possible (`3`) and the user who failed to commit or reveal their work rating will receive a reputation penalty.
   */
@@ -217,6 +233,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Bootstrap the colony by giving an initial amount of tokens and reputation to selected users. This function can only be called by the user assigned the `FOUNDER` authority role when the `taskCount` for the colony is equal to `0`.
@@ -226,8 +247,15 @@ export default class ColonyClient extends ContractClient {
       users: Array<Address>, // The array of users that will recieve an initial amount of tokens and reputation.
       amounts: Array<BigNumber>, // The array of corresponding token and reputation amounts each user will recieve.
     },
-    { ColonyBootstrapped: ColonyBootstrapped },
+    {
+      ColonyBootstrapped: ColonyBootstrapped,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Cancel a task. Once a task is cancelled, no further changes to the task can be made.
@@ -236,8 +264,15 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The numeric ID of the task.
     },
-    { TaskCanceled: TaskCanceled },
+    {
+      TaskCanceled: TaskCanceled,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Claim funds that the colony has received by adding them to the funding pot of the root domain. A small fee is deducted from the funds claimed and added to the colony rewards pot. No fee is deducted when tokens native to the colony are claimed.
@@ -246,8 +281,15 @@ export default class ColonyClient extends ContractClient {
     {
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
     },
-    { ColonyFundsClaimed: ColonyFundsClaimed },
+    {
+      ColonyFundsClaimed: ColonyFundsClaimed,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Claim the payout assigned to a task role. This function can only be called by the user who is assigned a task role (`MANAGER`, `EVALUATOR`, or `WORKER`) after the task has been finalized.
@@ -263,6 +305,11 @@ export default class ColonyClient extends ContractClient {
       Transfer: Transfer,
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Mark a task as complete. If the user assigned the `WORKER` task role fails to submit the task deliverable by the due date, this function must be called by the user assigned the `MANAGER` task role. This allows the task work to be rated and the task to be finalized.
@@ -271,8 +318,15 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The numeric ID of the task.
     },
-    { TaskCompleted: TaskCompleted },
+    {
+      TaskCompleted: TaskCompleted,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Create a new task within the colony.
@@ -284,17 +338,45 @@ export default class ColonyClient extends ContractClient {
       skillId?: number, // The numeric ID of the skill (optional with a default value of `null`).
       dueDate?: Date, // The due date of the task (optional with a default value of `30` days from now).
     },
-    { TaskAdded: TaskAdded, PotAdded: PotAdded, DomainAdded: DomainAdded },
+    {
+      TaskAdded: TaskAdded,
+      PotAdded: PotAdded,
+      DomainAdded: DomainAdded,
+    },
     ColonyClient,
+    {
+      name: 'makeTask',
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Enter colony recovery mode. This function can only be called by a user with a recovery role.
   */
-  enterRecoveryMode: ColonyClient.Sender<{}, {}, ColonyClient>;
+  enterRecoveryMode: ColonyClient.Sender<
+    {},
+    {},
+    ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Exit colony recovery mode. This function can be called by anyone if enough whitelist approvals are given.
   */
-  exitRecoveryMode: ColonyClient.Sender<{}, {}, ColonyClient>;
+  exitRecoveryMode: ColonyClient.Sender<
+    {},
+    {},
+    ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Finalize the reward payout cycle. This function can only be called when the reward payout cycle has finished, i.e. 60 days have passed since the creation of the reward payout cycle.
   */
@@ -304,6 +386,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Finalize a task. Once a task is finalized, each user assigned a task role can claim the payout assigned to their role and no further changes to the task can be made.
@@ -312,8 +399,15 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The numeric ID of the task.
     },
-    { TaskFinalized: TaskFinalized },
+    {
+      TaskFinalized: TaskFinalized,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Generate the rating secret used in task ratings. This function returns a keccak256 hash created from the `salt` and `value`.
@@ -327,6 +421,11 @@ export default class ColonyClient extends ContractClient {
       secret: HexString, // A keccak256 hash that keeps the task rating hidden.
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the authority contract address associated with the colony.
@@ -337,6 +436,12 @@ export default class ColonyClient extends ContractClient {
       address: Address, // The address of the authority contract associated with the colony.
     },
     ColonyClient,
+    {
+      name: 'authority',
+      contract: 'dappsys/auth.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about a domain.
@@ -350,6 +455,11 @@ export default class ColonyClient extends ContractClient {
       potId: number, // The numeric ID of the funding pot.
     },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of domains in the colony. The return value is also the numeric ID of the last domain created.
@@ -360,6 +470,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of domains.
     },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of claimed and waived reward payout cycles in the colony.
@@ -370,6 +485,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of reward payout cycles.
     },
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the total amount of funds that are not in the colony rewards pot. The total amount of funds that are not in the colony rewards pot is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
@@ -382,6 +502,11 @@ export default class ColonyClient extends ContractClient {
       total: BigNumber, // The total amount of funds that are not in the colony rewards pot.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the balance of a funding pot.
@@ -395,6 +520,11 @@ export default class ColonyClient extends ContractClient {
       balance: BigNumber, // The balance of tokens (or Ether) in the funding pot.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of users that are assigned a colony recovery role.
@@ -405,6 +535,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of users that are assigned a colony recovery role.
     },
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100.
@@ -415,6 +550,11 @@ export default class ColonyClient extends ContractClient {
       rewardInverse: BigNumber, // The inverse amount of the reward.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about a reward payout cycle.
@@ -432,6 +572,11 @@ export default class ColonyClient extends ContractClient {
       totalTokens: BigNumber, // The total amount of tokens at the time the reward payout cycle started.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about a task.
@@ -453,6 +598,11 @@ export default class ColonyClient extends ContractClient {
       status: TaskStatus, // The task status (`ACTIVE`, `CANCELLED` or `FINALIZED`).
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of tasks in the colony. The return value is also the numeric ID of the last task created.
@@ -463,6 +613,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of tasks.
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the task payout amount assigned to a task role. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
@@ -477,6 +632,11 @@ export default class ColonyClient extends ContractClient {
       amount: BigNumber, // The amount of tokens (or Ether) assigned to the task role as a payout.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about a task role.
@@ -492,6 +652,11 @@ export default class ColonyClient extends ContractClient {
       rating: number, // The rating that the user received (`1`, `2`, or `3`).
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about the ratings of a task.
@@ -505,6 +670,11 @@ export default class ColonyClient extends ContractClient {
       date: Date, // The date that the last rating was submitted.
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the secret of a rating that has been submitted. If a task is in the commit period of the rating process, the ratings are hidden in a keccak256 hash that was created from a `salt` and `value`. The rating secret can be retrieved but in order to reveal the secret, one would have to know both the `salt` and `value` used to generate the secret.
@@ -518,6 +688,11 @@ export default class ColonyClient extends ContractClient {
       secret: HexString, // A keccak256 hash that keeps the task rating hidden.
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the address of the ERC20 token contract that is the native token assigned to the colony. The native token is the token used to calculate reputation scores, i.e. `1` token earned for completing a task with an adequate rating (`2`) will result in `1` reputation point earned.
@@ -528,6 +703,11 @@ export default class ColonyClient extends ContractClient {
       address: Address, // The address of the ERC20 token contract.
     },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total payout amount assigned to all task roles. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
@@ -541,6 +721,11 @@ export default class ColonyClient extends ContractClient {
       amount: BigNumber, // The total amount of tokens (or Ether) assigned to all task roles as payouts.
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of transactions that the colony has made. The total number of transactions is equal to the ID of the last transaction.
@@ -551,6 +736,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of transactions that the colony has made.
     },
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the total number of claimed and waived reward payout cycles for a given user in the colony.
@@ -563,6 +753,11 @@ export default class ColonyClient extends ContractClient {
       count: number, // The total number of reward payout cycles.
     },
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the version number of the colony contract. The version number starts at `1` and is incremented by `1` with every new version.
@@ -573,6 +768,12 @@ export default class ColonyClient extends ContractClient {
       version: number, // The version number of the colony contract.
     },
     ColonyClient,
+    {
+      name: 'version',
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Check whether a user has an authority role.
@@ -586,6 +787,11 @@ export default class ColonyClient extends ContractClient {
       hasRole: boolean, // A boolean indicating whether or not the user has the authority role.
     },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Check whether or not the colony is in recovery mode.
@@ -596,6 +802,11 @@ export default class ColonyClient extends ContractClient {
       inRecoveryMode: boolean, // A boolean indicating whether or not the colony is in recovery mode.
     },
     ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Mint new tokens. This function can only be called if the address of the colony contract is the owner of the token contract. If this is the case, then this function can only be called by the user assigned the `FOUNDER` authority role.
@@ -609,6 +820,11 @@ export default class ColonyClient extends ContractClient {
       Transfer: Transfer,
     },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Move funds from one pot to another.
@@ -622,6 +838,11 @@ export default class ColonyClient extends ContractClient {
     },
     { ColonyFundsMovedBetweenFundingPots: ColonyFundsMovedBetweenFundingPots },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Register an ENS label for the colony.
@@ -631,8 +852,15 @@ export default class ColonyClient extends ContractClient {
       colonyName: string, // The ENS label that will be registered for the colony.
       orbitDBPath: string, // The path of the OrbitDB database associated with the colony.
     },
-    { ColonyLabelRegistered: ColonyLabelRegistered },
+    {
+      ColonyLabelRegistered: ColonyLabelRegistered,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Remove the `ADMIN` authority role from a user. This function can only be called by the user assigned the `FOUNDER` authroity role.
@@ -641,8 +869,15 @@ export default class ColonyClient extends ContractClient {
     {
       user: Address, // The address that we will be unassigned the `ADMIN` authority role.
     },
-    { ColonyAdminRoleRemoved: ColonyAdminRoleRemoved },
+    {
+      ColonyAdminRoleRemoved: ColonyAdminRoleRemoved,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Remove the colony recovery role from a user. This function can only be called by the `FOUNDER` authority role.
@@ -653,6 +888,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Remove the `EVALUATOR` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
@@ -661,8 +901,15 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The numeric ID of the task.
     },
-    { TaskRoleUserSet: TaskRoleUserSet },
+    {
+      TaskRoleUserSet: TaskRoleUserSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Remove the `WORKER` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
@@ -671,8 +918,15 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The numeric ID of the task.
     },
-    { TaskRoleUserSet: TaskRoleUserSet },
+    {
+      TaskRoleUserSet: TaskRoleUserSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Reveal a submitted work rating. In order to reveal a work rating, the same `salt` and `value` used to generate the `secret` when the task work rating was submitted must be provided again here to reveal the task work rating.
@@ -684,8 +938,15 @@ export default class ColonyClient extends ContractClient {
       rating: number, // The rating that was submitted (`1`, `2`, or `3`).
       salt: string, // The string that was used to generate the secret.
     },
-    { TaskWorkRatingRevealed: TaskWorkRatingRevealed },
+    {
+      TaskWorkRatingRevealed: TaskWorkRatingRevealed,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign the `ADMIN` authority role to a user. This function can only be called by the user assigned the `FOUNDER` authority role or a user assigned the `ADMIN` authority role. There is no limit to the number of users that can be assigned the `ADMIN` authority role.
@@ -694,8 +955,15 @@ export default class ColonyClient extends ContractClient {
     {
       user: Address, // The address that will be assigned the `ADMIN` authroity role.
     },
-    { ColonyAdminRoleSet: ColonyAdminRoleSet },
+    {
+      ColonyAdminRoleSet: ColonyAdminRoleSet,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the payouts for all task roles (`MANAGER`, `EVALUATOR`, and `WORKER`). This can only be called by the user assigned the `MANAGER` task role and only if the `EVALUATOR` and `WORKER` task roles are either not assigned or assigned to the same user as the `MANAGER` task role.
@@ -712,6 +980,11 @@ export default class ColonyClient extends ContractClient {
       TaskPayoutSet: TaskPayoutSet,
     },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign the `FOUNDER` authority role to a user. This function can only be called by the user currently assigned the `FOUNDER` authority role. There can only be one address assigned to the `FOUNDER` authority role, therefore, the user currently assigned will forfeit their role.
@@ -720,8 +993,15 @@ export default class ColonyClient extends ContractClient {
     {
       user: Address, // The address that will be assigned the `FOUNDER` authority role.
     },
-    { ColonyFounderRoleSet: ColonyFounderRoleSet },
+    {
+      ColonyFounderRoleSet: ColonyFounderRoleSet,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign a colony recovery role to a user. This function can only be called by the `FOUNDER` authority role.
@@ -732,6 +1012,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
@@ -743,6 +1028,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Set the task specification. The task specification, or "task brief", is a description of the work that must be completed for the task. The description is hashed and stored with the task for future reference during the rating process or in the event of a dispute.
@@ -752,8 +1042,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       specificationHash: IPFSHash, // The specification hash of the task (an IPFS hash).
     },
-    { TaskBriefSet: TaskBriefSet },
+    {
+      TaskBriefSet: TaskBriefSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the domain of a task. Every task must belong to a domain. This function can only be called by the user assigned the `MANAGER` task role.
@@ -763,8 +1060,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       domainId: number, // The numeric ID of the domain.
     },
-    { TaskDomainSet: TaskDomainSet },
+    {
+      TaskDomainSet: TaskDomainSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the due date of a task. The due date is the last day that the user assigned the `WORKER` task role can submit the task deliverable.
@@ -774,8 +1078,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       dueDate: Date, // The due date of the task.
     },
-    { TaskDueDateSet: TaskDueDateSet },
+    {
+      TaskDueDateSet: TaskDueDateSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign the `EVALUATOR` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `EVALUATOR` task role must both sign the transaction before it can be executed.
@@ -785,8 +1096,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       user: Address, // The address that will be assigned the `EVALUATOR` task role.
     },
-    { TaskRoleUserSet: TaskRoleUserSet },
+    {
+      TaskRoleUserSet: TaskRoleUserSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign the `MANAGER` task role to a user. This function can only be called before the task is finalized. The user currently assigned the `MANAGER` task role and the user being assigned the `MANAGER` task role must both sign the transaction before it can be executed.
@@ -796,8 +1114,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       user: Address, // The address that will be assigned the `MANANAGER` task role.
     },
-    { TaskRoleUserSet: TaskRoleUserSet },
+    {
+      TaskRoleUserSet: TaskRoleUserSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the skill of a task. Only one skill can be assigned per task. The user assigned the `MANAGER` task role and the user assigned the `WORKER` task role must both sign this transaction before it can be executed.
@@ -807,8 +1132,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       skillId: number, // The numeric ID of the skill.
     },
-    { TaskSkillSet: TaskSkillSet },
+    {
+      TaskSkillSet: TaskSkillSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Assign the `WORKER` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `WORKER` task role must both sign the transaction before it can be executed.
@@ -818,8 +1150,15 @@ export default class ColonyClient extends ContractClient {
       taskId: number, // The numeric ID of the task.
       user: Address, // The address that will be assigned the `WORKER` task role.
     },
-    { TaskRoleUserSet: TaskRoleUserSet },
+    {
+      TaskRoleUserSet: TaskRoleUserSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the payout amount for the `MANAGER` task role.
@@ -830,8 +1169,15 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The payout amount in tokens (or Ether).
     },
-    { TaskPayoutSet: TaskPayoutSet },
+    {
+      TaskPayoutSet: TaskPayoutSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the payout amount for the `EVALUATOR` task role.
@@ -842,8 +1188,15 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The payout amount in tokens (or Ether).
     },
-    { TaskPayoutSet: TaskPayoutSet },
+    {
+      TaskPayoutSet: TaskPayoutSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the payout amount for the `WORKER` task role.
@@ -854,8 +1207,15 @@ export default class ColonyClient extends ContractClient {
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The payout amount in tokens (or Ether).
     },
-    { TaskPayoutSet: TaskPayoutSet },
+    {
+      TaskPayoutSet: TaskPayoutSet,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the native token for the colony. This function can only be called by the user assigned the `FOUNDER` authority role.
@@ -866,6 +1226,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have either waived the reward payout cycle using `waiveRewardPayouts`, which means they forfeit a given number of reward payout cycles and unlock their share of tokens for those payout cycles, or reputation holders have claimed their rewards payout using `claimRewardPayout`, which means the payout was claimed and the tokens were transferred to their account.
@@ -874,8 +1239,15 @@ export default class ColonyClient extends ContractClient {
     {
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
     },
-    { RewardPayoutCycleStarted: RewardPayoutCycleStarted },
+    {
+      RewardPayoutCycleStarted: RewardPayoutCycleStarted,
+    },
     ColonyClient,
+    {
+      contract: 'ColonyFunding.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Submit the task deliverable. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted.
@@ -890,6 +1262,11 @@ export default class ColonyClient extends ContractClient {
       TaskDeliverableSubmitted: TaskDeliverableSubmitted,
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Submit the task deliverable and the work rating for the user assigned the `MANAGER` task role. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
@@ -905,6 +1282,11 @@ export default class ColonyClient extends ContractClient {
       TaskDeliverableSubmitted: TaskDeliverableSubmitted,
     },
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Submit a work rating for a task. This function can only be called by the user assigned the `EVALUATOR` task role, who is submitting a rating for the user assigned the `WORKER` task role, or the user assigned the `WORKER` task role, who is submitting a rating for the user assigned the `MANAGER` task role. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
@@ -917,6 +1299,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: 'ColonyTask.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Upgrade the colony to a new contract version. The new version number must be higher than the current version. Downgrading to old contract versions is not permitted.
@@ -925,8 +1312,15 @@ export default class ColonyClient extends ContractClient {
     {
       newVersion: number, // The version number of the colony contract.
     },
-    { ColonyUpgraded: ColonyUpgraded },
+    {
+      ColonyUpgraded: ColonyUpgraded,
+    },
     ColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Waive reward payout cycles. This unlocks tokens for a given number of reward payout cycles.
@@ -937,6 +1331,11 @@ export default class ColonyClient extends ContractClient {
     },
     {},
     ColonyClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
 
   static get defaultQuery() {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -438,7 +438,9 @@ export default class ColonyClient extends ContractClient {
     ColonyClient,
     {
       name: 'authority',
-      contract: 'dappsys/auth.sol',
+      contract: 'auth.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
       interface: 'IColony.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },

--- a/packages/colony-js-client/src/ColonyClient/senders/CreateTask.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/CreateTask.js
@@ -23,6 +23,7 @@ export default class CreateTask extends ContractClient.Sender<
   InputValues,
   OutputValues,
   ColonyClient,
+  *,
 > {
   async send(inputValues: InputValues, options: *) {
     // Validate that the domain exists before attempting to create a task

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -399,8 +399,9 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     ColonyNetworkClient,
     {
-      contract: '?',
-      interface: '?',
+      name: 'numRecoveryRoles',
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -188,8 +188,9 @@ export default class ColonyNetworkClient extends ContractClient {
     {},
     ColonyNetworkClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'Token.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -108,7 +108,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -126,7 +126,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -139,7 +139,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -156,7 +156,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -173,7 +173,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -190,7 +190,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -208,7 +208,7 @@ export default class ColonyNetworkClient extends ContractClient {
       name: 'supportsInterface',
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -221,7 +221,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -234,7 +234,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -252,7 +252,7 @@ export default class ColonyNetworkClient extends ContractClient {
       name: 'addr',
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -270,7 +270,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -287,7 +287,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -302,7 +302,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -319,7 +319,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -334,7 +334,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -350,7 +350,7 @@ export default class ColonyNetworkClient extends ContractClient {
       name: 'getMetaColony',
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -368,7 +368,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -385,7 +385,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -400,7 +400,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -415,7 +415,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -434,7 +434,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -449,7 +449,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -464,7 +464,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -481,7 +481,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -496,7 +496,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -513,7 +513,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -531,7 +531,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -546,7 +546,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -561,7 +561,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -577,7 +577,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ContractRecovery.sol',
       interface: 'IRecovery.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -594,7 +594,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -610,7 +610,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetworkENS.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -627,7 +627,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetworkAuction.sol',
       interface: 'IColonyNetwork.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
 

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -101,8 +101,15 @@ export default class ColonyNetworkClient extends ContractClient {
       version: number, // The versions number of the colony contract.
       resolver: Address, // The address of the resolver contract.
     },
-    { ColonyVersionAdded: ColonyVersionAdded },
+    {
+      ColonyVersionAdded: ColonyVersionAdded,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Add a new global or local skill to the skills tree.
@@ -112,13 +119,29 @@ export default class ColonyNetworkClient extends ContractClient {
       parentSkillId: number, // The numeric ID of the skill under which the new skill will be added.
       globalSkill: boolean, // A boolean indicating whether or not the skill will be a global skill.
     },
-    { SkillAdded: SkillAdded },
+    {
+      SkillAdded: SkillAdded,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Indicate approval to exit network recovery mode. This function can only be called by a user with a recovery role.
   */
-  approveExitRecovery: ColonyNetworkClient.Sender<{}, {}, ColonyNetworkClient>;
+  approveExitRecovery: ColonyNetworkClient.Sender<
+    {},
+    {},
+    ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Create a new colony on the network.
   */
@@ -126,8 +149,15 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       tokenAddress: Address, // The address of the token contract.
     },
-    { ColonyAdded: ColonyAdded },
+    {
+      ColonyAdded: ColonyAdded,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Create the Meta Colony.
@@ -136,8 +166,15 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       tokenAddress: Address, // The address of the token contract.
     },
-    { MetaColonyCreated: MetaColonyCreated },
+    {
+      MetaColonyCreated: MetaColonyCreated,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Create a new ERC20 token contract.
@@ -150,6 +187,11 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     {},
     ColonyNetworkClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Check whether or not ENS supports a contract interface. A supported contract interface implements `interfaceId`.
@@ -162,15 +204,39 @@ export default class ColonyNetworkClient extends ContractClient {
       isSupported: boolean, // A boolean indicating whether or not the contract interface is supported.
     },
     ColonyNetworkClient,
+    {
+      name: 'supportsInterface',
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Enter network recovery mode. This function can only be called by a user with a recovery role.
   */
-  enterRecoveryMode: ColonyNetworkClient.Sender<{}, {}, ColonyNetworkClient>;
+  enterRecoveryMode: ColonyNetworkClient.Sender<
+    {},
+    {},
+    ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Exit network recovery mode. This function can be called by anyone if enough whitelist approvals are given.
   */
-  exitRecoveryMode: ColonyNetworkClient.Sender<{}, {}, ColonyNetworkClient>;
+  exitRecoveryMode: ColonyNetworkClient.Sender<
+    {},
+    {},
+    ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
+  >;
   /*
   Get the address of a registered ENS label. This function will return an empty address if an ENS label has not been registered.
   */
@@ -182,6 +248,12 @@ export default class ColonyNetworkClient extends ContractClient {
       ensAddress: Address, // The address associated with the ENS label.
     },
     ColonyNetworkClient,
+    {
+      name: 'addr',
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the ID of a child skill.
@@ -195,6 +267,11 @@ export default class ColonyNetworkClient extends ContractClient {
       childSkillId: number, // The numeric ID of the child skill.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the colony contract address for a colony.
@@ -207,6 +284,11 @@ export default class ColonyNetworkClient extends ContractClient {
       address: Address, // The address of the colony contract.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of colonies on the network. The return value is also the numeric ID of the last colony created.
@@ -217,6 +299,11 @@ export default class ColonyNetworkClient extends ContractClient {
       count: number, // The total number of colonies.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the address of the resolver contract for a specific colony version.
@@ -229,6 +316,11 @@ export default class ColonyNetworkClient extends ContractClient {
       address: Address, // The address of the resolver contract.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the latest colony contract version. This is the version used to create all new colonies.
@@ -239,6 +331,11 @@ export default class ColonyNetworkClient extends ContractClient {
       version: number, // The version number of the latest colony contract.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the Meta Colony contract address.
@@ -249,6 +346,12 @@ export default class ColonyNetworkClient extends ContractClient {
       address: Address, // The address of the Meta Colony contract.
     },
     ColonyNetworkClient,
+    {
+      name: 'getMetaColony',
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the ID of a parent skill.
@@ -262,6 +365,11 @@ export default class ColonyNetworkClient extends ContractClient {
       parentSkillId: number, // The numeric ID of the parent skill.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the address of the OrbitDB database associaated with a user profile.
@@ -274,6 +382,11 @@ export default class ColonyNetworkClient extends ContractClient {
       orbitDBAddress: string, // The path of the OrbitDB database associated with the user profile.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of users that are assigned a network recovery role.
@@ -284,6 +397,11 @@ export default class ColonyNetworkClient extends ContractClient {
       count: number, // The total number of users that are assigned a colony recovery role.
     },
     ColonyNetworkClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the ID of the root global skill.
@@ -294,6 +412,11 @@ export default class ColonyNetworkClient extends ContractClient {
       skillId: number, // The numeric ID of the root global skill.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get information about a domain.
@@ -308,6 +431,11 @@ export default class ColonyNetworkClient extends ContractClient {
       isGlobalSkill: boolean, // A boolean indicating whether or not the skill is a global skill.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the total number of global and local skills in the network.
@@ -318,6 +446,11 @@ export default class ColonyNetworkClient extends ContractClient {
       count: number, // The total number of global and local skills in the network.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Get the token locking contract address.
@@ -328,6 +461,11 @@ export default class ColonyNetworkClient extends ContractClient {
       lockingAddress: Address, // The address of the token locking contract.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Check whether or not an address is a colony contract.
@@ -340,6 +478,11 @@ export default class ColonyNetworkClient extends ContractClient {
       isColony: boolean, // A boolean indicating whether or not an address is a colony contract.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Check whether or not the network is in recovery mode.
@@ -350,6 +493,11 @@ export default class ColonyNetworkClient extends ContractClient {
       inRecoveryMode: boolean, // A boolean indicating whether or not the network is in recovery mode.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Lookup the registed ENS label for an address. This function will return an empty string if the address does not have a registered ENS label.
@@ -362,6 +510,11 @@ export default class ColonyNetworkClient extends ContractClient {
       domain: string, // The ENS label associated with the address.
     },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Register an ENS label for a user.
@@ -371,8 +524,15 @@ export default class ColonyNetworkClient extends ContractClient {
       username: string, // The ENS label that will be registered for the user.
       orbitDBPath: string, // The path of the OrbitDB database associated with the user profile.
     },
-    { UserLabelRegistered: UserLabelRegistered },
+    {
+      UserLabelRegistered: UserLabelRegistered,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Remove the network recovery role from a user. This function can only be called by the `FOUNDER` authority role.
@@ -383,6 +543,11 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     {},
     ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Assign a network recovery role to a user. This function can only be called by the `FOUNDER` authority role.
@@ -393,6 +558,11 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     {},
     ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
@@ -404,6 +574,11 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     {},
     ColonyNetworkClient,
+    {
+      contract: 'ContractRecovery.sol',
+      interface: 'IRecovery.sol',
+      version: 0,
+    },
   >;
   /*
   Set the token locking address.
@@ -412,8 +587,15 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       tokenLockingAddress: Address, // The address of the locking contract.
     },
-    { TokenLockingAddressSet: TokenLockingAddressSet },
+    {
+      TokenLockingAddressSet: TokenLockingAddressSet,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetwork.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Set up the registrar.
@@ -425,6 +607,11 @@ export default class ColonyNetworkClient extends ContractClient {
     },
     {},
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetworkENS.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
   /*
   Create and start an auction for a token owned by the Colony Network. The auction will be for the total amount of the specificed tokens that are owned by the Colony Network.
@@ -433,8 +620,15 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       tokenAddress: Address, // The address of the token contract.
     },
-    { AuctionCreated: AuctionCreated },
+    {
+      AuctionCreated: AuctionCreated,
+    },
     ColonyNetworkClient,
+    {
+      contract: 'ColonyNetworkAuction.sol',
+      interface: 'IColonyNetwork.sol',
+      version: 0,
+    },
   >;
 
   static get defaultQuery() {

--- a/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
@@ -6,12 +6,12 @@ export default class CreateToken<
   InputValues: *,
   OutputValues: *,
   Client: *,
-  NetworkData: *,
+  ContractData: *,
 > extends ContractClient.Sender<
   InputValues,
   OutputValues,
   Client,
-  NetworkData,
+  ContractData,
 > {
   constructor({
     name = 'createToken',

--- a/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
@@ -6,7 +6,13 @@ export default class CreateToken<
   InputValues: *,
   OutputValues: *,
   Client: *,
-> extends ContractClient.Sender<InputValues, OutputValues, Client> {
+  NetworkData: *,
+> extends ContractClient.Sender<
+  InputValues,
+  OutputValues,
+  Client,
+  NetworkData,
+> {
   constructor({
     name = 'createToken',
     defaultValues = { decimals: 18 },

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -39,8 +39,15 @@ export default class MetaColonyClient extends ContractClient {
     {
       parentSkillId: number, // The numeric ID of the skill under which the new skill will be added.
     },
-    { SkillAdded: SkillAdded },
+    {
+      SkillAdded: SkillAdded,
+    },
     MetaColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IMetaColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the authority contract address associated with the colony.
@@ -51,6 +58,12 @@ export default class MetaColonyClient extends ContractClient {
       address: Address, // The address of the authority contract associated with the colony.
     },
     MetaColonyClient,
+    {
+      name: 'authority',
+      contract: 'dappsys/auth.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Get the address of the ERC20 token contract that is the native token assigned to the Meta Colony.
@@ -61,6 +74,11 @@ export default class MetaColonyClient extends ContractClient {
       address: Address, // The address of the ERC20 token contract.
     },
     MetaColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Mint tokens for the Colony Network. This can only be called from the Meta Colony, and only by the user assigned the `FOUNDER` role.
@@ -69,8 +87,15 @@ export default class MetaColonyClient extends ContractClient {
     {
       amount: BigNumber, // The amount of new tokens that will be minted.
     },
-    { Mint: Mint },
+    {
+      Mint: Mint,
+    },
     MetaColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IMetaColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100. This can only be called from the Meta Colony, and only by the user assigned the `FOUNDER` role.
@@ -81,6 +106,11 @@ export default class MetaColonyClient extends ContractClient {
     },
     {},
     MetaColonyClient,
+    {
+      contract: 'Colony.sol',
+      interface: 'IMetaColony.sol',
+      version: 0,
+    },
   >;
 
   static get defaultQuery() {

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -46,7 +46,7 @@ export default class MetaColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IMetaColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -62,7 +62,7 @@ export default class MetaColonyClient extends ContractClient {
       name: 'authority',
       contract: 'dappsys/auth.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -77,7 +77,7 @@ export default class MetaColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -94,7 +94,7 @@ export default class MetaColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IMetaColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -109,7 +109,7 @@ export default class MetaColonyClient extends ContractClient {
     {
       contract: 'Colony.sol',
       interface: 'IMetaColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
 

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -168,6 +168,9 @@ export default class MetaColonyClient extends ContractClient {
     this.addSender('mintTokensForColonyNetwork', {
       input: [['amount', 'bigNumber']],
     });
+    this.addSender('setNetworkFeeInverse', {
+      input: [['feeInverse', 'number']],
+    });
   }
 
   async getReputation({

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -50,24 +50,6 @@ export default class MetaColonyClient extends ContractClient {
     },
   >;
   /*
-  Get the authority contract address associated with the colony.
-  */
-  getAuthority: MetaColonyClient.Caller<
-    {},
-    {
-      address: Address, // The address of the authority contract associated with the colony.
-    },
-    MetaColonyClient,
-    {
-      name: 'authority',
-      contract: 'auth.sol',
-      // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
-      interface: 'IColony.sol',
-      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
-    },
-  >;
-  /*
   Get the address of the ERC20 token contract that is the native token assigned to the Meta Colony.
   */
   getToken: MetaColonyClient.Caller<
@@ -175,10 +157,6 @@ export default class MetaColonyClient extends ContractClient {
     /* eslint-enable max-len */
 
     // Callers
-    this.addCaller('getAuthority', {
-      functionName: 'authority',
-      output: [['address', 'address']],
-    });
     this.addCaller('getToken', {
       output: [['address', 'address']],
     });

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -62,7 +62,7 @@ export default class MetaColonyClient extends ContractClient {
       name: 'authority',
       contract: 'auth.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       interface: 'IColony.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },

--- a/packages/colony-js-client/src/MetaColonyClient/index.js
+++ b/packages/colony-js-client/src/MetaColonyClient/index.js
@@ -60,7 +60,9 @@ export default class MetaColonyClient extends ContractClient {
     MetaColonyClient,
     {
       name: 'authority',
-      contract: 'dappsys/auth.sol',
+      contract: 'auth.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
       interface: 'IColony.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },

--- a/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
+++ b/packages/colony-js-client/src/TokenClient/callers/GetTokenInfo.js
@@ -12,6 +12,7 @@ export default class GetTokenInfo extends ContractClient.Caller<
   InputValues,
   *,
   TokenClient,
+  *,
 > {
   constructor(params: *) {
     super({

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -49,8 +49,15 @@ export default class TokenClient extends ContractClient {
       user: Address, // The address that will be approved for the allowance (the token `spender`).
       amount: BigNumber, // The amount of tokens that will be approved (the amount `allowed`).
     },
-    { Approval: Approval },
+    {
+      Approval: Approval,
+    },
     TokenClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Burn tokens. This is an `ERC20Extended` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
@@ -59,8 +66,15 @@ export default class TokenClient extends ContractClient {
     {
       amount: BigNumber, // The amount of tokens that will be burned.
     },
-    { Burn: Burn },
+    {
+      Burn: Burn,
+    },
     TokenClient,
+    {
+      contract: 'ERC20Extended.sol',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the token allowance of an address. The allowance is the amount of tokens that the `spender` is authorized to transfer using the `transferFrom` function.
@@ -74,6 +88,12 @@ export default class TokenClient extends ContractClient {
       amount: BigNumber, // The amount of tokens that were approved (the amount `allowed`).
     },
     TokenClient,
+    {
+      name: 'allowance',
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the the token balance of an address.
@@ -86,6 +106,12 @@ export default class TokenClient extends ContractClient {
       amount: BigNumber, // The balance of tokens for the address.
     },
     TokenClient,
+    {
+      name: 'balanceOf',
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get information about the token.
@@ -98,6 +124,11 @@ export default class TokenClient extends ContractClient {
       decimals: number, // The number of decimals.
     },
     TokenClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Get the total supply of the token.
@@ -108,6 +139,12 @@ export default class TokenClient extends ContractClient {
       amount: BigNumber, // The total supply of the token.
     },
     TokenClient,
+    {
+      name: 'totalSupply',
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Mint new tokens. This is an `ERC20Extended` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
@@ -116,8 +153,15 @@ export default class TokenClient extends ContractClient {
     {
       amount: BigNumber, // The amount of tokens that will be minted.
     },
-    { Mint: Mint },
+    {
+      Mint: Mint,
+    },
     TokenClient,
+    {
+      contract: 'ERC20Extended.sol',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Assign an account the `ADMIN` authority role within a colony.
@@ -126,8 +170,16 @@ export default class TokenClient extends ContractClient {
     {
       authority: Address, // The address that will be assigned the `ADMIN` authority role.
     },
-    { LogSetAuthority: LogSetAuthority },
+    {
+      LogSetAuthority: LogSetAuthority,
+    },
     TokenClient,
+    {
+      name: 'authority',
+      contract: 'dappsys/auth.sol',
+      interface: 'IColony.sol',
+      version: 0,
+    },
   >;
   /*
   Set the `owner` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
@@ -136,8 +188,15 @@ export default class TokenClient extends ContractClient {
     {
       owner: Address, // The address that will be assigned as the new owner.
     },
-    { LogSetOwner: LogSetOwner },
+    {
+      LogSetOwner: LogSetOwner,
+    },
     TokenClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Transfer tokens from the address calling the function to another address. The current address must have a sufficient token balance.
@@ -149,6 +208,11 @@ export default class TokenClient extends ContractClient {
     },
     {},
     TokenClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
   /*
   Transfer tokens from one address to another address. The address the tokens are transferred from must have a sufficient token balance and it must have a sufficient token allowance approved by the token owner.
@@ -159,8 +223,15 @@ export default class TokenClient extends ContractClient {
       destinationAddress: Address, // The address to which tokens will be transferred.
       amount: BigNumber, // The amount of tokens that will be transferred.
     },
-    { Transfer: Transfer },
+    {
+      Transfer: Transfer,
+    },
     TokenClient,
+    {
+      contract: '?',
+      interface: '?',
+      version: 0,
+    },
   >;
 
   static get defaultQuery() {

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -54,8 +54,9 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'erc20.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -72,7 +73,8 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       contract: 'ERC20Extended.sol',
-      interface: '?',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -90,8 +92,9 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       name: 'allowance',
-      contract: '?',
-      interface: '?',
+      contract: 'erc20.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -108,8 +111,9 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       name: 'balanceOf',
-      contract: '?',
-      interface: '?',
+      contract: 'erc20.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -125,8 +129,9 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'name, symbol, decimals',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -141,8 +146,9 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       name: 'totalSupply',
-      contract: '?',
-      interface: '?',
+      contract: 'erc20.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -159,7 +165,8 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       contract: 'ERC20Extended.sol',
-      interface: '?',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -175,11 +182,9 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      name: 'authority',
       contract: 'auth.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
-      interface: 'IColony.sol',
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -195,8 +200,9 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'auth.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -211,8 +217,9 @@ export default class TokenClient extends ContractClient {
     {},
     TokenClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'erc20.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
@@ -230,8 +237,9 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: '?',
-      interface: '?',
+      contract: 'Token.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -129,7 +129,7 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: 'name, symbol, decimals',
+      contract: 'Token.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/JoinColony/colonyToken/blob/7359eedaadacd55a1393c795964bd61513b2af33/contracts',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -56,7 +56,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -73,7 +73,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: 'ERC20Extended.sol',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -92,7 +92,7 @@ export default class TokenClient extends ContractClient {
       name: 'allowance',
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -110,7 +110,7 @@ export default class TokenClient extends ContractClient {
       name: 'balanceOf',
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -127,7 +127,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -143,7 +143,7 @@ export default class TokenClient extends ContractClient {
       name: 'totalSupply',
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -160,7 +160,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: 'ERC20Extended.sol',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -178,7 +178,7 @@ export default class TokenClient extends ContractClient {
       name: 'authority',
       contract: 'dappsys/auth.sol',
       interface: 'IColony.sol',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -195,7 +195,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -211,7 +211,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
   /*
@@ -230,7 +230,7 @@ export default class TokenClient extends ContractClient {
     {
       contract: '?',
       interface: '?',
-      version: 0,
+      version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },
   >;
 

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -256,6 +256,7 @@ export default class TokenClient extends ContractClient {
     const destinationAddress = ['destinationAddress', 'address'];
     const user = ['user', 'address'];
 
+    // Events
     this.addEvent('Transfer', [
       ['from', 'address'],
       ['to', 'address'],
@@ -271,49 +272,42 @@ export default class TokenClient extends ContractClient {
     this.addEvent('LogSetOwner', [['owner', 'address']]);
     this.addEvent('LogSetAuthority', [['authority', 'address']]);
 
+    // Callers
     this.getTokenInfo = new GetTokenInfo({ client: this });
-
     this.addCaller('getTotalSupply', {
       functionName: 'totalSupply',
       output: [amount],
     });
-
     this.addCaller('getBalanceOf', {
       functionName: 'balanceOf',
       input: [sourceAddress],
       output: [amount],
     });
-
     this.addCaller('getAllowance', {
       functionName: 'allowance',
       input: [sourceAddress, user],
       output: [amount],
     });
 
+    // Senders
     this.addSender('transfer', {
       input: [destinationAddress, amount],
     });
-
     this.addSender('transferFrom', {
       input: [sourceAddress, destinationAddress, amount],
     });
-
     this.addSender('approve', {
       input: [user, amount],
     });
-
     this.addSender('mint', {
       input: [amount],
     });
-
     this.addSender('burn', {
       input: [amount],
     });
-
     this.addSender('setOwner', {
       input: [['owner', 'address']],
     });
-
     this.addSender('setAuthority', {
       input: [['authority', 'address']],
     });

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -176,7 +176,9 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       name: 'authority',
-      contract: 'dappsys/auth.sol',
+      contract: 'auth.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/002389d43cf54e8f0b919fee1fc364b20ebdf626/',
       interface: 'IColony.sol',
       version: 'f73dc84a41f5fc1962c999a24e13b15ba491b8a6',
     },

--- a/packages/colony-js-client/src/addTokenLockingMethods.js
+++ b/packages/colony-js-client/src/addTokenLockingMethods.js
@@ -10,9 +10,14 @@ const addTokenLockingMethods = (client: ContractClient) => {
   client.addCaller('getTotalLockCount', {
     output: [['count', 'number']],
   });
-  this.addCaller('getUserLock', {
+  client.addCaller('getUserLock', {
     input: [['user', 'address']],
     output: [['count', 'number']],
+  });
+
+  // Senders
+  client.addSender('incrementLockCounterTo', {
+    input: [['token', 'tokenAddress'], ['lockId', 'number']],
   });
 };
 

--- a/packages/colony-js-client/src/addTokenLockingMethods.js
+++ b/packages/colony-js-client/src/addTokenLockingMethods.js
@@ -10,6 +10,10 @@ const addTokenLockingMethods = (client: ContractClient) => {
   client.addCaller('getTotalLockCount', {
     output: [['count', 'number']],
   });
+  this.addCaller('getUserLock', {
+    input: [['user', 'address']],
+    output: [['count', 'number']],
+  });
 };
 
 export default addTokenLockingMethods;

--- a/packages/colony-js-client/src/addTokenLockingMethods.js
+++ b/packages/colony-js-client/src/addTokenLockingMethods.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import ContractClient from '@colony/colony-js-contract-client';
+
+/*
+ * Add methods from `ITokenLocking.sol` to a given `ContractClient`.
+ */
+const addTokenLockingMethods = (client: ContractClient) => {
+  // Callers
+  client.addCaller('getTotalLockCount', {
+    output: [['count', 'number']],
+  });
+};
+
+export default addTokenLockingMethods;

--- a/packages/colony-js-contract-client/src/classes/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethod.js
@@ -18,6 +18,7 @@ export default class ContractMethod<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
+  NetworkData: { [dataValueName: string]: any },
 > {
   assertValid: Function;
   client: IContractClient;
@@ -25,6 +26,7 @@ export default class ContractMethod<
   functionName: string;
   input: Params;
   name: string;
+  networkData: NetworkData;
   output: Params;
 
   /**

--- a/packages/colony-js-contract-client/src/classes/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethod.js
@@ -22,11 +22,11 @@ export default class ContractMethod<
 > {
   assertValid: Function;
   client: IContractClient;
+  contractData: ContractData;
   defaultValues: DefaultValues;
   functionName: string;
   input: Params;
   name: string;
-  networkData: ContractData;
   output: Params;
 
   /**

--- a/packages/colony-js-contract-client/src/classes/ContractMethod.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethod.js
@@ -18,7 +18,7 @@ export default class ContractMethod<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-  NetworkData: { [dataValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
 > {
   assertValid: Function;
   client: IContractClient;
@@ -26,7 +26,7 @@ export default class ContractMethod<
   functionName: string;
   input: Params;
   name: string;
-  networkData: NetworkData;
+  networkData: ContractData;
   output: Params;
 
   /**

--- a/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
@@ -11,7 +11,13 @@ export default class ContractMethodCaller<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-> extends ContractMethod<InputValues, OutputValues, IContractClient> {
+  NetworkData: { [dataValueName: string]: any },
+> extends ContractMethod<
+  InputValues,
+  OutputValues,
+  IContractClient,
+  NetworkData,
+> {
   _validateEmpty: ?ValidateEmpty;
 
   static containsNullValues(values: Object | null) {

--- a/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodCaller.js
@@ -11,12 +11,12 @@ export default class ContractMethodCaller<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-  NetworkData: { [dataValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
 > extends ContractMethod<
   InputValues,
   OutputValues,
   IContractClient,
-  NetworkData,
+  ContractData,
 > {
   _validateEmpty: ?ValidateEmpty;
 

--- a/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
@@ -20,7 +20,13 @@ export default class ContractMethodMultisigSender<
   InputValues: { [outputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-> extends ContractMethodSender<InputValues, OutputValues, IContractClient> {
+  NetworkData: { [dataValueName: string]: any },
+> extends ContractMethodSender<
+  InputValues,
+  OutputValues,
+  IContractClient,
+  NetworkData,
+> {
   nonceFunctionName: string;
   nonceInput: Params;
   multisigFunctionName: string;

--- a/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodMultisigSender.js
@@ -20,12 +20,12 @@ export default class ContractMethodMultisigSender<
   InputValues: { [outputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-  NetworkData: { [dataValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
 > extends ContractMethodSender<
   InputValues,
   OutputValues,
   IContractClient,
-  NetworkData,
+  ContractData,
 > {
   nonceFunctionName: string;
   nonceInput: Params;

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -20,7 +20,13 @@ export default class ContractMethodSender<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-> extends ContractMethod<InputValues, OutputValues, IContractClient> {
+  NetworkData: { [dataValueName: string]: any },
+> extends ContractMethod<
+  InputValues,
+  OutputValues,
+  IContractClient,
+  NetworkData,
+> {
   _defaultGasLimit: ?number;
 
   constructor({

--- a/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/classes/ContractMethodSender.js
@@ -20,12 +20,12 @@ export default class ContractMethodSender<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-  NetworkData: { [dataValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
 > extends ContractMethod<
   InputValues,
   OutputValues,
   IContractClient,
-  NetworkData,
+  ContractData,
 > {
   _defaultGasLimit: ?number;
 

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -26,12 +26,12 @@ export default class MultisigOperation<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
-  NetworkData: { [dataValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
   Sender: ContractMethodMultisigSender<
     InputValues,
     OutputValues,
     IContractClient,
-    NetworkData,
+    ContractData,
   >,
 > {
   sender: Sender;

--- a/packages/colony-js-contract-client/src/classes/MultisigOperation.js
+++ b/packages/colony-js-contract-client/src/classes/MultisigOperation.js
@@ -26,10 +26,12 @@ export default class MultisigOperation<
   InputValues: { [inputValueName: string]: any },
   OutputValues: { [outputValueName: string]: any },
   IContractClient: ContractClient,
+  NetworkData: { [dataValueName: string]: any },
   Sender: ContractMethodMultisigSender<
     InputValues,
     OutputValues,
     IContractClient,
+    NetworkData,
   >,
 > {
   sender: Sender;


### PR DESCRIPTION
## Description

This pull request adds contract information to the client methods and events, which is used to display information in the docs about what contract the colonyJS methods and events are associated with.

In the process of looking up the methods and events on the contract, I found some things that need to be updated/removed, which I've added to the checklist below and will address here.

Thinking in terms of colonyJS supporting multiple colony contract versions, the contract information could contain colony contract versions that would be used to filter out methods and events that need to be loaded into the colony client, therefore different colonies using different colony contract versions would only get the methods and events that related to the version they are using. This is not included in this pull request but I figured it would be worth mentioning here. (#340)

## Checklist

#### ColonyClient

- [X] Address `assignWorkRating` (internal function)
  * Removed in commit `c4bc4a9`
- [X] Address `getGlobalRewardPayoutCount` (no matching contract methods)
  * Updated to `getTotalLockCount` in commit `58efcf8`
- [X] Address `getRecoveryRolesCount` (no colonyJS method, no matching contract methods)
  * Updated contract data in commit `ff91460`
- [X] Address `getTransactionCount` (no colonyJS method, no contract interface)
  * Removed in commit `e392f72`
- [X] Address `getUserRewardPayoutCount` (no matching contract methods)
  * Update to `getUserLock` in commit `0efb6b1`
- [X] Address `setToken` (no matching contract methods)
  * Removed in commit `8e8abef`
- [X] Address `waiveRewardPayouts` (no matching contract methods)
  * Updated to `incrementLockCounterTo` in commit `c1f4b58`
- [X] Address `initialise` (no colonyJS spec, should this be here?)
  * Removed in commit `5818b55`

#### ColonyNetworkClient

- [X] Address `getRecoveryRolesCount` (no colonyJS method, no matching contract methods)
  * Updated contract data in commit `ff91460`

#### MetaColonyClient

- [X] Address `getAuthority` (should this be here? already included in colony client)
  * Removed in commit `813b3b4`
- [ ] Address `getToken` (should this be here? already included in colony client)
  * ___This needs to be addressed in another PR.___
- [X] Address `setNetworkFeeInverse` (no colonyJS method)
  * Added in commit `8200095`