### PR TITLE
Add EthersWrappedWallet to colony-js-client

### DIFF
--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -49,9 +49,11 @@
         "@colony/colony-js-contract-loader-http": "^1.10.0",
         "@colony/colony-js-contract-loader-network": "^1.6.2",
         "@colony/colony-js-utils": "^1.8.1",
+        "@colony/purser-core": "^2.1.0",
         "assert": "^1.4.1",
         "babel-runtime": "^6.26.0",
         "bn.js": "^4.11.6",
+        "ethereumjs-tx": "^1.3.7",
         "ethers": "3.0.27",
         "isomorphic-fetch": "^2.2.1",
         "web3-utils": "^1.0.0-beta.34"

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -5,6 +5,7 @@ import EthersAdapter from '@colony/colony-js-adapter-ethers';
 import NetworkLoader from '@colony/colony-js-contract-loader-network';
 import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
 import ColonyNetworkClient from './ColonyNetworkClient/index';
+import EthersWrappedWallet from './lib/EthersWrappedWallet/index';
 
 // This method provides a simple way of getting an initialized network client
 // that uses NetworkLoader for the remote network and TrufflePigLoader for a
@@ -28,14 +29,12 @@ const getNetworkClient = async (network: string, wallet: any) => {
     provider = providers.getDefaultProvider(network);
   }
 
