### PR TITLE
Minor fixes and improvements to use of EWW

### DIFF
--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -29,12 +29,18 @@ const getNetworkClient = async (network: string, wallet: any) => {
     provider = providers.getDefaultProvider(network);
   }
 
+  // Use EthersWrappedWallet if purser wallet
+  const ethersWallet =
+    wallet.type && wallet.subtype
+      ? new EthersWrappedWallet(wallet, provider)
+      : wallet;
+
   // Initialize adpaters using ethers
   const adapter = new EthersAdapter({
     loader,
     provider,
     // $FlowFixMe colonyJS types don't yet accept some methods as async
-    wallet: new EthersWrappedWallet(wallet, provider),
+    wallet: ethersWallet,
   });
 
   // Initialize network client using ethers adapter and default query

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -50,7 +50,7 @@ export default class EthersWrappedWallet {
       gasPrice: gasPrice ? new BigNumber(gasPrice) : await this.getGasPrice(),
       nonce: nonce || (await this.getTransactionCount()),
       to,
-      value: new BigNumber(value),
+      value,
     };
     const signedTx = await this.sign(signOptions);
 
@@ -105,7 +105,7 @@ export default class EthersWrappedWallet {
 
   async send(
     to: string,
-    value: string,
+    value: BigNumber,
     options: TransactionOptions = {},
   ): Promise<TransactionReceipt> {
     return this.sendTransaction({

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -46,7 +46,11 @@ export default class EthersWrappedWallet {
     const signOptions = {
       chainId: chainId || this.provider.chainId,
       data,
-      gasLimit: gasLimit ? new BigNumber(gasLimit) : await this.estimateGas(tx),
+      // If no gas limit is provided, we need to get the estimate and multiply
+      // it by 1.1 (an amount that will prevent the transaction from failing)
+      gasLimit: gasLimit
+        ? new BigNumber(gasLimit)
+        : new BigNumber((await this.estimateGas(tx)).toNumber() * 1.1),
       gasPrice: gasPrice ? new BigNumber(gasPrice) : await this.getGasPrice(),
       nonce: nonce || (await this.getTransactionCount()),
       to,

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -15,11 +15,12 @@ import type {
 } from './types';
 
 export default class EthersWrappedWallet {
+  address: string;
   wallet: GenericWallet;
-
   provider: *;
 
   constructor(wallet: *, provider: *) {
+    this.address = wallet.address;
     this.wallet = wallet;
     this.provider = provider;
   }

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -15,14 +15,16 @@ import type {
 } from './types';
 
 export default class EthersWrappedWallet {
-  address: string;
   wallet: GenericWallet;
   provider: *;
 
   constructor(wallet: *, provider: *) {
-    this.address = wallet.address;
     this.wallet = wallet;
     this.provider = provider;
+  }
+
+  get address() {
+    return this.wallet.address;
   }
 
   async getAddress(): Promise<string> {
@@ -51,7 +53,9 @@ export default class EthersWrappedWallet {
       // it by 1.1 (an amount that will prevent the transaction from failing)
       gasLimit: gasLimit
         ? new BigNumber(gasLimit)
-        : new BigNumber((await this.estimateGas(tx)).toNumber() * 1.1),
+        : (await this.estimateGas(tx))
+            .mul(new BigNumber('11'))
+            .div(new BigNumber('10')),
       gasPrice: gasPrice ? new BigNumber(gasPrice) : await this.getGasPrice(),
       nonce: nonce || (await this.getTransactionCount()),
       to,


### PR DESCRIPTION
## Description

This pull request fixes the following issues:

- [x] I can still use an `ethers` wallet when using the `getNetworkClient` method
- [x] `adapter.wallet.wallet.address` should be `adapter.wallet.address`
- [x] I don't need to set the `gasLimit` for methods when using a purser wallet
- [x] `adapter.wallet.send(address, amount)` should accept a big number for `amount`

Resolves #368 
