### PR TITLE
Add `getNetworkClient` to colony-js-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## v.Next
 
+**New Features**
+
+* Add `getNetworkClient` method using `NetworkLoader` (`@colony/colony-js-client`)
+
 **Maintenance**
 
-* `TokenClient` is now based on the `DSToken` contract, due to the removal of `ERC20ExtendedToken` (`@colony/colony-js-client`)
+* `TokenClient` is now based on the `DSToken` contract (`@colony/colony-js-client`)
 
 ## v1.10.0
 
@@ -41,7 +45,9 @@
 
 **Maintenance**
 
+* Update `token` to `tokenClient` (`@colony/colony-js-client`)
 * Remove methods from `ColonyClient` (`@colony/colony-js-client`)
+  * `ColonyTokenSet`
   * `assignWorkRating`
   * `initialise`
   * `getTransactionCount`

--- a/README.md
+++ b/README.md
@@ -40,11 +40,9 @@ We're using [yarn workspaces](https://yarnpkg.com/blog/2017/08/02/introducing-wo
 
 ### Workflow
 
-The `master` branch currently supports colonyNetwork up to commit `f73dc84a41f5fc1962c999a24e13b15ba491b8a6`. Official package releases will be published using the `master` branch. Fixes and maintenance to support this version of colonyNetwork should be merged into the `master` branch.
-
 The `develop` branch is working towards supporting the latest version of colonyNetwork. Unofficial package releases will be published using the `develop` branch. Fixes and maintenance to support the latest version of colonyNetwork should be merged into the `develop` branch.
 
