### PR TITLE
Add local support for `getNetworkLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 **New Features**
 
-* Add `getNetworkClient` method using `NetworkLoader` (`@colony/colony-js-client`)
+* Add `getNetworkClient` method (`@colony/colony-js-client`)
 
 **Maintenance**
 
-* `TokenClient` is now based on the `DSToken` contract (`@colony/colony-js-client`)
+* Update `TokenClient` to use `DSToken` contract (`@colony/colony-js-client`)
 
 ## v1.10.0
 

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -12,13 +12,21 @@ Use `getNetworkClient` to get an instance of `ColonyNetworkClient`:
 
 ```js
 
+// Get the network client using the rinkeby network
 const networkClient = getNetworkClient(`rinkeby`, wallet);
 
 ```
 
-See [purser](/purser/docs-overview) to learn how to create a wallet instance.
+```js
 
-Or create an instance of `ColonyNetworkClient` by providing an adapter:
+// Get the network client using the local network
+const networkClient = getNetworkClient(`local`, wallet);
+
+```
+
+See [purser](/purser/docs-overview) to learn how to create a wallet instance. If you are using this method with the "local" option, you will need to have [TrufflePig](https://github.com/JoinColony/trufflepig) installed and running.
+
+Another way to create an instance of `ColonyNetworkClient` is by providing an adapter:
 
 ```js
 

--- a/docs/_Intro_GetStarted.md
+++ b/docs/_Intro_GetStarted.md
@@ -26,37 +26,56 @@ You will need to install the following packages:
 - `@colony/colony-js-client`
 - `@colony/purser-software`
 
-
 Install the packages with the following command:
 
 ```
 yarn add @colony/colony-js-client @colony/purser
 ```
 
-## Connect Network
+## Open Wallet
 
-Create a `colony.js` file in the root of your project and add the following code:
+Create a `colony.js` file in the root of your project and add the following:
 
 ```js
 
 // Import the prerequisites
-const { getNetworkClient } = require('@colony/colony-js-client');
 const { open } = require('@colony/purser-software');
 
-// Set the private key (We recommend using a wallet that you strictly use for testing)
-const privateKey = '0x000000000000000000000000000000000000000000000000000000000000000';
-
-// An example method for connecting
-const connectNetwork = async (network) => {
+// Return a wallet instance
+const openWallet = async (privateKey) => {
 
   // Create wallet instance with private key
   const wallet = await open({ privateKey });
 
+  // Check out the logs to see the address of the contract signer
+  console.log('Wallet Address: ', wallet.address);
+
+  // Return wallet
+  return wallet;
+
+};
+
+```
+
+## Connect Network
+
+Add the following to the prerequisites:
+
+```js
+
+const { getNetworkClient } = require('@colony/colony-js-client');
+
+```
+
+Add the following below the `openWallet` example:
+
+```js
+
+// Return a network client instance
+const getNetworkClient = async (wallet) => {
+
   // Get network client for given network using wallet instance
   const networkClient = await getNetworkClient(network, wallet);
-
-  // Check out the logs to see the address of the contract signer
-  console.log('Account Address: ', networkClient.contract.signer.address);
 
   // Check out the logs to see the address of the deployed network
   console.log('Network Address: ', networkClient.contract.address);
@@ -70,18 +89,15 @@ const connectNetwork = async (network) => {
 
 ## Create Token
 
-Add the following code below the `connectNetwork` example:
+Add the following below the `connectNetwork` example:
 
 ```js
 
 // An example method for creating a token
