### PR TITLE
Fix transaction retrieval after sending in EWW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## v.NEXT
+## v1.11.2
+
+**Bug Fixes**
+
+* Fix transaction retrieval after sending in `EthersWrappedWallet` (`@colony/colony-js-client`)
 
 **Types**
 
 * Add missing event definitions to `ColonyClient` (`@colony/colony-js-client`)
+  * `ColonyAdminRoleSet`
+  * `ColonyFounderRoleSet`
 
 ## v1.11.1
 

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -74,7 +74,12 @@ export default class EthersWrappedWallet {
       txHash = await this.provider.sendTransaction(signedTx);
     }
 
-    return this.provider.getTransaction(txHash);
+    // We need to wait for transaction to be mined but ganache will mine the
+    // transaction too quickly causing us to wait indefinitely, therefore, we
+    // need to try getting the transaction and then, if that fails, we need to
+    // try getting the transaction using `waitForTransaction`.
+    const transaction = await this.provider.getTransaction(txHash);
+    return transaction || this.provider.waitForTransaction(txHash);
   }
 
   /**


### PR DESCRIPTION
## Description

This pull request ensures getting a transaction is successful after being sent when using the EWW.

We were attempting to get the transaction before the transaction had been mined. To solve this, this pull request implements `provider.waitForTransaction` if the first attempt returns `null`