-See [Publishing Releases](https://github.com/JoinColony/colonyJS/wiki/Publishing-Releases) for publishing steps.
+The `master` branch currently supports colonyNetwork up to commit `f73dc84a41f5fc1962c999a24e13b15ba491b8a6`. Official package releases will be published using the `master` branch. Hot fixes to support this version of colonyNetwork should be merged into the `master` branch, which will then be merged into `develop`.
 
 ### Yarn workspaces
 
@@ -90,3 +88,5 @@ for the environment to resolve the common devDependencies:
 ```
 lerna run --scope=@colony/my-package-name test
 ```
+
+See [Publishing Releases](https://github.com/JoinColony/colonyJS/wiki/Publishing-Releases) for publishing workflow.

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -8,7 +8,17 @@ Clients are aggregations of all the interactions possible with the colonyNetwork
 
 ## ColonyNetworkClient
 
-Create an instance of `ColonyNetworkClient` by providing an adapter:
+Use `getNetworkClient` to get an instance of `ColonyNetworkClient`:
+
+```js
+
+const networkClient = getNetworkClient(`rinkeby`, wallet);
+
+```
+
+See [purser](/purser/docs-overview) to learn how to create a wallet instance.
+
+Or create an instance of `ColonyNetworkClient` by providing an adapter:
 
 ```js
 

--- a/docs/_Intro_GetStarted.md
+++ b/docs/_Intro_GetStarted.md
@@ -23,16 +23,14 @@ Open up your terminal and move to your project directory. You can create a new p
 
 You will need to install the following packages:
 
-- `@colony/colony-js-adapter-ethers@1.6.2`
-- `@colony/colony-js-client@1.6.2`
-- `@colony/colony-js-contract-loader-network@1.6.2`
-- `ethers@3.0.27`
+- `@colony/colony-js-client`
+- `@colony/purser-software`
 
 
 Install the packages with the following command:
 
 ```
-yarn add @colony/colony-js-adapter-ethers@1.6.2 @colony/colony-js-client@1.6.2 @colony/colony-js-contract-loader-network@1.6.2 ethers@3.0.27
+yarn add @colony/colony-js-client @colony/purser
 ```
 
 ## Connect Network
@@ -42,38 +40,20 @@ Create a `colony.js` file in the root of your project and add the following code
 ```js
 
 // Import the prerequisites
-const { providers, Wallet } = require('ethers');
-const { default: EthersAdapter } = require('@colony/colony-js-adapter-ethers');
-const { default: NetworkLoader } = require('@colony/colony-js-contract-loader-network');
-const { default: ColonyNetworkClient } = require('@colony/colony-js-client');
+const { getNetworkClient } = require('@colony/colony-js-client');
+const { open } = require('@colony/purser-software');
 
-// An example method for connecting to the network
+// Set the private key (We recommend using a wallet that you strictly use for testing)
+const privateKey = '0x000000000000000000000000000000000000000000000000000000000000000';
+
+// An example method for connecting
 const connectNetwork = async (network) => {
 
-  // Create instance of NetworkLoader
-  const loader = new NetworkLoader({ network });
+  // Create wallet instance with private key
+  const wallet = await open({ privateKey });
 
-  // Create provider for wallet and ethers adapter
-  const provider = providers.getDefaultProvider(network);
-
-  // Set the private key (We recommend using a wallet that you strictly use for testing)
-  const privateKey = '0x000000000000000000000000000000000000000000000000000000000000000';
-
-  // Create wallet with private key and provider
-  const wallet = new Wallet(privateKey, provider);
-
-  // Create a new ethers adapter
-  const adapter = new EthersAdapter({
-    loader,
-    provider,
-    wallet,
-  });
-
-  // Connect to ColonyNetwork with the adapter
-  const networkClient = new ColonyNetworkClient({ adapter });
-
-  // Initialize networkClient
-  await networkClient.init();
+  // Get network client for given network using wallet instance
+  const networkClient = await getNetworkClient(network, wallet);
 
   // Check out the logs to see the address of the contract signer
   console.log('Account Address: ', networkClient.contract.signer.address);
@@ -81,7 +61,7 @@ const connectNetwork = async (network) => {
   // Check out the logs to see the address of the deployed network
   console.log('Network Address: ', networkClient.contract.address);
 
-  // Return networkClient
+  // Return network client
   return networkClient;
 
 };
@@ -94,10 +74,10 @@ Add the following code below the `connectNetwork` example:
 
 ```js
 
-// An example method for creating an ERC20 token
+// An example method for creating a token
 const createToken = async (networkClient, name, symbol) => {
 
-  // Create a new ERC20 token
+  // Create a token
   const tokenAddress = await networkClient.createToken({
     name,
     symbol,

--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -43,12 +43,15 @@
     },
     "dependencies": {
         "@colony/colony-js-adapter": "^1.9.0",
+        "@colony/colony-js-adapter-ethers": "^1.10.0",
         "@colony/colony-js-contract-client": "^1.10.0",
         "@colony/colony-js-contract-loader": "^1.8.1",
+        "@colony/colony-js-contract-loader-network": "^1.6.2",
         "@colony/colony-js-utils": "^1.8.1",
         "assert": "^1.4.1",
         "babel-runtime": "^6.26.0",
         "bn.js": "^4.11.6",
+        "ethers": "3.0.27",
         "isomorphic-fetch": "^2.2.1",
         "web3-utils": "^1.0.0-beta.34"
     },

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -8,6 +8,7 @@ import ColonyNetworkClient from './ColonyNetworkClient/index';
 const getNetworkClient = async (network: string, wallet: any) => {
   const loader = new NetworkLoader({ network });
   const provider = providers.getDefaultProvider(network);
+  if (!wallet.provider) Object.assign(wallet, { provider });
   const adapter = new EthersAdapter({
     loader,
     provider,

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+import { providers } from 'ethers';
+import EthersAdapter from '@colony/colony-js-adapter-ethers';
+import NetworkLoader from '@colony/colony-js-contract-loader-network';
+import ColonyNetworkClient from './ColonyNetworkClient/index';
+
+const getNetworkClient = async (network: string, wallet: any) => {
+  const loader = new NetworkLoader({ network });
+  const provider = providers.getDefaultProvider(network);
+  const adapter = new EthersAdapter({
+    loader,
+    provider,
+    wallet,
+  });
+  const networkClient = new ColonyNetworkClient({ adapter, query: {} });
+  await networkClient.init();
+  return networkClient;
+};
+
+export default getNetworkClient;

--- a/packages/colony-js-client/src/index.js
+++ b/packages/colony-js-client/src/index.js
@@ -14,6 +14,8 @@ import ColonyClient from './ColonyClient/index';
 import TokenClient from './TokenClient/index';
 import TokenLockingClient from './TokenLockingClient/index';
 
+import getNetworkClient from './getNetworkClient';
+
 export type {
   ColonyClient,
   ColonyNetworkClient,
@@ -39,5 +41,7 @@ export {
   TASK_STATUSES,
   WORKER_ROLE,
 } from './constants';
+
+export { getNetworkClient };
 
 export default ColonyNetworkClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,23 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@colony/colony-js-contract-loader-network@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader-network/-/colony-js-contract-loader-network-1.6.2.tgz#12b88484b1fa40e065d1f4295f14590483928e51"
+  integrity sha512-sNMcN7VBlHyU7rCxRHAFmIYyU6C5sU2jX5cBaMvZPCrkmuW52RMFQUXc+ZvC3QJ2QyNjKtPV8uS7Kc1OKOJTXw==
+  dependencies:
+    "@colony/colony-js-contract-loader" "1.5.4"
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+
+"@colony/colony-js-contract-loader@1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-loader/-/colony-js-contract-loader-1.5.4.tgz#4b43cf66671f2ea419490cc676b08619b28002f8"
+  integrity sha1-S0PPZmcfLqQZSQzGdrCGGbKAAvg=
+  dependencies:
+    assert "^1.4.1"
+    babel-runtime "^6.26.0"
+
 "@colony/eslint-config-colony@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@colony/eslint-config-colony/-/eslint-config-colony-4.0.1.tgz#74495655bf461ef196edc262983c471b42cf2d75"
@@ -2691,7 +2708,7 @@ eth-lib@0.1.27:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
-ethers@^3.0.27:
+ethers@3.0.27, ethers@^3.0.27:
   version "3.0.27"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.27.tgz#f9e89bb43a7265a65512d3142c51f26489667f53"
   dependencies:


### PR DESCRIPTION
## Description

This is a bit of an experiment and a potential temporary solution to making the connection process a bit easier for developers. The `getNetworkClient` method proposed here is using `NetworkLoader` and `EthersAdapter`, additional inputs could be added to make this more dynamic but the target is to simplify the process for the "Get Started" page, which connects to the `rinkeby` test network.

The method supports the following use:
```
const { providers, Wallet } = require('ethers');
const { getNetworkClient } = require('@colony/colony-js-client');

const network = 'rinkeby';
const privateKey = '0x0...';

const connectNetwork = async () => {
  const provider = providers.getDefaultProvider(network);
  const wallet = new Wallet(privateKey, provider);
  const networkClient = await getNetworkClient(network, wallet);
  return networkClient;
};

```

Ideally the method would also support the following use (getting an error at the moment):
```
const { getNetworkClient } = require('@colony/colony-js-client');
const { open } = require('@colony/purser-software');

const network = 'rinkeby';
const privateKey = '0x0...';

const connectNetwork = async () => {
  const wallet = await open({ privateKey });
  const networkClient = await getNetworkClient(network, wallet);
  return networkClient;
};

```

## Dependencies

**Added to `colony-js-client`**:

```
"@colony/colony-js-adapter-ethers": "^1.10.0",
"@colony/colony-js-contract-loader-network": "^1.6.2",
"ethers": "3.0.27",
```