-const createToken = async (networkClient, name, symbol) => {
+const createToken = async (networkClient, symbol) => {
 
   // Create a token
-  const tokenAddress = await networkClient.createToken({
-    name,
-    symbol,
-  });
+  const tokenAddress = await networkClient.createToken({ symbol });
 
   // Check out the logs to see the token address
   console.log('Token Address: ', tokenAddress);
@@ -95,7 +111,7 @@ const createToken = async (networkClient, name, symbol) => {
 
 ## Create Colony
 
-Add the following code below the `createToken` example:
+Add the following below the `createToken` example:
 
 ```js
 
@@ -124,7 +140,7 @@ const createColony = async (networkClient, tokenAddress) => {
 
 ## Create Task
 
-Add the following code below the `createColony` example:
+Add the following below the `createColony` example:
 
 ```js
 
@@ -153,17 +169,41 @@ const createTask = async (colonyClient, specificationHash) => {
 
 You now have all the example methods you need to connect to the network, create a token, create a colony, and create a task. Next, you will need to add some code that will execute those methods.
 
-Add the following code below the `createTask` example:
+Add the following below the `createTask` example:
 
 
 ```js
 
-// Execute example methods
+// Run examples
 (async () => {
-  const networkClient = await connectNetwork('rinkeby');
-  const tokenAddress = await createToken(networkClient, 'Token', 'TKN');
+
+  // Set network to rinkeby
+  const network = 'rinkeby';
+
+  // Set the private key (We recommend using a wallet that you strictly use for testing)
+  const privateKey = '0x000000000000000000000000000000000000000000000000000000000000000';
+
+  // Set the token symbol
+  const tokenSymbol = 'TKN';
+
+  // Set the task specification
+  const taskSpecification = 'QmThycv5h17LTx2DM5qAKNBpHKDL3YTkpfvp1krq2hmUdB';
+
+  // Get the wallet instance
+  const wallet = await getNetworkClient(privateKey);
+
+  // Get the network client instance
+  const networkClient = await getNetworkClient(network);
+
+  // Create a token and store the returned address
+  const tokenAddress = await createToken(networkClient, tokenSymbol);
+
+  // Create a colony and store the returned colony client
   const colonyClient = await createColony(networkClient, tokenAddress);
-  await createTask(colonyClient, 'QmThycv5h17LTx2DM5qAKNBpHKDL3YTkpfvp1krq2hmUdB');
+
+  // Create a task with an example specification hash
+  await createTask(colonyClient, taskSpecification);
+
 })()
   .then(() => process.exit())
   .catch(error => console.error(error));

--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -46,6 +46,7 @@
         "@colony/colony-js-adapter-ethers": "^1.10.0",
         "@colony/colony-js-contract-client": "^1.10.0",
         "@colony/colony-js-contract-loader": "^1.8.1",
+        "@colony/colony-js-contract-loader-http": "^1.10.0",
         "@colony/colony-js-contract-loader-network": "^1.6.2",
         "@colony/colony-js-utils": "^1.8.1",
         "assert": "^1.4.1",

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -3,19 +3,45 @@
 import { providers } from 'ethers';
 import EthersAdapter from '@colony/colony-js-adapter-ethers';
 import NetworkLoader from '@colony/colony-js-contract-loader-network';
+import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
 import ColonyNetworkClient from './ColonyNetworkClient/index';
 
+// This method provides a simple way of getting an initialized network client
+// that uses NetworkLoader for the remote network and TrufflePigLoader for a
+// local testrpc network (TrufflePig must be installed and running).
 const getNetworkClient = async (network: string, wallet: any) => {
-  const loader = new NetworkLoader({ network });
-  const provider = providers.getDefaultProvider(network);
+  let loader;
+  let provider;
+
+  // Set loader and provider
+  if (network === 'local') {
+    loader = new TrufflepigLoader();
+
+    // Throw custom error if TrufflePig is not installed and running
+    loader.getAccounts().catch(() => {
+      throw new Error('Make sure you have TrufflePig installed and running.');
+    });
+
+    provider = new providers.JsonRpcProvider();
+  } else {
+    loader = new NetworkLoader({ network });
+    provider = providers.getDefaultProvider(network);
+  }
+
+  // Support offline wallets (wallets opened with purser)
   if (!wallet.provider) Object.assign(wallet, { provider });
+
+  // Initialize adpaters using ethers
   const adapter = new EthersAdapter({
     loader,
     provider,
     wallet,
   });
+
+  // Initialize network client using ethers adapter and default query
   const networkClient = new ColonyNetworkClient({ adapter, query: {} });
   await networkClient.init();
+
   return networkClient;
 };
 


### PR DESCRIPTION
## Description

This pull request adds the option to use "local" for the network parameter in the `getNetworkClient`, which gets an initialized network client that using TrufflePigLoader and the default testrpc provider.

This is a bit opinionated but users still have the option to initialize a colony network client using the former loader and adapter setup. This will make getting started much easier for developers who would like to hit the ground running.

## Checklist

- [X] Update documentation

## Dependencies

**Added to `colony-js-client`**:

```
"@colony/colony-js-contract-loader-http": "^1.10.0",
```