-  // Support offline wallets (wallets opened with purser)
-  if (!wallet.provider) Object.assign(wallet, { provider });
-
   // Initialize adpaters using ethers
   const adapter = new EthersAdapter({
     loader,
     provider,
-    wallet,
+    // $FlowFixMe
+    wallet: new EthersWrappedWallet(wallet, provider),
   });
 
   // Initialize network client using ethers adapter and default query

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -33,7 +33,7 @@ const getNetworkClient = async (network: string, wallet: any) => {
   const adapter = new EthersAdapter({
     loader,
     provider,
-    // $FlowFixMe
+    // $FlowFixMe colonyJS types don't yet accept some methods as async
     wallet: new EthersWrappedWallet(wallet, provider),
   });
 

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -8,12 +8,11 @@ import EthereumTx from 'ethereumjs-tx';
 import { utils } from 'ethers';
 import { isHex } from 'web3-utils';
 
-import type { ContractResponse } from '../../index';
-
-import type { TransactionOptions, TransactionRequest } from './types';
-
-type ContractResponseMeta = $PropertyType<ContractResponse<*>, 'meta'>;
-type TransactionReceipt = $PropertyType<ContractResponseMeta, 'receipt'>;
+import type {
+  TransactionOptions,
+  TransactionReceipt,
+  TransactionRequest,
+} from './types';
 
 export default class EthersWrappedWallet {
   wallet: GenericWallet;

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -1,0 +1,145 @@
+/* @flow */
+
+import type { GenericWallet } from '@colony/purser-core/es';
+
+import { hexSequenceNormalizer } from '@colony/purser-core/normalizers';
+import BigNumber from 'bn.js';
+import EthereumTx from 'ethereumjs-tx';
+import { utils } from 'ethers';
+import { isHex } from 'web3-utils';
+
+import type { ContractResponse } from '../../index';
+
+import type { TransactionOptions, TransactionRequest } from './types';
+
+type ContractResponseMeta = $PropertyType<ContractResponse<*>, 'meta'>;
+type TransactionReceipt = $PropertyType<ContractResponseMeta, 'receipt'>;
+
+export default class EthersWrappedWallet {
+  wallet: GenericWallet;
+
+  provider: *;
+
+  constructor(wallet: *, provider: *) {
+    this.wallet = wallet;
+    this.provider = provider;
+  }
+
+  async getAddress(): Promise<string> {
+    return this.wallet.address;
+  }
+
+  async signMessage(message: any): Promise<string> {
+    const payload =
+      typeof message === 'string' && !isHex(message)
+        ? { message }
+        : { messageData: message };
+    return this.wallet.signMessage(payload);
+  }
+
+  /**
+   * Given a partial transaction request, sets the remaining required fields,
+   * signs the transaction with the Purser wallet and sends it using the
+   * provider.
+   */
+  async sendTransaction(tx: TransactionRequest): Promise<TransactionReceipt> {
+    const { chainId, data, gasLimit, gasPrice, nonce, to, value } = tx;
+    const signOptions = {
+      chainId: chainId || this.provider.chainId,
+      data,
+      gasLimit: gasLimit ? new BigNumber(gasLimit) : await this.estimateGas(tx),
+      gasPrice: gasPrice ? new BigNumber(gasPrice) : await this.getGasPrice(),
+      nonce: nonce || (await this.getTransactionCount()),
+      to,
+      value: new BigNumber(value),
+    };
+    const signedTx = await this.sign(signOptions);
+
+    let txHash;
+    if (this.wallet.subtype === 'metamask') {
+      // if metamask, tx has already been sent
+      // TODO: add `online` main wallet type or similar to Purser
+      const parsedSignedTx = new EthereumTx(signedTx);
+      txHash = hexSequenceNormalizer(parsedSignedTx.hash().toString('hex'));
+    } else {
+      // otherwise we still need to send it
+      txHash = await this.provider.sendTransaction(signedTx);
+    }
+
+    return this.provider.getTransaction(txHash);
+  }
+
+  /**
+   * Estimates the gas cost of a transaction using the provider and converts to
+   * our BN format.
+   */
+  async estimateGas(tx: TransactionRequest): Promise<BigNumber> {
+    // We need to properly send `from`, so that `msg.sender` will have the correct value when estimating
+    const from = await this.getAddress();
+    const transformedTx = { ...tx, from };
+    const estimate = await this.provider.estimateGas(transformedTx);
+    return new BigNumber(estimate.toString());
+  }
+
+  /**
+   * Gets the gas price from the provider and converts to our BN format.
+   */
+  async getGasPrice(): Promise<BigNumber> {
+    const price = await this.provider.getGasPrice();
+    return new BigNumber(price.toString());
+  }
+
+  async getBalance(): Promise<BigNumber> {
+    const address = await this.getAddress();
+    return this.provider.getBalance(address);
+  }
+
+  async getTransactionCount(): Promise<number> {
+    const address = await this.getAddress();
+    return this.provider.getTransactionCount(address);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  parseTransaction(tx: string): Object {
+    return utils.parseTransaction(tx);
+  }
+
+  async send(
+    to: string,
+    value: string,
+    options: TransactionOptions = {},
+  ): Promise<TransactionReceipt> {
+    return this.sendTransaction({
+      to,
+      value,
+      ...options,
+    });
+  }
+
+  /**
+   * Sign a given complete transaction request in Ethers format using Purser.
+   */
+  async sign({ data, ...tx }: TransactionRequest): Promise<string> {
+    return this.wallet.sign({ ...tx, inputData: data });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  verifyMessage(message: string, signature: string): string {
+    return utils.verifyMessage(message, signature);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  encrypt() {
+    throw new Error('Wallet method "encrypt" not available');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get privateKey() {
+    throw new Error('Wallet property "privateKey" not available');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  set privateKey(privateKey: any) {
+    throw new Error('Wallet property "privateKey" not available');
+  }
+}

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/types.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/types.js
@@ -2,6 +2,8 @@
 
 import type BigNumber from 'bn.js';
 
+import type { ContractResponse } from '../../index';
+
 export type TransactionRequest = {
   chainId?: number,
   data?: string,
@@ -18,3 +20,6 @@ export type TransactionOptions = {
   nonce?: number,
   value?: BigNumber,
 };
+
+export type ContractResponseMeta = $PropertyType<ContractResponse<*>, 'meta'>;
+export type TransactionReceipt = $PropertyType<ContractResponseMeta, 'receipt'>;

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/types.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/types.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import type BigNumber from 'bn.js';
+
+export type TransactionRequest = {
+  chainId?: number,
+  data?: string,
+  gasLimit?: number | BigNumber,
+  gasPrice?: number | BigNumber,
+  nonce?: number,
+  to?: string,
+  value?: BigNumber,
+};
+
+export type TransactionOptions = {
+  gasLimit?: number,
+  gasPrice?: number,
+  nonce?: number,
+  value?: BigNumber,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -82,9 +89,25 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@colony/eslint-config-colony/-/eslint-config-colony-4.0.1.tgz#74495655bf461ef196edc262983c471b42cf2d75"
 
+"@colony/purser-core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-core/-/purser-core-2.1.0.tgz#d991b6542c450be2453dedb3bc9f44129176d921"
+  integrity sha512-DowZeOlV+q6/Ag4EjwyH/Q8BH5+1Wj9f+pN2tVPDRDEswiImKCnp4ofpWOuh3xyemBwFj2NqMSRF3u+JyBLZsw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    bn.js "^4.11.8"
+    ethereumjs-util "^6.0.0"
+    ethers "^4.0.12"
+    hdkey "^1.1.0"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@types/node@^10.3.2":
+  version "10.12.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.26.tgz#2dec19f1f7981c95cb54bab8f618ecb5dc983d0e"
+  integrity sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg==
 
 JSONStream@^1.0.4:
   version "1.3.2"
@@ -1201,6 +1224,20 @@ binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
+bindings@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.4.0.tgz#909efa49f2ebe07ecd3cb136778f665052040127"
+  integrity sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bip66@^1.1.3:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
+  integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
+  dependencies:
+    safe-buffer "^5.0.1"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -1215,7 +1252,7 @@ bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.6, bn.js@^4.4.0:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.3, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
@@ -1315,7 +1352,7 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   dependencies:
@@ -1379,6 +1416,11 @@ browserslist@^2.1.2:
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
+
+bs58@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-2.0.1.tgz#55908d58f1982aba2008fa1bed8f91998a29bf8d"
+  integrity sha1-VZCNWPGYKrogCPob7Y+RmYopv40=
 
 bs58@^4.0.1:
   version "4.0.1"
@@ -1737,6 +1779,14 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+coinstring@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/coinstring/-/coinstring-2.3.0.tgz#cdb63363a961502404a25afb82c2e26d5ff627a4"
+  integrity sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=
+  dependencies:
+    bs58 "^2.0.1"
+    create-hash "^1.1.1"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -2070,7 +2120,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.2:
+create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   dependencies:
@@ -2392,6 +2442,15 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+drbg.js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"
+  integrity sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=
+  dependencies:
+    browserify-aes "^1.0.6"
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2447,6 +2506,19 @@ elliptic@6.3.3:
 elliptic@^6.0.0, elliptic@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
+elliptic@^6.2.3:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -2719,6 +2791,45 @@ eth-lib@0.1.27:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
+ethereum-common@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
+  integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
+
+ethereumjs-tx@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
+  integrity sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==
+  dependencies:
+    ethereum-common "^0.0.18"
+    ethereumjs-util "^5.0.0"
+
+ethereumjs-util@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"
+  integrity sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "^0.1.3"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
+ethereumjs-util@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
+  integrity sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethers@3.0.27, ethers@^3.0.27:
   version "3.0.27"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.27.tgz#f9e89bb43a7265a65512d3142c51f26489667f53"
@@ -2734,12 +2845,36 @@ ethers@3.0.27, ethers@^3.0.27:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
+ethers@^4.0.12:
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.25.tgz#d2d9ee78fbf5896e793b91959503ef245f6ad5dc"
+  integrity sha512-nxpszD7e1+cXwi/DuaBFmAit0M/+9Suy8nImpiv41nT3tNg8bBKA9mz8VdQbg0X/NT6e5icqdeQpz3FHcy58wg==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
   dependencies:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
+
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
+  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
 
 event-stream@~3.3.0:
   version "3.3.4"
@@ -2983,6 +3118,11 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -3641,7 +3781,7 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@1.1.3, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
   dependencies:
@@ -3665,6 +3805,15 @@ hawk@~6.0.2:
     cryptiles "3.x.x"
     hoek "4.x.x"
     sntp "2.x.x"
+
+hdkey@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-1.1.1.tgz#c2b3bfd5883ff9529b72f2f08b28be0972a9f64a"
+  integrity sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==
+  dependencies:
+    coinstring "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -5135,6 +5284,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keccak@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.4.0.tgz#572f8a6dbee8e7b3aa421550f9e6408ca2186f80"
+  integrity sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==
+  dependencies:
+    bindings "^1.2.1"
+    inherits "^2.0.3"
+    nan "^2.2.1"
+    safe-buffer "^5.1.0"
+
 keccakjs@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/keccakjs/-/keccakjs-0.2.1.tgz#1d633af907ef305bbf9f2fa616d56c44561dfa4d"
@@ -5761,6 +5920,11 @@ mute-stream@0.0.7:
 nan@^2.0.5, nan@^2.3.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nan@^2.2.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
+  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
 
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
@@ -6725,6 +6889,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -6976,6 +7145,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rlp@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.2.tgz#e6677b83cca9105371d930e01d8ffc1263139d05"
+  integrity sha512-Ng2kJEN731Sfv4ZAY2i0ytPMc0BbJKBsVNl0QZY8LxOWSwd+1xpg+fpSRfaMn0heHU447s6Kgy8qfHZR0XTyVw==
+  dependencies:
+    bn.js "^4.11.1"
+    safe-buffer "^5.1.1"
+
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -7050,6 +7227,25 @@ scoped-regex@^1.0.0:
 scrypt-js@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
+
+scrypt-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
+  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
+
+secp256k1@^3.0.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.6.2.tgz#da835061c833c74a12f75c73d2ec2e980f00dc1f"
+  integrity sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==
+  dependencies:
+    bindings "^1.2.1"
+    bip66 "^1.1.3"
+    bn.js "^4.11.3"
+    create-hash "^1.1.2"
+    drbg.js "^1.0.1"
+    elliptic "^6.2.3"
+    nan "^2.2.1"
+    safe-buffer "^5.1.0"
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Description

This pull request uses `EthersWrappedWallet` when passing a wallet instance to the adapter in the `getNetworkClient` method, allowing purser wallet instances to be used with `getNetworkClient`.

## Dependencies

**Added to `colony-js-client`**:

```
"@colony/purser-core": "^2.1.0",
"ethereumjs-tx": "^1.3.7",
```
