### PR TITLE
Fixes and updates to documentation

### DIFF
--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -2,12 +2,15 @@
 title: ColonyClient
 section: API
 order: 1
-tocdepth: 1
 ---
 
 The `ColonyClient` class is a standard interface for interactions with the methods and events described in both `IColony.sol` and `IMetaColony.sol`. These interactions are generally concerned with actions within a colony, such as adding a new domain, creating a task, moving funds between pots, and managing permissions.
 
 See [Clients](/colonyjs/components-clients) for information about initializing `ColonyClient`.
+
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
 
 ==TOC==
 
@@ -20,22 +23,22 @@ See [Clients](/colonyjs/components-clients) for information about initializing `
 
 Generate the rating secret used in task ratings. This function returns a keccak256 hash created from the `salt` and `value`.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |salt|string|The string that will be used to generate a secret.|
 |value|number|The task rating that will be hidden (`1`, `2`, or `3`).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -50,15 +53,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the authority contract address associated with the colony.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the authority contract associated with the colony.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `authority`
@@ -72,22 +75,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a domain.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |domainId|number|The ID of the domain.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |localSkillId|number|The ID of the local skill.|
 |potId|number|The ID of the funding pot.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -102,15 +105,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the total number of domains in the colony. The return value is also the ID of the last domain created.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of domains.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -124,21 +127,21 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the total amount of funds that are not in the colony rewards pot. The total amount of funds that are not in the colony rewards pot is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |total|big number|The total amount of funds that are not in the colony rewards pot.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -152,22 +155,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a funding pot.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |potId|number|The numeric ID of the funding pot.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |associatedType|string|The associated type of the funding pot (`domain` or `task`).|
 |associatedTypeId|number|The id of the associated type (`domainId` or `taskId`).|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -181,22 +184,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the balance of a funding pot.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the funding pot.|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |balance|big number|The balance of tokens (or Ether) in the funding pot.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -211,15 +214,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the total number of funding pots.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of funding pots.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -234,15 +237,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the total number of users that are assigned a colony recovery role.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `numRecoveryRoles`
@@ -257,15 +260,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Get the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The inverse amount of the reward.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -279,17 +282,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a reward payout cycle.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the reward payout cycle.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |blockNumber|number|The block number at the time the reward payout cycle started.|
 |remainingTokenAmount|big number|The remaining amount of unclaimed tokens (or Ether).|
@@ -298,7 +301,7 @@ A promise which resolves to an object containing the following properties:
 |totalTokenAmountForRewardPayout|big number|The total amount of tokens set aside for the reward payout cycle.|
 |totalTokens|big number|The total amount of tokens at the time the reward payout cycle started.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -312,17 +315,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a task.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |completionDate|date|The date when the task deliverable was submitted.|
 |deliverableHash|IPFS hash|The deliverable hash of the task (an IPFS hash).|
@@ -335,7 +338,7 @@ A promise which resolves to an object containing the following properties:
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 |status|task status|The task status (`ACTIVE`, `CANCELLED` or `FINALIZED`).|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -350,15 +353,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the total number of tasks in the colony. The return value is also the ID of the last task created.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of tasks.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -372,23 +375,23 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the task payout amount assigned to a task role. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The task role (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of tokens (or Ether) assigned to the task role as a payout.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -402,24 +405,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role of the task (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the user that is assigned the task role.|
 |rateFail|boolean|A boolean indicating whether or not the user failed to rate their counterpart.|
 |rating|number|The rating that the user received (`1`, `2`, or `3`).|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -433,22 +436,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about the ratings of a task.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of submitted ratings for a task.|
 |date|date|The date that the last rating was submitted.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -462,22 +465,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the secret of a rating that has been submitted. If a task is in the commit period of the rating process, the ratings are hidden in a keccak256 hash that was created from a `salt` and `value`. The rating secret can be retrieved but in order to reveal the secret, one would have to know both the `salt` and `value` used to generate the secret.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that submitted the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -492,15 +495,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the address of the token contract that is the native token assigned to the colony. The native token is the token used to calculate reputation scores, i.e. `1` token earned for completing a task with an adequate rating (`2`) will result in `1` reputation point earned.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the token contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -514,22 +517,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the total payout amount assigned to all task roles. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The total amount of tokens (or Ether) assigned to all task roles as payouts.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -544,15 +547,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Get the version number of the colony contract. The version number starts at `1` and is incremented by `1` with every new version.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The version number of the colony contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `version`
@@ -566,22 +569,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Check whether a user has an authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that will be checked.|
 |role|authority role|The authority role that will be checked (`FOUNDER` or `ADMIN`).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |hasRole|boolean|A boolean indicating whether or not the user has the authority role.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -596,15 +599,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Check whether or not the colony is in recovery mode.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the colony is in recovery mode.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -622,17 +625,17 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Add a domain to the colony. Adding new domains is currently retricted to one level, i.e. the `parentDomainId` must be the id of the root domain `1`, which represents the colony itself.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |parentDomainId|number|The ID of the parent domain.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |domainId|number|The ID of the domain that was added.|
 |potId|number|The numeric ID of the pot that was added.|
@@ -642,7 +645,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotaddedaddlistener-potid-------)|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -656,23 +659,23 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Add a new global skill to the skills tree. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |parentSkillId|number|The ID of the skill under which the new skill will be added.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -687,13 +690,13 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 Indicate approval to exit colony recovery mode. This function can only be called by a user with a recovery role.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -707,24 +710,24 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Bootstrap the colony by giving an initial amount of tokens and reputation to selected users. This function can only be called by the user assigned the `FOUNDER` authority role when the `taskCount` for the colony is equal to `0`.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |users|array|The array of users that will recieve an initial amount of tokens and reputation.|
 |amounts|array|The array of corresponding token and reputation amounts each user will recieve.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |users|array|The array of users that received an initial amount of tokens and reputation.|
 |amounts|array|The array of corresponding token and reputation amounts each user recieved.|
 |ColonyBootstrapped|object|Contains the data defined in [ColonyBootstrapped](#eventscolonybootstrappedaddlistener-users-amounts-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -738,24 +741,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Claim funds that the colony has received by adding them to the funding pot of the root domain. A small fee is deducted from the funds claimed and added to the colony rewards pot. No fee is deducted when tokens native to the colony are claimed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |fee|big number|The fee deducted from the claim and added to the colony rewards pot.|
 |payoutRemainder|big number|The remaining funds (after the fee) moved to the top-level domain pot.|
 |ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimedaddlistener-token-fee-payoutremainder-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -769,19 +772,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Claim the payout assigned to a task role. This function can only be called by the user who is assigned a task role (`MANAGER`, `EVALUATOR`, or `WORKER`) after the task has been finalized.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that submitted the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was assigned the task payout (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -793,7 +796,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -807,22 +810,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Mark a task as complete. If the user assigned the `WORKER` task role fails to submit the task deliverable by the due date, this function must be called by the user assigned the `MANAGER` task role. This allows the task work to be rated and the task to be finalized.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -836,20 +839,20 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Create a new task within the colony.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 |domainId|number (optional)|The ID of the domain (default value of `1`).|
 |skillId|number (optional)|The ID of the skill (default value of `null`).|
 |dueDate|date (optional)|The due date of the task (default value of `30` days from creation).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |potId|number|The numeric ID of the pot that was added.|
 |taskId|number|The ID of the task that was added.|
@@ -860,7 +863,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
 |TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `makeTask`
@@ -875,13 +878,13 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Enter colony recovery mode. This function can only be called by a user with a recovery role.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -896,13 +899,13 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Exit colony recovery mode. This function can be called by anyone if enough whitelist approvals are given.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -916,22 +919,22 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Finalize the reward payout cycle. This function can only be called when the reward payout cycle has finished, i.e. 60 days have passed since the creation of the reward payout cycle.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the reward payout cycle.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that ended.|
 |RewardPayoutCycleEnded|object|Contains the data defined in [RewardPayoutCycleEnded](#eventsrewardpayoutcycleendedaddlistener-payoutid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -945,22 +948,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Finalize a task. Once a task is finalized, each user assigned a task role can claim the payout assigned to their role and no further changes to the task can be made.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was finalized.|
 |TaskFinalized|object|Contains the data defined in [TaskFinalized](#eventstaskfinalizedaddlistener-taskid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -974,9 +977,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Make a payment. This function can only be called by the user assigned either the `FOUNDER` or `ADMIN` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |worker|address||
 |token|address||
@@ -984,11 +987,11 @@ Make a payment. This function can only be called by the user assigned either the
 |domainId|number||
 |skillId|number||
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |potId|number|The numeric ID of the pot that was added.|
 |taskId|number|The ID of the task that was added.|
@@ -1013,7 +1016,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1027,23 +1030,23 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Mint new tokens. This function can only be called if the address of the colony contract is the owner of the token contract. If this is the case, then this function can only be called by the user assigned the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of new tokens that will be minted.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address that initiated the mint event.|
 |amount|big number|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1057,17 +1060,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Mint tokens for the Colony Network. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of new tokens that will be minted.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address that initiated the mint event.|
 |amount|big number|The amount of tokens that were minted.|
@@ -1077,7 +1080,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1091,20 +1094,20 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 
 Move funds from one pot to another.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |fromPot|number|The ID of the pot from which funds will be moved.|
 |toPot|number|The ID of the pot to which funds will be moved.|
 |amount|big number|The amount of funds that will be moved between pots.|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |fromPot|number|The ID of the pot from which the funds were moved.|
 |toPot|number|The ID of the pot to which the funds were moved.|
@@ -1112,7 +1115,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|address|The address of the token contract (an empty address if Ether).|
 |ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpotsaddlistener-frompot-topot-amount-token-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1126,24 +1129,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Register an ENS label for the colony.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyName|string|The ENS label that will be registered for the colony.|
 |orbitDBPath|string|The path of the OrbitDB database associated with the colony.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colony|address|The address of the colony that was modified.|
 |label|string|The label that was registered for the colony.|
 |ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregisteredaddlistener-colony-label-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1157,22 +1160,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `ADMIN` authority role from a user. This function can only be called by the user assigned the `FOUNDER` authroity role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that we will be unassigned the `ADMIN` authority role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that was unassigned the `ADMIN` authority role.|
 |ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#eventscolonyadminroleremovedaddlistener-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1186,19 +1189,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the colony recovery role from a user. This function can only be called by the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be unassigned a colony recovery role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1212,27 +1215,27 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Reveal a submitted work rating. In order to reveal a work rating, the same `salt` and `value` used to generate the `secret` when the task work rating was submitted must be provided again here to reveal the task work rating.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that received the rating (`MANAGER` or `WORKER`).|
 |rating|number|The rating that was submitted (`1`, `2`, or `3`).|
 |salt|string|The string that was used to generate the secret.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that received the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |rating|number|The value of the rating that was revealed (`1`, `2`, or `3`).|
 |TaskWorkRatingRevealed|object|Contains the data defined in [TaskWorkRatingRevealed](#eventstaskworkratingrevealedaddlistener-taskid-role-rating-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1246,22 +1249,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `ADMIN` authority role to a user. This function can only be called by the user assigned the `FOUNDER` authority role or a user assigned the `ADMIN` authority role. There is no limit to the number of users that can be assigned the `ADMIN` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned the `ADMIN` authroity role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that was assigned the `ADMIN` authority role.|
 |ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#eventscolonyadminrolesetaddlistener-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1275,9 +1278,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payouts for all task roles (`MANAGER`, `EVALUATOR`, and `WORKER`). This can only be called by the user assigned the `MANAGER` task role and only if the `EVALUATOR` and `WORKER` task roles are either not assigned or assigned to the same user as the `MANAGER` task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |token|address|The address of the token contract (an empty address if Ether).|
@@ -1285,11 +1288,11 @@ Set the payouts for all task roles (`MANAGER`, `EVALUATOR`, and `WORKER`). This 
 |evaluatorAmount|big number|The payout amount in tokens (or Ether) for the `EVALUATOR` task role.|
 |workerAmount|big number|The payout amount in tokens (or Ether) for the `WORKER` task role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -1297,7 +1300,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1311,23 +1314,23 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `FOUNDER` authority role to a user. This function can only be called by the user currently assigned the `FOUNDER` authority role. There can only be one address assigned to the `FOUNDER` authority role, therefore, the user currently assigned will forfeit their role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned the `FOUNDER` authority role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |oldFounder|address|The address that assigned the `FOUNDER` authority role (the old founder).|
 |newFounder|address|The address that was assigned the `FOUNDER` authority role (the new founder).|
 |ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#eventscolonyfounderrolesetaddlistener-oldfounder-newfounder-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1341,19 +1344,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the inverse amount of the reward. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |feeInverse|number|The inverse amount that will be set.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1367,19 +1370,19 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 
 Assign a colony recovery role to a user. This function can only be called by the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned a colony recovery role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1393,22 +1396,22 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The inverse amount of the reward.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The reward inverse value that was set.|
 |ColonyRewardInverseSet|object|Contains the data defined in [ColonyRewardInverseSet](#eventscolonyrewardinversesetaddlistener-rewardinverse-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1422,20 +1425,20 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |slot|number|The ID of the storage slot that will be modified.|
 |value|hex string|The hex string of data that will be set as the value.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1449,17 +1452,17 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have claimed their rewards payout using `claimRewardPayout`. Reputation holders can also waive their reward payout and unlock their tokens for past reward payout cycles by using `incrementLockCounterTo`.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that started.|
 |token|address|The address of the token contract (an empty address if Ether).|
@@ -1467,7 +1470,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#eventsrewardpayoutcyclestartedaddlistener-payoutid-------)|
 |TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlockedaddlistener-token-lockcount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1481,25 +1484,25 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit the task deliverable. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |deliverableHash|IPFS hash|The deliverable hash of the task (an IPFS hash).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1513,26 +1516,26 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit the task deliverable and the work rating for the user assigned the `MANAGER` task role. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |deliverableHash|IPFS hash|The deliverable hash of the task (an IPFS hash).|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
 |TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
 |TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1546,21 +1549,21 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit a work rating for a task. This function can only be called by the user assigned the `EVALUATOR` task role, who is submitting a rating for the user assigned the `WORKER` task role, or the user assigned the `WORKER` task role, who is submitting a rating for the user assigned the `MANAGER` task role. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that will receive the rating (`MANAGER` or `WORKER`).|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1574,23 +1577,23 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Upgrade the colony to a new contract version. The new version number must be higher than the current version. Downgrading to old contract versions is not permitted.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |newVersion|number|The version number of the colony contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |oldVersion|number|The old version number of the colony.|
 |newVersion|number|The new version number of the colony.|
 |ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#eventscolonyupgradedaddlistener-oldversion-newversion-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1608,22 +1611,22 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Cancel a task. Once a task is cancelled, no further changes to the task can be made.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was canceled.|
 |TaskCanceled|object|Contains the data defined in [TaskCanceled](#eventstaskcanceledaddlistener-taskid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1637,24 +1640,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `EVALUATOR` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1668,24 +1671,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `WORKER` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1699,24 +1702,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the task specification. The task specification, or "task brief", is a description of the work that must be completed for the task. The description is hashed and stored with the task for future reference during the rating process or in the event of a dispute.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
 |TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#eventstaskbriefsetaddlistener-taskid-specificationhash-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1730,24 +1733,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the domain of a task. Every task must belong to a domain. This function can only be called by the user assigned the `MANAGER` task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |domainId|number|The ID of the domain.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |domainId|number|The ID of the domain that was set.|
 |TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#eventstaskdomainsetaddlistener-taskid-domainid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1761,24 +1764,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the due date of a task. The due date is the last day that the user assigned the `WORKER` task role can submit the task deliverable.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |dueDate|date|The due date of the task.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |dueDate|date|The due date that was set.|
 |TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1792,25 +1795,25 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `EVALUATOR` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `EVALUATOR` task role must both sign the transaction before it can be executed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |user|address|The address that will be assigned the `EVALUATOR` task role.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1824,25 +1827,25 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `MANAGER` task role to a user. This function can only be called before the task is finalized. The user currently assigned the `MANAGER` task role and the user being assigned the `MANAGER` task role must both sign the transaction before it can be executed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |user|address|The address that will be assigned the `MANANAGER` task role.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1856,24 +1859,24 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the skill of a task. Only one skill can be assigned per task. The user assigned the `MANAGER` task role and the user assigned the `WORKER` task role must both sign this transaction before it can be executed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |skillId|number|The ID of the skill.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |skillId|number|The ID of the skill that was set.|
 |TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1887,25 +1890,25 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `WORKER` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `WORKER` task role must both sign the transaction before it can be executed.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |user|address|The address that will be assigned the `WORKER` task role.|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
 |TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1919,19 +1922,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `MANAGER` task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -1939,7 +1942,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1953,19 +1956,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `EVALUATOR` task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -1973,7 +1976,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1987,19 +1990,19 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `WORKER` task role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
-#### Response
+**Response**
 
 An instance of a `MultiSigOperation` whose sender will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -2007,7 +2010,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -2025,9 +2028,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that was unassigned the `ADMIN` authority role.|
 
@@ -2036,9 +2039,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that was assigned the `ADMIN` authority role.|
 
@@ -2047,9 +2050,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |users|array|The array of users that received an initial amount of tokens and reputation.|
 |amounts|array|The array of corresponding token and reputation amounts each user recieved.|
@@ -2059,9 +2062,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |oldFounder|address|The address that assigned the `FOUNDER` authority role (the old founder).|
 |newFounder|address|The address that was assigned the `FOUNDER` authority role (the new founder).|
@@ -2071,9 +2074,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |fee|big number|The fee deducted from the claim and added to the colony rewards pot.|
@@ -2084,9 +2087,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |fromPot|number|The ID of the pot from which the funds were moved.|
 |toPot|number|The ID of the pot to which the funds were moved.|
@@ -2098,9 +2101,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyNetwork|address|The address of the Colony Network.|
 
@@ -2109,9 +2112,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colony|address|The address of the colony that was modified.|
 |label|string|The label that was registered for the colony.|
@@ -2121,9 +2124,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The reward inverse value that was set.|
 
@@ -2132,9 +2135,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |oldVersion|number|The old version number of the colony.|
 |newVersion|number|The new version number of the colony.|
@@ -2144,9 +2147,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |domainId|number|The ID of the domain that was added.|
 
@@ -2155,9 +2158,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address that initiated the mint event.|
 |amount|big number|The amount of tokens that were minted.|
@@ -2167,9 +2170,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |potId|number|The numeric ID of the pot that was added.|
 
@@ -2178,9 +2181,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |rewardPayoutId|number|The ID of the reward payout cycle.|
 |user|address|The address of the user who claimed the reward payout.|
@@ -2192,9 +2195,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that ended.|
 
@@ -2203,9 +2206,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that started.|
 
@@ -2214,9 +2217,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
@@ -2226,9 +2229,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was added.|
 
@@ -2237,9 +2240,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
@@ -2249,9 +2252,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was canceled.|
 
@@ -2260,9 +2263,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 
@@ -2271,9 +2274,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
@@ -2283,9 +2286,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |domainId|number|The ID of the domain that was set.|
@@ -2295,9 +2298,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |dueDate|date|The due date that was set.|
@@ -2307,9 +2310,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was finalized.|
 
@@ -2318,9 +2321,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was assigned the task payout (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -2332,9 +2335,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -2346,9 +2349,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -2359,9 +2362,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |skillId|number|The ID of the skill that was set.|
@@ -2371,9 +2374,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that received the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
@@ -2384,9 +2387,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |lockCount|number|The total lock count for the token.|
@@ -2396,9 +2399,9 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -17,7 +17,7 @@ See [ContractClient](/colonyjs/api-contractclient) for more information about th
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.**.
+**All callers return promises which resolve to an object containing the given return values.**
 
 ### `generateSecret.call({ salt, value })`
 
@@ -645,9 +645,11 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |potId|number|The numeric ID of the pot that was added.|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
-|DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainaddedaddlistener-domainid-------)|
-|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotaddedaddlistener-potid-------)|
-|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
+|DomainAdded|object|Contains the data defined in [DomainAdded](#eventsdomainadded)|
+|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotadded)|
+|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -681,7 +683,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
-|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
+|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -704,9 +708,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -741,7 +747,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |users|array|The array of users that received an initial amount of tokens and reputation.|
 |amounts|array|The array of corresponding token and reputation amounts each user recieved.|
-|ColonyBootstrapped|object|Contains the data defined in [ColonyBootstrapped](#eventscolonybootstrappedaddlistener-users-amounts-------)|
+|ColonyBootstrapped|object|Contains the data defined in [ColonyBootstrapped](#eventscolonybootstrapped)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -776,7 +784,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|address|The address of the token contract (an empty address if Ether).|
 |fee|big number|The fee deducted from the claim and added to the colony rewards pot.|
 |payoutRemainder|big number|The remaining funds (after the fee) moved to the top-level domain pot.|
-|ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimedaddlistener-token-fee-payoutremainder-------)|
+|ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimed)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -817,8 +827,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
-|TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
-|Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+|TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimed)|
+|Transfer|object|Contains the data defined in [Transfer](#eventstransfer)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -851,7 +863,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
-|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
+|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompleted)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -890,10 +904,12 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The ID of the task that was added.|
 |skillId|number|The ID of the skill that was set.|
 |dueDate|date|The due date that was set.|
-|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotaddedaddlistener-potid-------)|
-|TaskAdded|object|Contains the data defined in [TaskAdded](#eventstaskaddedaddlistener-taskid-------)|
-|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
-|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
+|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotadded)|
+|TaskAdded|object|Contains the data defined in [TaskAdded](#eventstaskadded)|
+|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillset)|
+|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedateset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -916,9 +932,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -941,9 +959,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -976,7 +996,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that ended.|
-|RewardPayoutCycleEnded|object|Contains the data defined in [RewardPayoutCycleEnded](#eventsrewardpayoutcycleendedaddlistener-payoutid-------)|
+|RewardPayoutCycleEnded|object|Contains the data defined in [RewardPayoutCycleEnded](#eventsrewardpayoutcycleended)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1009,7 +1031,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was finalized.|
-|TaskFinalized|object|Contains the data defined in [TaskFinalized](#eventstaskfinalizedaddlistener-taskid-------)|
+|TaskFinalized|object|Contains the data defined in [TaskFinalized](#eventstaskfinalized)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1058,15 +1082,17 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
-|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotaddedaddlistener-potid-------)|
-|TaskAdded|object|Contains the data defined in [TaskAdded](#eventstaskaddedaddlistener-taskid-------)|
-|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
-|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
-|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
-|ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpotsaddlistener-frompot-topot-amount-token-------)|
-|TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimedaddlistener-taskid-role-token-amount-------)|
-|Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+|FundingPotAdded|object|Contains the data defined in [FundingPotAdded](#eventsfundingpotadded)|
+|TaskAdded|object|Contains the data defined in [TaskAdded](#eventstaskadded)|
+|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillset)|
+|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedateset)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
+|ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpots)|
+|TaskPayoutClaimed|object|Contains the data defined in [TaskPayoutClaimed](#eventstaskpayoutclaimed)|
+|Transfer|object|Contains the data defined in [Transfer](#eventstransfer)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1100,7 +1126,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address that initiated the mint event.|
 |amount|big number|The amount of tokens that were minted.|
-|Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
+|Mint|object|Contains the data defined in [Mint](#eventsmint)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1137,8 +1165,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
-|Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
-|Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+|Mint|object|Contains the data defined in [Mint](#eventsmint)|
+|Transfer|object|Contains the data defined in [Transfer](#eventstransfer)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1177,7 +1207,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |toPot|number|The ID of the pot to which the funds were moved.|
 |amount|big number|The amount of funds that were moved between pots.|
 |token|address|The address of the token contract (an empty address if Ether).|
-|ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpotsaddlistener-frompot-topot-amount-token-------)|
+|ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpots)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1212,7 +1244,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |colony|address|The address of the colony that was modified.|
 |label|string|The label that was registered for the colony.|
-|ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregisteredaddlistener-colony-label-------)|
+|ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregistered)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1245,7 +1279,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that was unassigned the `ADMIN` authority role.|
-|ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#eventscolonyadminroleremovedaddlistener-user-------)|
+|ColonyAdminRoleRemoved|object|Contains the data defined in [ColonyAdminRoleRemoved](#eventscolonyadminroleremoved)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1273,9 +1309,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1313,7 +1351,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that received the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |rating|number|The value of the rating that was revealed (`1`, `2`, or `3`).|
-|TaskWorkRatingRevealed|object|Contains the data defined in [TaskWorkRatingRevealed](#eventstaskworkratingrevealedaddlistener-taskid-role-rating-------)|
+|TaskWorkRatingRevealed|object|Contains the data defined in [TaskWorkRatingRevealed](#eventstaskworkratingrevealed)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1346,7 +1386,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that was assigned the `ADMIN` authority role.|
-|ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#eventscolonyadminrolesetaddlistener-user-------)|
+|ColonyAdminRoleSet|object|Contains the data defined in [ColonyAdminRoleSet](#eventscolonyadminroleset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1386,7 +1428,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
-|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1420,7 +1464,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |oldFounder|address|The address that assigned the `FOUNDER` authority role (the old founder).|
 |newFounder|address|The address that was assigned the `FOUNDER` authority role (the new founder).|
-|ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#eventscolonyfounderrolesetaddlistener-oldfounder-newfounder-------)|
+|ColonyFounderRoleSet|object|Contains the data defined in [ColonyFounderRoleSet](#eventscolonyfounderroleset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1448,9 +1494,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1478,9 +1526,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1513,7 +1563,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The reward inverse value that was set.|
-|ColonyRewardInverseSet|object|Contains the data defined in [ColonyRewardInverseSet](#eventscolonyrewardinversesetaddlistener-rewardinverse-------)|
+|ColonyRewardInverseSet|object|Contains the data defined in [ColonyRewardInverseSet](#eventscolonyrewardinverseset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1542,9 +1594,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1579,8 +1633,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |payoutId|number|The ID of the payout cycle that started.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |lockCount|number|The total lock count for the token.|
-|RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#eventsrewardpayoutcyclestartedaddlistener-payoutid-------)|
-|TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlockedaddlistener-token-lockcount-------)|
+|RewardPayoutCycleStarted|object|Contains the data defined in [RewardPayoutCycleStarted](#eventsrewardpayoutcyclestarted)|
+|TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlocked)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1615,8 +1671,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
-|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
-|TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
+|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompleted)|
+|TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmitted)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1652,8 +1710,10 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
-|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompletedaddlistener-taskid-------)|
-|TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmittedaddlistener-taskid-deliverablehash-------)|
+|TaskCompleted|object|Contains the data defined in [TaskCompleted](#eventstaskcompleted)|
+|TaskDeliverableSubmitted|object|Contains the data defined in [TaskDeliverableSubmitted](#eventstaskdeliverablesubmitted)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1683,9 +1743,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1719,7 +1781,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |oldVersion|number|The old version number of the colony.|
 |newVersion|number|The new version number of the colony.|
-|ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#eventscolonyupgradedaddlistener-oldversion-newversion-------)|
+|ColonyUpgraded|object|Contains the data defined in [ColonyUpgraded](#eventscolonyupgraded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1752,7 +1816,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was canceled.|
-|TaskCanceled|object|Contains the data defined in [TaskCanceled](#eventstaskcanceledaddlistener-taskid-------)|
+|TaskCanceled|object|Contains the data defined in [TaskCanceled](#eventstaskcanceled)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1783,7 +1849,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1814,7 +1882,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1845,7 +1915,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
-|TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#eventstaskbriefsetaddlistener-taskid-specificationhash-------)|
+|TaskBriefSet|object|Contains the data defined in [TaskBriefSet](#eventstaskbriefset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1876,7 +1948,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |domainId|number|The ID of the domain that was set.|
-|TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#eventstaskdomainsetaddlistener-taskid-domainid-------)|
+|TaskDomainSet|object|Contains the data defined in [TaskDomainSet](#eventstaskdomainset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1907,7 +1981,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |dueDate|date|The due date that was set.|
-|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedatesetaddlistener-taskid-duedate-------)|
+|TaskDueDateSet|object|Contains the data defined in [TaskDueDateSet](#eventstaskduedateset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1939,7 +2015,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -1971,7 +2049,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -2002,7 +2082,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |skillId|number|The ID of the skill that was set.|
-|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillsetaddlistener-taskid-skillid-------)|
+|TaskSkillSet|object|Contains the data defined in [TaskSkillSet](#eventstaskskillset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -2034,7 +2116,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was set (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |user|address|The user that was assigned the task role.|
-|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleusersetaddlistener-taskid-role-user-------)|
+|TaskRoleUserSet|object|Contains the data defined in [TaskRoleUserSet](#eventstaskroleuserset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -2068,7 +2152,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
-|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -2102,7 +2188,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
-|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -2136,7 +2224,9 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
-|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutsetaddlistener-taskid-role-token-amount-------)|
+|TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -8,7 +8,7 @@ The `ColonyClient` class is a standard interface for interactions with the metho
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 
@@ -2152,33 +2152,54 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 ## Events
 
 
-### `events.ColonyAdminRoleRemoved.addListener(({ user }) => { /* ... */ })`
+### `events.ColonyAdminRoleRemoved`
+
+**Methods**
+
+`.addListener(({ user }) => { /* ... */ })`
+
+`.removeListener(({ user }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that was unassigned the `ADMIN` authority role.|
 
 
-### `events.ColonyAdminRoleSet.addListener(({ user }) => { /* ... */ })`
+### `events.ColonyAdminRoleSet`
+
+**Methods**
+
+`.addListener(({ user }) => { /* ... */ })`
+
+`.removeListener(({ user }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that was assigned the `ADMIN` authority role.|
 
 
-### `events.ColonyBootstrapped.addListener(({ users, amounts }) => { /* ... */ })`
+### `events.ColonyBootstrapped`
+
+**Methods**
+
+`.addListener(({ users, amounts }) => { /* ... */ })`
+
+`.removeListener(({ users, amounts }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2186,11 +2207,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |amounts|array|The array of corresponding token and reputation amounts each user recieved.|
 
 
-### `events.ColonyFounderRoleSet.addListener(({ oldFounder, newFounder }) => { /* ... */ })`
+### `events.ColonyFounderRoleSet`
+
+**Methods**
+
+`.addListener(({ oldFounder, newFounder }) => { /* ... */ })`
+
+`.removeListener(({ oldFounder, newFounder }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2198,11 +2226,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |newFounder|address|The address that was assigned the `FOUNDER` authority role (the new founder).|
 
 
-### `events.ColonyFundsClaimed.addListener(({ token, fee, payoutRemainder }) => { /* ... */ })`
+### `events.ColonyFundsClaimed`
+
+**Methods**
+
+`.addListener(({ token, fee, payoutRemainder }) => { /* ... */ })`
+
+`.removeListener(({ token, fee, payoutRemainder }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2211,11 +2246,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |payoutRemainder|big number|The remaining funds (after the fee) moved to the top-level domain pot.|
 
 
-### `events.ColonyFundsMovedBetweenFundingPots.addListener(({ fromPot, toPot, amount, token }) => { /* ... */ })`
+### `events.ColonyFundsMovedBetweenFundingPots`
+
+**Methods**
+
+`.addListener(({ fromPot, toPot, amount, token }) => { /* ... */ })`
+
+`.removeListener(({ fromPot, toPot, amount, token }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2225,22 +2267,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |token|address|The address of the token contract (an empty address if Ether).|
 
 
-### `events.ColonyInitialised.addListener(({ colonyNetwork }) => { /* ... */ })`
+### `events.ColonyInitialised`
+
+**Methods**
+
+`.addListener(({ colonyNetwork }) => { /* ... */ })`
+
+`.removeListener(({ colonyNetwork }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |colonyNetwork|address|The address of the Colony Network.|
 
 
-### `events.ColonyLabelRegistered.addListener(({ colony, label }) => { /* ... */ })`
+### `events.ColonyLabelRegistered`
+
+**Methods**
+
+`.addListener(({ colony, label }) => { /* ... */ })`
+
+`.removeListener(({ colony, label }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2248,22 +2304,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |label|string|The label that was registered for the colony.|
 
 
-### `events.ColonyRewardInverseSet.addListener(({ rewardInverse }) => { /* ... */ })`
+### `events.ColonyRewardInverseSet`
+
+**Methods**
+
+`.addListener(({ rewardInverse }) => { /* ... */ })`
+
+`.removeListener(({ rewardInverse }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The reward inverse value that was set.|
 
 
-### `events.ColonyUpgraded.addListener(({ oldVersion, newVersion }) => { /* ... */ })`
+### `events.ColonyUpgraded`
+
+**Methods**
+
+`.addListener(({ oldVersion, newVersion }) => { /* ... */ })`
+
+`.removeListener(({ oldVersion, newVersion }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2271,22 +2341,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |newVersion|number|The new version number of the colony.|
 
 
-### `events.DomainAdded.addListener(({ domainId }) => { /* ... */ })`
+### `events.DomainAdded`
+
+**Methods**
+
+`.addListener(({ domainId }) => { /* ... */ })`
+
+`.removeListener(({ domainId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |domainId|number|The ID of the domain that was added.|
 
 
-### `events.Mint.addListener(({ address, amount }) => { /* ... */ })`
+### `events.Mint`
+
+**Methods**
+
+`.addListener(({ address, amount }) => { /* ... */ })`
+
+`.removeListener(({ address, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2294,22 +2378,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |amount|big number|The amount of tokens that were minted.|
 
 
-### `events.FundingPotAdded.addListener(({ potId }) => { /* ... */ })`
+### `events.FundingPotAdded`
+
+**Methods**
+
+`.addListener(({ potId }) => { /* ... */ })`
+
+`.removeListener(({ potId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The numeric ID of the pot that was added.|
 
 
-### `events.RewardPayoutClaimed.addListener(({ rewardPayoutId, user, fee, payoutRemainder }) => { /* ... */ })`
+### `events.RewardPayoutClaimed`
+
+**Methods**
+
+`.addListener(({ rewardPayoutId, user, fee, payoutRemainder }) => { /* ... */ })`
+
+`.removeListener(({ rewardPayoutId, user, fee, payoutRemainder }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2319,33 +2417,54 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |payoutRemainder|big number|The remaining payout amount (after the fee) transferred to the user.|
 
 
-### `events.RewardPayoutCycleEnded.addListener(({ payoutId }) => { /* ... */ })`
+### `events.RewardPayoutCycleEnded`
+
+**Methods**
+
+`.addListener(({ payoutId }) => { /* ... */ })`
+
+`.removeListener(({ payoutId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that ended.|
 
 
-### `events.RewardPayoutCycleStarted.addListener(({ payoutId }) => { /* ... */ })`
+### `events.RewardPayoutCycleStarted`
+
+**Methods**
+
+`.addListener(({ payoutId }) => { /* ... */ })`
+
+`.removeListener(({ payoutId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the payout cycle that started.|
 
 
-### `events.SkillAdded.addListener(({ skillId, parentSkillId }) => { /* ... */ })`
+### `events.SkillAdded`
+
+**Methods**
+
+`.addListener(({ skillId, parentSkillId }) => { /* ... */ })`
+
+`.removeListener(({ skillId, parentSkillId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2353,22 +2472,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |parentSkillId|number|The ID of the parent skill.|
 
 
-### `events.TaskAdded.addListener(({ taskId }) => { /* ... */ })`
+### `events.TaskAdded`
+
+**Methods**
+
+`.addListener(({ taskId }) => { /* ... */ })`
+
+`.removeListener(({ taskId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was added.|
 
 
-### `events.TaskBriefSet.addListener(({ taskId, specificationHash }) => { /* ... */ })`
+### `events.TaskBriefSet`
+
+**Methods**
+
+`.addListener(({ taskId, specificationHash }) => { /* ... */ })`
+
+`.removeListener(({ taskId, specificationHash }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2376,33 +2509,54 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |specificationHash|string|The specification hash that was set (an IPFS hash).|
 
 
-### `events.TaskCanceled.addListener(({ taskId }) => { /* ... */ })`
+### `events.TaskCanceled`
+
+**Methods**
+
+`.addListener(({ taskId }) => { /* ... */ })`
+
+`.removeListener(({ taskId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was canceled.|
 
 
-### `events.TaskCompleted.addListener(({ taskId }) => { /* ... */ })`
+### `events.TaskCompleted`
+
+**Methods**
+
+`.addListener(({ taskId }) => { /* ... */ })`
+
+`.removeListener(({ taskId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was completed.|
 
 
-### `events.TaskDeliverableSubmitted.addListener(({ taskId, deliverableHash }) => { /* ... */ })`
+### `events.TaskDeliverableSubmitted`
+
+**Methods**
+
+`.addListener(({ taskId, deliverableHash }) => { /* ... */ })`
+
+`.removeListener(({ taskId, deliverableHash }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2410,11 +2564,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |deliverableHash|IPFS hash|The deliverable hash that was submitted (an IPFS hash).|
 
 
-### `events.TaskDomainSet.addListener(({ taskId, domainId }) => { /* ... */ })`
+### `events.TaskDomainSet`
+
+**Methods**
+
+`.addListener(({ taskId, domainId }) => { /* ... */ })`
+
+`.removeListener(({ taskId, domainId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2422,11 +2583,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |domainId|number|The ID of the domain that was set.|
 
 
-### `events.TaskDueDateSet.addListener(({ taskId, dueDate }) => { /* ... */ })`
+### `events.TaskDueDateSet`
+
+**Methods**
+
+`.addListener(({ taskId, dueDate }) => { /* ... */ })`
+
+`.removeListener(({ taskId, dueDate }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2434,22 +2602,36 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |dueDate|date|The due date that was set.|
 
 
-### `events.TaskFinalized.addListener(({ taskId }) => { /* ... */ })`
+### `events.TaskFinalized`
+
+**Methods**
+
+`.addListener(({ taskId }) => { /* ... */ })`
+
+`.removeListener(({ taskId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task that was finalized.|
 
 
-### `events.TaskPayoutClaimed.addListener(({ taskId, role, token, amount }) => { /* ... */ })`
+### `events.TaskPayoutClaimed`
+
+**Methods**
+
+`.addListener(({ taskId, role, token, amount }) => { /* ... */ })`
+
+`.removeListener(({ taskId, role, token, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2459,11 +2641,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |amount|big number|The task payout amount that was claimed.|
 
 
-### `events.TaskPayoutSet.addListener(({ taskId, role, token, amount }) => { /* ... */ })`
+### `events.TaskPayoutSet`
+
+**Methods**
+
+`.addListener(({ taskId, role, token, amount }) => { /* ... */ })`
+
+`.removeListener(({ taskId, role, token, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2473,11 +2662,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |amount|big number|The task payout amount that was set.|
 
 
-### `events.TaskRoleUserSet.addListener(({ taskId, role, user }) => { /* ... */ })`
+### `events.TaskRoleUserSet`
+
+**Methods**
+
+`.addListener(({ taskId, role, user }) => { /* ... */ })`
+
+`.removeListener(({ taskId, role, user }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2486,11 +2682,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |user|address|The user that was assigned the task role.|
 
 
-### `events.TaskSkillSet.addListener(({ taskId, skillId }) => { /* ... */ })`
+### `events.TaskSkillSet`
+
+**Methods**
+
+`.addListener(({ taskId, skillId }) => { /* ... */ })`
+
+`.removeListener(({ taskId, skillId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2498,11 +2701,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |skillId|number|The ID of the skill that was set.|
 
 
-### `events.TaskWorkRatingRevealed.addListener(({ taskId, role, rating }) => { /* ... */ })`
+### `events.TaskWorkRatingRevealed`
+
+**Methods**
+
+`.addListener(({ taskId, role, rating }) => { /* ... */ })`
+
+`.removeListener(({ taskId, role, rating }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2511,11 +2721,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |rating|number|The value of the rating that was revealed (`1`, `2`, or `3`).|
 
 
-### `events.TokenLocked.addListener(({ token, lockCount }) => { /* ... */ })`
+### `events.TokenLocked`
+
+**Methods**
+
+`.addListener(({ token, lockCount }) => { /* ... */ })`
+
+`.removeListener(({ token, lockCount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2523,11 +2740,18 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 |lockCount|number|The total lock count for the token.|
 
 
-### `events.Transfer.addListener(({ from, to, value }) => { /* ... */ })`
+### `events.Transfer`
+
+**Methods**
+
+`.addListener(({ from, to, value }) => { /* ... */ })`
+
+`.removeListener(({ from, to, value }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -6,9 +6,9 @@ order: 1
 
 The `ColonyClient` class is a standard interface for interactions with the methods and events described in both `IColony.sol` and `IMetaColony.sol`. These interactions are generally concerned with actions within a colony, such as adding a new domain, creating a task, moving funds between pots, and managing permissions.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `ColonyClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ See [ContractClient](/colonyjs/api-contractclient) for information about the `Co
 
 Generate the rating secret used in task ratings. This function returns a keccak256 hash created from the `salt` and `value`.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -75,7 +75,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a domain.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -127,7 +127,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the total amount of funds that are not in the colony rewards pot. The total amount of funds that are not in the colony rewards pot is a value that keeps track of the total assets a colony has to work with, which may be split among several distinct pots associated with various domains and tasks.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -155,7 +155,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a funding pot.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -184,7 +184,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the balance of a funding pot.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -282,7 +282,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a reward payout cycle.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -315,7 +315,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a task.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -375,7 +375,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the task payout amount assigned to a task role. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -405,7 +405,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about a task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -436,7 +436,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get information about the ratings of a task.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -465,7 +465,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the secret of a rating that has been submitted. If a task is in the commit period of the rating process, the ratings are hidden in a keccak256 hash that was created from a `salt` and `value`. The rating secret can be retrieved but in order to reveal the secret, one would have to know both the `salt` and `value` used to generate the secret.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -517,7 +517,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Get the total payout amount assigned to all task roles. Multiple tokens can be used for task payouts, therefore the token must be specified when calling this function. In order to get the task payout amount in Ether, `token` must be an empty address.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -569,7 +569,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Check whether a user has an authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -625,11 +625,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Add a domain to the colony. Adding new domains is currently retricted to one level, i.e. the `parentDomainId` must be the id of the root domain `1`, which represents the colony itself.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |parentDomainId|number|The ID of the parent domain.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -659,11 +663,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Add a new global skill to the skills tree. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |parentSkillId|number|The ID of the skill under which the new skill will be added.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -690,6 +698,10 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 Indicate approval to exit colony recovery mode. This function can only be called by a user with a recovery role.
 
 
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
 **Response**
 
 An instance of a `ContractResponse`
@@ -710,12 +722,16 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Bootstrap the colony by giving an initial amount of tokens and reputation to selected users. This function can only be called by the user assigned the `FOUNDER` authority role when the `taskCount` for the colony is equal to `0`.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |users|array|The array of users that will recieve an initial amount of tokens and reputation.|
 |amounts|array|The array of corresponding token and reputation amounts each user will recieve.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -741,11 +757,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Claim funds that the colony has received by adding them to the funding pot of the root domain. A small fee is deducted from the funds claimed and added to the colony rewards pot. No fee is deducted when tokens native to the colony are claimed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -772,13 +792,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Claim the payout assigned to a task role. This function can only be called by the user who is assigned a task role (`MANAGER`, `EVALUATOR`, or `WORKER`) after the task has been finalized.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that submitted the rating (`MANAGER`, `EVALUATOR`, or `WORKER`).|
 |token|address|The address of the token contract (an empty address if Ether).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -810,11 +834,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Mark a task as complete. If the user assigned the `WORKER` task role fails to submit the task deliverable by the due date, this function must be called by the user assigned the `MANAGER` task role. This allows the task work to be rated and the task to be finalized.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -839,7 +867,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Create a new task within the colony.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -847,6 +875,10 @@ Create a new task within the colony.
 |domainId|number (optional)|The ID of the domain (default value of `1`).|
 |skillId|number (optional)|The ID of the skill (default value of `null`).|
 |dueDate|date (optional)|The due date of the task (default value of `30` days from creation).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -878,6 +910,10 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 Enter colony recovery mode. This function can only be called by a user with a recovery role.
 
 
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
 **Response**
 
 An instance of a `ContractResponse`
@@ -899,6 +935,10 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Exit colony recovery mode. This function can be called by anyone if enough whitelist approvals are given.
 
 
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
 **Response**
 
 An instance of a `ContractResponse`
@@ -919,11 +959,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Finalize the reward payout cycle. This function can only be called when the reward payout cycle has finished, i.e. 60 days have passed since the creation of the reward payout cycle.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |payoutId|number|The ID of the reward payout cycle.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -948,11 +992,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Finalize a task. Once a task is finalized, each user assigned a task role can claim the payout assigned to their role and no further changes to the task can be made.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -977,7 +1025,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Make a payment. This function can only be called by the user assigned either the `FOUNDER` or `ADMIN` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -986,6 +1034,10 @@ Make a payment. This function can only be called by the user assigned either the
 |amount|big number||
 |domainId|number||
 |skillId|number||
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1030,11 +1082,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Mint new tokens. This function can only be called if the address of the colony contract is the owner of the token contract. If this is the case, then this function can only be called by the user assigned the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of new tokens that will be minted.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1060,11 +1116,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Mint tokens for the Colony Network. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of new tokens that will be minted.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1094,7 +1154,7 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 
 Move funds from one pot to another.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1102,6 +1162,10 @@ Move funds from one pot to another.
 |toPot|number|The ID of the pot to which funds will be moved.|
 |amount|big number|The amount of funds that will be moved between pots.|
 |token|address|The address of the token contract (an empty address if Ether).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1129,12 +1193,16 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Register an ENS label for the colony.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |colonyName|string|The ENS label that will be registered for the colony.|
 |orbitDBPath|string|The path of the OrbitDB database associated with the colony.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1160,11 +1228,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `ADMIN` authority role from a user. This function can only be called by the user assigned the `FOUNDER` authroity role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that we will be unassigned the `ADMIN` authority role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1189,11 +1261,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the colony recovery role from a user. This function can only be called by the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be unassigned a colony recovery role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1215,7 +1291,7 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Reveal a submitted work rating. In order to reveal a work rating, the same `salt` and `value` used to generate the `secret` when the task work rating was submitted must be provided again here to reveal the task work rating.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1223,6 +1299,10 @@ Reveal a submitted work rating. In order to reveal a work rating, the same `salt
 |role|task role|The role that received the rating (`MANAGER` or `WORKER`).|
 |rating|number|The rating that was submitted (`1`, `2`, or `3`).|
 |salt|string|The string that was used to generate the secret.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1249,11 +1329,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `ADMIN` authority role to a user. This function can only be called by the user assigned the `FOUNDER` authority role or a user assigned the `ADMIN` authority role. There is no limit to the number of users that can be assigned the `ADMIN` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned the `ADMIN` authroity role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1278,7 +1362,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payouts for all task roles (`MANAGER`, `EVALUATOR`, and `WORKER`). This can only be called by the user assigned the `MANAGER` task role and only if the `EVALUATOR` and `WORKER` task roles are either not assigned or assigned to the same user as the `MANAGER` task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1287,6 +1371,10 @@ Set the payouts for all task roles (`MANAGER`, `EVALUATOR`, and `WORKER`). This 
 |managerAmount|big number|The payout amount in tokens (or Ether) for the `MANAGER` task role.|
 |evaluatorAmount|big number|The payout amount in tokens (or Ether) for the `EVALUATOR` task role.|
 |workerAmount|big number|The payout amount in tokens (or Ether) for the `WORKER` task role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1314,11 +1402,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `FOUNDER` authority role to a user. This function can only be called by the user currently assigned the `FOUNDER` authority role. There can only be one address assigned to the `FOUNDER` authority role, therefore, the user currently assigned will forfeit their role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned the `FOUNDER` authority role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1344,11 +1436,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the inverse amount of the reward. This can only be called from the Meta Colony and only by the user assigned the `FOUNDER` role. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |feeInverse|number|The inverse amount that will be set.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1370,11 +1466,15 @@ Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9b
 
 Assign a colony recovery role to a user. This function can only be called by the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be assigned a colony recovery role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1396,11 +1496,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the inverse amount of the reward. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |rewardInverse|big number|The inverse amount of the reward.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1425,12 +1529,16 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |slot|number|The ID of the storage slot that will be modified.|
 |value|hex string|The hex string of data that will be set as the value.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1452,11 +1560,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Start the next reward payout cycle. All the funds in the colony rewards pot for the given token will become locked until reputation holders have claimed their rewards payout using `claimRewardPayout`. Reputation holders can also waive their reward payout and unlock their tokens for past reward payout cycles by using `incrementLockCounterTo`.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1484,12 +1596,16 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit the task deliverable. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |deliverableHash|IPFS hash|The deliverable hash of the task (an IPFS hash).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1516,13 +1632,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit the task deliverable and the work rating for the user assigned the `MANAGER` task role. This function can only be called by the user assigned the `WORKER` task role on or before the task due date. The submission cannot be overwritten, which means the deliverable cannot be changed once it has been submitted. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |deliverableHash|IPFS hash|The deliverable hash of the task (an IPFS hash).|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1549,13 +1669,17 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Submit a work rating for a task. This function can only be called by the user assigned the `EVALUATOR` task role, who is submitting a rating for the user assigned the `WORKER` task role, or the user assigned the `WORKER` task role, who is submitting a rating for the user assigned the `MANAGER` task role. In order to submit a rating, a `secret` must be generated using the `generateSecret` method, which keeps the rating hidden until all ratings have been submitted and revealed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The role that will receive the rating (`MANAGER` or `WORKER`).|
 |secret|hex string|A keccak256 hash that keeps the task rating hidden.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1577,11 +1701,15 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Upgrade the colony to a new contract version. The new version number must be higher than the current version. Downgrading to old contract versions is not permitted.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |newVersion|number|The version number of the colony contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1611,7 +1739,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Cancel a task. Once a task is cancelled, no further changes to the task can be made.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1640,7 +1768,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `EVALUATOR` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1671,7 +1799,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Remove the `WORKER` task role assignment. This function can only be called before the task is complete, i.e. either before the deliverable has been submitted or the user assigned the `WORKER` task role has failed to meet the deadline and the user assigned the `MANAGER` task role has marked the task as complete.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1702,7 +1830,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the task specification. The task specification, or "task brief", is a description of the work that must be completed for the task. The description is hashed and stored with the task for future reference during the rating process or in the event of a dispute.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1733,7 +1861,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the domain of a task. Every task must belong to a domain. This function can only be called by the user assigned the `MANAGER` task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1764,7 +1892,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the due date of a task. The due date is the last day that the user assigned the `WORKER` task role can submit the task deliverable.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1795,7 +1923,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `EVALUATOR` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `EVALUATOR` task role must both sign the transaction before it can be executed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1827,7 +1955,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `MANAGER` task role to a user. This function can only be called before the task is finalized. The user currently assigned the `MANAGER` task role and the user being assigned the `MANAGER` task role must both sign the transaction before it can be executed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1859,7 +1987,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the skill of a task. Only one skill can be assigned per task. The user assigned the `MANAGER` task role and the user assigned the `WORKER` task role must both sign this transaction before it can be executed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1890,7 +2018,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Assign the `WORKER` task role to a user. This function can only be called before the task is finalized. The user assigned the `MANAGER` task role and the user being assigned the `WORKER` task role must both sign the transaction before it can be executed.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1922,7 +2050,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `MANAGER` task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1956,7 +2084,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `EVALUATOR` task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1990,7 +2118,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 Set the payout amount for the `WORKER` task role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2028,7 +2156,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2039,7 +2167,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2050,7 +2178,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2062,7 +2190,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2074,7 +2202,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2087,7 +2215,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2101,7 +2229,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2112,7 +2240,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2124,7 +2252,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2135,7 +2263,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2147,7 +2275,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2158,7 +2286,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2170,7 +2298,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2181,7 +2309,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2195,7 +2323,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2206,7 +2334,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2217,7 +2345,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2229,7 +2357,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2240,7 +2368,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2252,7 +2380,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2263,7 +2391,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2274,7 +2402,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2286,7 +2414,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2298,7 +2426,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2310,7 +2438,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2321,7 +2449,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2335,7 +2463,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2349,7 +2477,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2362,7 +2490,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2374,7 +2502,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2387,7 +2515,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -2399,7 +2527,7 @@ Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba12
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -8,6 +8,10 @@ The `ColonyNetworkClient` is a standard interface for interactions with methods 
 
 See [Clients](/colonyjs/components-clients) for information about initializing `ColonyNetworkClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==
 
 ## Instance methods
@@ -18,14 +22,14 @@ See [Clients](/colonyjs/components-clients) for information about initializing `
 
 Get the address of a Colony for the specified id of a deployed colony contract.
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |key|string|Name of the Colony to get|
 |id|number|Integer number of the Colony|
 
-#### Response
+**Response**
 
 `Promise<Address>`. The address of the given Colony contract
 
@@ -33,14 +37,14 @@ Get the address of a Colony for the specified id of a deployed colony contract.
 
 Returns an initialized ColonyClient for the specified id of a deployed colony contract.
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |key|string|Name of the Colony to get|
 |id|number|Integer number of the Colony|
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
@@ -48,13 +52,13 @@ Returns an initialized ColonyClient for the specified id of a deployed colony co
 
 Returns an initialized ColonyClient for the contract at address `contractAddress`
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |contractAddress|Adress|Address of a deployed Colony contract|
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
@@ -62,7 +66,7 @@ Returns an initialized ColonyClient for the contract at address `contractAddress
 
 Gets the Meta Colony as an initialized ColonyClient
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the MetaColony contract
 
@@ -75,21 +79,21 @@ Gets the Meta Colony as an initialized ColonyClient
 
 Check whether or not ENS supports a contract interface. A supported contract interface implements `interfaceId`.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |interfaceId|hex string|The hashed ID of the contract interface as specified in ERC-165.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |isSupported|boolean|A boolean indicating whether or not the contract interface is supported.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `supportsInterface`
@@ -103,21 +107,21 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of a registered ENS label. This function will return an empty address if an ENS label has not been registered.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |nameHash|hex string|The hached ENS label that will be checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |ensAddress|address|The address associated with the ENS label.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `addr`
@@ -131,22 +135,22 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the ID of a child skill.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The numberic ID of the skill that will be checked.|
 |childSkillIndex|number|The index of the child skill array to be checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |childSkillId|number|The ID of the child skill.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -160,21 +164,21 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the colony contract address for a colony.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |id|number|The ID of the colony.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the colony contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -189,15 +193,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the total number of colonies on the network. The return value is also the ID of the last colony created.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of colonies.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -211,21 +215,21 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of the resolver contract for a specific colony version.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The version number of the colony contract.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the resolver contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -240,15 +244,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the latest colony contract version. This is the version used to create all new colonies.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The version number of the latest colony contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -263,15 +267,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the inverse amount of the network fee. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse amount of the network fee.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -286,15 +290,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the Meta Colony contract address.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address of the Meta Colony contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `getMetaColony`
@@ -308,22 +312,22 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the ID of a parent skill.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The numberic ID of the skill that will be checked.|
 |parentSkillIndex|number|The index of the parent skill array to be checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |parentSkillId|number|The ID of the parent skill.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -337,21 +341,21 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of the OrbitDB database associaated with a user profile.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |nameHash|hex string|The hashed ENS label that was registered for the user.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |orbitDBAddress|string|The path of the OrbitDB database associated with the user profile.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -366,15 +370,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the total number of users that are assigned a network recovery role.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of users that are assigned a colony recovery role.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `numRecoveryRoles`
@@ -389,15 +393,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Get the ID of the root global skill.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the root global skill.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -411,23 +415,23 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get information about a domain.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the skill.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |nParents|number|The total number of parent skills.|
 |nChildren|number|The total number of child skills.|
 |isGlobalSkill|boolean|A boolean indicating whether or not the skill is a global skill.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -442,15 +446,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the total number of global and local skills in the network.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of global and local skills in the network.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -465,15 +469,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Get the token locking contract address.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |lockingAddress|address|The address of the token locking contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -487,21 +491,21 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Check whether or not an address is a colony contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colony|address|The address that will be checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |isColony|boolean|A boolean indicating whether or not an address is a colony contract.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -516,15 +520,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Check whether or not the network is in recovery mode.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |inRecoveryMode|boolean|A boolean indicating whether or not the network is in recovery mode.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -538,21 +542,21 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Lookup the registed ENS label for an address. This function will return an empty string if the address does not have a registered ENS label.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |ensAddress|address|The address that will checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |domain|string|The ENS label associated with the address.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -570,24 +574,24 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Add a new colony contract version and set the address of the resolver contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The versions number of the colony contract.|
 |resolver|address|The address of the resolver contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The version number of the colony contract that was added.|
 |resolver|address|The address of the resolver contract.|
 |ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#eventscolonyversionaddedaddlistener-version-resolver-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -601,24 +605,24 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Add a new global or local skill to the skills tree.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |parentSkillId|number|The ID of the skill under which the new skill will be added.|
 |globalSkill|boolean|A boolean indicating whether or not the skill will be a global skill.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
 |SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -633,13 +637,13 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Indicate approval to exit network recovery mode. This function can only be called by a user with a recovery role.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -653,24 +657,24 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Create a new colony on the network.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyId|number|The ID of the colony that was added.|
 |colonyAddress|address|The address of the colony contract that was created.|
 |tokenAddress|address|The address of the token contract that was assigned.|
 |ColonyAdded|object|Contains the data defined in [ColonyAdded](#eventscolonyaddedaddlistener-colonyid-colonyaddress-tokenaddress-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -684,24 +688,24 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create the Meta Colony.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyAddress|number|The address of the Meta Colony.|
 |tokenAddress|address|The address of the CLNY token contract.|
 |rootSkillId|number|The ID of the root skill.|
 |MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#eventsmetacolonycreatedaddlistener-colonyaddress-tokenaddress-rootskillid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -715,19 +719,19 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create a new ERC20 token contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |symbol|string|The symbol of the token.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will receive a receipt with a `contractAddress` property (the address of the newly-deployed contract)
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -741,13 +745,13 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 Enter network recovery mode. This function can only be called by a user with a recovery role.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -762,13 +766,13 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Exit network recovery mode. This function can be called by anyone if enough whitelist approvals are given.
 
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -782,24 +786,24 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Register an ENS label for a user.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |username|string|The ENS label that will be registered for the user.|
 |orbitDBPath|string|The path of the OrbitDB database associated with the user profile.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that registered a label.|
 |label|string|The ENS label that was registered for the user.|
 |UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#eventsuserlabelregisteredaddlistener-user-label-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -813,19 +817,19 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Remove the network recovery role from a user. This function can only be called by the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that will be unassigned a network recovery role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -839,22 +843,22 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the inverse amount of the network fee. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse amount of the network fee.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse value of the network fee that was set.|
 |NetworkFeeInverseSet|object|Contains the data defined in [NetworkFeeInverseSet](#eventsnetworkfeeinversesetaddlistener-feeinverse-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -868,19 +872,19 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Assign a network recovery role to a user. This function can only be called by the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that will be assigned a network recovery role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -894,20 +898,20 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |slot|number|The ID of the storage slot that will be modified.|
 |value|hex string|The hex string of data that will be set as the value.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -921,22 +925,22 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the token locking address.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenLockingAddress|address|The address of the locking contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenLocking|address|The address of the token locking contract.|
 |TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#eventstokenlockingaddresssetaddlistener-tokenlocking-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -950,20 +954,20 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Set up the registrar.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |ens|address|The adddress of the ENS registrar.|
 |rootNode|string|The namehash of the root node for the domain.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -977,24 +981,24 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create and start an auction for a token owned by the Colony Network. The auction will be for the total amount of the specificed tokens that are owned by the Colony Network.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |auction|string|The address of the auction contract that was created.|
 |token|address|The address of the token contract that was assigned.|
 |quantity|big number|The amount of tokens available for the auction.|
 |AuctionCreated|object|Contains the data defined in [AuctionCreated](#eventsauctioncreatedaddlistener-auction-token-quantity-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -1013,9 +1017,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |auction|string|The address of the auction contract that was created.|
 |token|address|The address of the token contract that was assigned.|
@@ -1026,9 +1030,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyId|number|The ID of the colony that was added.|
 |colonyAddress|address|The address of the colony contract that was created.|
@@ -1039,9 +1043,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colony|address|The address of the colony that registered a label.|
 |label|string|The ENS label that was registered for the colony.|
@@ -1051,9 +1055,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |resolver|address|The address of the resolver contract.|
 
@@ -1062,9 +1066,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |version|number|The version number of the colony contract that was added.|
 |resolver|address|The address of the resolver contract.|
@@ -1074,9 +1078,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |colonyAddress|number|The address of the Meta Colony.|
 |tokenAddress|address|The address of the CLNY token contract.|
@@ -1087,9 +1091,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |miningCycleResolver|address|The address of the resolver contract for the reputation mining cycle contract.|
 
@@ -1098,9 +1102,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse value of the network fee that was set.|
 
@@ -1109,9 +1113,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |hash|hex string|The root hash of the reputation state that was accepted.|
 |nNodes|number|The total number of nodes in the reputation state.|
@@ -1121,9 +1125,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |inactiveReputationMiningCycle|address|The address of the reputation mining cycle that was initialized.|
 
@@ -1132,9 +1136,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |newHash|hex string|The reputation root hash that was set.|
 |newNNodes|number|The total number of nodes in the reputation state.|
@@ -1146,9 +1150,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
@@ -1158,9 +1162,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |tokenLocking|address|The address of the token locking contract.|
 
@@ -1169,9 +1173,9 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that registered a label.|
 |label|string|The ENS label that was registered for the user.|

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -6,9 +6,9 @@ order: 2
 
 The `ColonyNetworkClient` is a standard interface for interactions with methods and events described in `IColonyNetwork.sol`. These interactions are generally concerned with the colony network as a whole. This includes operations like getting a count of all colonies on the network, querying for information about a skill, or registering an ENS label for a user.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `ColonyNetworkClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyNetworkClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 
@@ -79,7 +79,7 @@ Gets the Meta Colony as an initialized ColonyClient
 
 Check whether or not ENS supports a contract interface. A supported contract interface implements `interfaceId`.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -107,7 +107,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of a registered ENS label. This function will return an empty address if an ENS label has not been registered.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -135,7 +135,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the ID of a child skill.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -164,7 +164,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the colony contract address for a colony.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -215,7 +215,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of the resolver contract for a specific colony version.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -312,7 +312,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the ID of a parent skill.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -341,7 +341,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get the address of the OrbitDB database associaated with a user profile.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -415,7 +415,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Get information about a domain.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -491,7 +491,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Check whether or not an address is a colony contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -542,7 +542,7 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Lookup the registed ENS label for an address. This function will return an empty string if the address does not have a registered ENS label.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -574,12 +574,16 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Add a new colony contract version and set the address of the resolver contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |version|number|The versions number of the colony contract.|
 |resolver|address|The address of the resolver contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -605,12 +609,16 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Add a new global or local skill to the skills tree.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |parentSkillId|number|The ID of the skill under which the new skill will be added.|
 |globalSkill|boolean|A boolean indicating whether or not the skill will be a global skill.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -637,6 +645,10 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 Indicate approval to exit network recovery mode. This function can only be called by a user with a recovery role.
 
 
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
 **Response**
 
 An instance of a `ContractResponse`
@@ -657,11 +669,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Create a new colony on the network.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -688,11 +704,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create the Meta Colony.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -719,11 +739,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create a new ERC20 token contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |symbol|string|The symbol of the token.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -744,6 +768,10 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 Enter network recovery mode. This function can only be called by a user with a recovery role.
 
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -766,6 +794,10 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 Exit network recovery mode. This function can be called by anyone if enough whitelist approvals are given.
 
 
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
 **Response**
 
 An instance of a `ContractResponse`
@@ -786,12 +818,16 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Register an ENS label for a user.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |username|string|The ENS label that will be registered for the user.|
 |orbitDBPath|string|The path of the OrbitDB database associated with the user profile.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -817,11 +853,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Remove the network recovery role from a user. This function can only be called by the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that will be unassigned a network recovery role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -843,11 +883,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the inverse amount of the network fee. If the fee is 1% (or 0.01), the inverse amount will be 100.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse amount of the network fee.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -872,11 +916,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Assign a network recovery role to a user. This function can only be called by the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address of the user that will be assigned a network recovery role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -898,12 +946,16 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the value for a storage slot while in recovery mode. This can only be called by a user with a recovery role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |slot|number|The ID of the storage slot that will be modified.|
 |value|hex string|The hex string of data that will be set as the value.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -925,11 +977,15 @@ Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/9bba
 
 Set the token locking address.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |tokenLockingAddress|address|The address of the locking contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -954,12 +1010,16 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Set up the registrar.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |ens|address|The adddress of the ENS registrar.|
 |rootNode|string|The namehash of the root node for the domain.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -981,11 +1041,15 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 Create and start an auction for a token owned by the Colony Network. The auction will be for the total amount of the specificed tokens that are owned by the Colony Network.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |tokenAddress|address|The address of the token contract.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -1017,7 +1081,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1030,7 +1094,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1043,7 +1107,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1055,7 +1119,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1066,7 +1130,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1078,7 +1142,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1091,7 +1155,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1102,7 +1166,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1113,7 +1177,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1125,7 +1189,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1136,7 +1200,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1150,7 +1214,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1162,7 +1226,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1173,7 +1237,7 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -73,7 +73,7 @@ Gets the Meta Colony as an initialized ColonyClient
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.**.
+**All callers return promises which resolve to an object containing the given return values.**
 
 ### `ensSupportsInterface.call({ interfaceId })`
 
@@ -593,7 +593,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |version|number|The version number of the colony contract that was added.|
 |resolver|address|The address of the resolver contract.|
-|ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#eventscolonyversionaddedaddlistener-version-resolver-------)|
+|ColonyVersionAdded|object|Contains the data defined in [ColonyVersionAdded](#eventscolonyversionadded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -628,7 +630,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |skillId|number|The ID of the skill that was added.|
 |parentSkillId|number|The ID of the parent skill.|
-|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladdedaddlistener-skillid-parentskillid-------)|
+|SkillAdded|object|Contains the data defined in [SkillAdded](#eventsskilladded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -651,9 +655,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -688,7 +694,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |colonyId|number|The ID of the colony that was added.|
 |colonyAddress|address|The address of the colony contract that was created.|
 |tokenAddress|address|The address of the token contract that was assigned.|
-|ColonyAdded|object|Contains the data defined in [ColonyAdded](#eventscolonyaddedaddlistener-colonyid-colonyaddress-tokenaddress-------)|
+|ColonyAdded|object|Contains the data defined in [ColonyAdded](#eventscolonyadded)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -723,7 +731,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |colonyAddress|number|The address of the Meta Colony.|
 |tokenAddress|address|The address of the CLNY token contract.|
 |rootSkillId|number|The ID of the root skill.|
-|MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#eventsmetacolonycreatedaddlistener-colonyaddress-tokenaddress-rootskillid-------)|
+|MetaColonyCreated|object|Contains the data defined in [MetaColonyCreated](#eventsmetacolonycreated)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -751,9 +761,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse` which will receive a receipt with a `contractAddress` property (the address of the newly-deployed contract)
+An instance of a `ContractResponse` which will receive a receipt with a `contractAddress` property.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -775,9 +787,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -800,9 +814,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -837,7 +853,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |user|address|The address of the user that registered a label.|
 |label|string|The ENS label that was registered for the user.|
-|UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#eventsuserlabelregisteredaddlistener-user-label-------)|
+|UserLabelRegistered|object|Contains the data defined in [UserLabelRegistered](#eventsuserlabelregistered)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -865,9 +883,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -900,7 +920,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse value of the network fee that was set.|
-|NetworkFeeInverseSet|object|Contains the data defined in [NetworkFeeInverseSet](#eventsnetworkfeeinversesetaddlistener-feeinverse-------)|
+|NetworkFeeInverseSet|object|Contains the data defined in [NetworkFeeInverseSet](#eventsnetworkfeeinverseset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -928,9 +950,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -959,9 +983,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -994,7 +1020,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |tokenLocking|address|The address of the token locking contract.|
-|TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#eventstokenlockingaddresssetaddlistener-tokenlocking-------)|
+|TokenLockingAddressSet|object|Contains the data defined in [TokenLockingAddressSet](#eventstokenlockingaddressset)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1023,9 +1051,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -1060,7 +1090,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |auction|string|The address of the auction contract that was created.|
 |token|address|The address of the token contract that was assigned.|
 |quantity|big number|The amount of tokens available for the auction.|
-|AuctionCreated|object|Contains the data defined in [AuctionCreated](#eventsauctioncreatedaddlistener-auction-token-quantity-------)|
+|AuctionCreated|object|Contains the data defined in [AuctionCreated](#eventsauctioncreated)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -8,7 +8,7 @@ The `ColonyNetworkClient` is a standard interface for interactions with methods 
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyNetworkClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 
@@ -1077,11 +1077,18 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 ## Events
 
 
-### `events.AuctionCreated.addListener(({ auction, token, quantity }) => { /* ... */ })`
+### `events.AuctionCreated`
+
+**Methods**
+
+`.addListener(({ auction, token, quantity }) => { /* ... */ })`
+
+`.removeListener(({ auction, token, quantity }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1090,11 +1097,18 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |quantity|big number|The amount of tokens available for the auction.|
 
 
-### `events.ColonyAdded.addListener(({ colonyId, colonyAddress, tokenAddress }) => { /* ... */ })`
+### `events.ColonyAdded`
+
+**Methods**
+
+`.addListener(({ colonyId, colonyAddress, tokenAddress }) => { /* ... */ })`
+
+`.removeListener(({ colonyId, colonyAddress, tokenAddress }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1103,11 +1117,18 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |tokenAddress|address|The address of the token contract that was assigned.|
 
 
-### `events.ColonyLabelRegistered.addListener(({ colony, label }) => { /* ... */ })`
+### `events.ColonyLabelRegistered`
+
+**Methods**
+
+`.addListener(({ colony, label }) => { /* ... */ })`
+
+`.removeListener(({ colony, label }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1115,22 +1136,36 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |label|string|The ENS label that was registered for the colony.|
 
 
-### `events.ColonyNetworkInitialised.addListener(({ resolver }) => { /* ... */ })`
+### `events.ColonyNetworkInitialised`
+
+**Methods**
+
+`.addListener(({ resolver }) => { /* ... */ })`
+
+`.removeListener(({ resolver }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |resolver|address|The address of the resolver contract.|
 
 
-### `events.ColonyVersionAdded.addListener(({ version, resolver }) => { /* ... */ })`
+### `events.ColonyVersionAdded`
+
+**Methods**
+
+`.addListener(({ version, resolver }) => { /* ... */ })`
+
+`.removeListener(({ version, resolver }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1138,11 +1173,18 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |resolver|address|The address of the resolver contract.|
 
 
-### `events.MetaColonyCreated.addListener(({ colonyAddress, tokenAddress, rootSkillId }) => { /* ... */ })`
+### `events.MetaColonyCreated`
+
+**Methods**
+
+`.addListener(({ colonyAddress, tokenAddress, rootSkillId }) => { /* ... */ })`
+
+`.removeListener(({ colonyAddress, tokenAddress, rootSkillId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1151,33 +1193,54 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |rootSkillId|number|The ID of the root skill.|
 
 
-### `events.MiningCycleResolverSet.addListener(({ miningCycleResolver }) => { /* ... */ })`
+### `events.MiningCycleResolverSet`
+
+**Methods**
+
+`.addListener(({ miningCycleResolver }) => { /* ... */ })`
+
+`.removeListener(({ miningCycleResolver }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |miningCycleResolver|address|The address of the resolver contract for the reputation mining cycle contract.|
 
 
-### `events.NetworkFeeInverseSet.addListener(({ feeInverse }) => { /* ... */ })`
+### `events.NetworkFeeInverseSet`
+
+**Methods**
+
+`.addListener(({ feeInverse }) => { /* ... */ })`
+
+`.removeListener(({ feeInverse }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |feeInverse|big number|The inverse value of the network fee that was set.|
 
 
-### `events.ReputationMiningCycleComplete.addListener(({ hash, nNodes }) => { /* ... */ })`
+### `events.ReputationMiningCycleComplete`
+
+**Methods**
+
+`.addListener(({ hash, nNodes }) => { /* ... */ })`
+
+`.removeListener(({ hash, nNodes }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1185,22 +1248,36 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |nNodes|number|The total number of nodes in the reputation state.|
 
 
-### `events.ReputationMiningInitialised.addListener(({ inactiveReputationMiningCycle }) => { /* ... */ })`
+### `events.ReputationMiningInitialised`
+
+**Methods**
+
+`.addListener(({ inactiveReputationMiningCycle }) => { /* ... */ })`
+
+`.removeListener(({ inactiveReputationMiningCycle }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |inactiveReputationMiningCycle|address|The address of the reputation mining cycle that was initialized.|
 
 
-### `events.ReputationRootHashSet.addListener(({ newHash, newNNodes, stakers, reward }) => { /* ... */ })`
+### `events.ReputationRootHashSet`
+
+**Methods**
+
+`.addListener(({ newHash, newNNodes, stakers, reward }) => { /* ... */ })`
+
+`.removeListener(({ newHash, newNNodes, stakers, reward }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1210,11 +1287,18 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |reward|array|The array of corresponding amounts of CLNY each user received.|
 
 
-### `events.SkillAdded.addListener(({ skillId, parentSkillId }) => { /* ... */ })`
+### `events.SkillAdded`
+
+**Methods**
+
+`.addListener(({ skillId, parentSkillId }) => { /* ... */ })`
+
+`.removeListener(({ skillId, parentSkillId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -1222,22 +1306,36 @@ Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree
 |parentSkillId|number|The ID of the parent skill.|
 
 
-### `events.TokenLockingAddressSet.addListener(({ tokenLocking }) => { /* ... */ })`
+### `events.TokenLockingAddressSet`
+
+**Methods**
+
+`.addListener(({ tokenLocking }) => { /* ... */ })`
+
+`.removeListener(({ tokenLocking }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |tokenLocking|address|The address of the token locking contract.|
 
 
-### `events.UserLabelRegistered.addListener(({ user, label }) => { /* ... */ })`
+### `events.UserLabelRegistered`
+
+**Methods**
+
+`.addListener(({ user, label }) => { /* ... */ })`
+
+`.removeListener(({ user, label }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_ContractClient.md
+++ b/docs/_API_ContractClient.md
@@ -112,3 +112,19 @@ Given a `MultisigOperation` in JSON format, the `restoreOperation` method restor
 `Promise<MultisigOperation>` - A promise that resolves to a `MultisigOperation` instance.
 
 See [MultisigOperation](/api-multisigoperation/) for more information and [Using Multisignature](/topics-using-multisignature/) for examples.
+
+## Events
+
+Each client instance created by the `ContractClient` superclass has an `events` property that contains all the events associated with the contract methods for the given client. Listeners can be added and removed from each event.
+
+### `addListener(input)`
+
+**Input**
+
+`function` - A callback function using the return values for the event as the input parameters.
+
+### `removeListener(input)`
+
+**Input**
+
+`function` - A callback function using the return values for the event as the input parameters.

--- a/docs/_API_ContractClient.md
+++ b/docs/_API_ContractClient.md
@@ -1,0 +1,363 @@
+---
+title: ContractClient
+section: API
+order: 0
+---
+
+`ContractClient` is a superclass for all implementations of [clients](/colonyjs/components-clients/). Each client contains abstractions such as `Caller`, `Sender`, and `MulitisigSender` which are inherited from the `ContractClient` superclass. The `ContractClient` superclass also contains tools for listening to events and interacting with the reputation mining system.
+
+==TOC==
+
+## Callers
+
+Callers passively interacts with objects on the blockchain and do not produce transactions. They are associated with a single contract method. Callers will usually expect certain parameters and return a promise that resolves to an object.
+
+### `call(input)`
+
+The `call` method performs the associated call method on the contract and returns the output values.
+
+#### Input Values
+
+`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+
+#### Output Values
+
+`Promise<{ [string]: any }>` - A promise that resolves to an object containing the key value pairs of the output.
+
+#### Example
+
+Callers usually accept an object of named parameters (e.g. `taskId`) and return an object with named values (e.g. `dueDate`).
+
+```js
+
+const task = await colonyClient.getTask.call({ taskId: 1 });
+
+// -> {
+//      cancelled: false,
+//      deliverableDate: Date(...),
+//      deliverableHash: '0x...',
+//      domainId: 1,
+//      dueDate: Date(...),
+//      finalized: false,
+//      id: 1,
+//      skillId: 4,
+//      specificationHash: '0x...',
+//    }
+
+```
+
+Some callers do not accept an object of named parameters.
+
+```js
+
+const tasks = await colonyClient.getTaskCount.call();
+
+// -> { count: 201 }
+
+```
+
+## Senders
+
+Senders are used to create blockchain transactions. Like callers, they associated with a single contract method. A sender can either be used to call `send()`, which will parse a transaction and execute it on the underlying contract, or `estimate()`, which will simply return an estimate of the transaction gas cost.
+
+
+### `estimate(input)`
+
+The `estimate` method will estimate the Gas cost of the transaction for the associated smart contract method.
+
+#### Input Values
+
+`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+
+#### Output Values
+
+`Promise<BigNumber>` - A promise that resolves to a `BigNumber` object which represents the estimated gas cost.
+
+#### Example
+
+```js
+
+const estimate = await networkClient.createColony.estimate({
+  tokenAddress: '0x...',
+});
+
+// -> BigNumber(2501852)
+
+```
+
+### `send(input, options)`
+
+The `send` method signs and sends off a transaction for the associated contract method. It returns a `ContractResponse` object which contains the transaction metadata as well as event data (if applicable).
+
+#### Input Values
+
+**input**
+
+`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+
+**options**
+
+|Option|Type|Description|
+|---|---|---|
+|timeoutMs|number|Milliseconds to wait until this transaction will time out|
+|waitForMining|boolean|If true, it will wait for the transaction to be mined before resolving the resulting promise (default: true)|
+|gasLimit|BigNumber|Sets the maximum gas limit for the transaction
+|gasPrice|BigNumber|The price in wei per gas unit
+|nonce|number|The transaction nonce
+|value|BigNumber|The amount in wei that the transaction will send
+
+#### Output Values
+
+`Promise<ContractResponse>` - With [ContractResponse](#contractresponse) being an object with the following properties:
+
+with `waitForMining` set to `true`:
+
+|Property|Type|Description|
+|---|---|---|
+|successful|boolean|Indicates whether the transaction was executed successfully|
+|eventData|Object|Contains eventData emitted by the smart contract (see docs of the particular contract client)|
+|meta|Object|Contains the `transaction` and a `receipt` object passed on by the used ethereum adapter|
+
+with `waitForMining` set to `false`:
+
+|Property|Type|Description|
+|---|---|---|
+|successfulPromise|Promise<boolean>|Just like above but will only be resolved when mined|
+|eventDataPromise|Object|Just like above but will only be resolved when event data is emitted|
+|meta|Object|Just like above execpt the `receipt` is `receiptPromise` and will be resolved when mined|
+
+#### Example
+
+```js
+
+const response = await networkClient.createColony.send({
+  tokenAddress: '0x...',
+});
+
+// -> {
+//      successful: true,
+//      eventData: { colonyId: 21, colonyAddress: '0x...' },
+//      meta: {
+//        receipt: { /* ...receipt properties  */ },
+//        transaction: { /* ...transaction properties  */ },
+//      },
+//    }
+
+```
+
+The `send` method also accepts `options` as an optional second parameter.
+
+```js
+
+await networkClient.createColony.send({
+  tokenAddress: '0x...',
+}, {
+  gasLimit: 400000,
+  timeoutMs: 1000 * 60 * 2,
+  waitForMining: true,
+});
+
+// -> {
+//      successful: true,
+//      eventData: { colonyId: 21, colonyAddress: '0x...' },
+//      meta: {
+//        receipt: { /* ...receipt properties  */ },
+//        transaction: { /* ...transaction properties  */ },
+//      },
+//    }
+
+```
+
+## MultisigSender
+
+The `MutlisigSender` class is a used to create multisignature transactions. They are associated with a method on the smart contract which requires more than one signature to be executed. For more information see [Using Multisignature](/colonyjs/topics-usingmultisignature/).
+
+### `startOperation(input)`
+
+Given named input values, it will generate the `MultisigOperation` needed to gather all signatures to send off this transaction.
+
+#### Input Values
+
+**`input`** `{ [string]: any }` - Any key value pair of contract input parameters
+
+#### Output Values
+
+`Promise<MultisigOperation>` - Promise that resolves to a `MultisigOperation` instance.
+
+### `restoreOperation(json)`
+
+Given a serialized operation object as a valid json string, it restores the given operation.
+
+#### Input Values
+
+**`json`** `string` - A serialized operation created via a MultisigOperation instance's .toJSON() method
+
+#### Output Values
+
+`Promise<MultisigOperation>` - Promise that resolves to a `MultisigOperation` instance.
+
+## MultisigOperation
+
+The `MultisigOperation` class is a part of the `ContractClient` to handle Multisignature transactions. They are usually created by a `MultisigSender` class and are associated with the sender which created them.
+
+### `requiredSignees`
+
+`[Address]` - Array of all addresses which are needed to sign off this transaction.
+
+### `missingSignees`
+
+`[Address]` - Array of all addresses which are still missing to sign off this transaction.
+
+### `sign()`
+
+Sign the message hash with the current wallet or provider and add the signature. This method is asynchronous.
+
+#### Output Values
+
+The `MultisigOperation` instance.
+
+### `refresh()`
+
+Refresh the nonce value, required signees, and message hash. This method is asyncrhonous.
+
+If there was no nonce value, a new one will be set; otherwise, if the nonce value changed, the it will be updated, and the `_signers` will be reset. This is done because when the nonce values changes, the signatures that were collected will not work, and the operation will need to be re-signed by all parties.
+
+#### Output Values
+
+The `MultisigOperation` instance.
+
+### `addSignersFromJSON(json)`
+
+Given the state of an operation as JSON, validate the parsed state and add in the signers.
+
+#### Input Values
+
+**`json`** `string` - A serialized `MultisigOperation`.
+
+#### Output Values
+
+The `MultisigOperation` instance with the added signature(s).
+
+### `toJSON()`
+
+Serializes this operation.
+
+#### Output Values
+
+`string` - The serialized `MultisigOperation`
+
+### `send(input, options)`
+
+Given named input values it sends off the MultisigOperation to the contract. Has the same API and return values as [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options).
+
+#### Input Values
+
+**`input`** `{ [string]: any }` - Any key value pair of contract input parameters
+
+**`options`** `SendOptions` - Custom options to use for this transaction. See [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options)
+
+#### Output Values
+
+`Promise<ContractResponse>` - See [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options)
+
+## ContractResponse
+
+A `ContractResponse` is an object with properties that vary based on the `waitForMining` option.
+
+With `waitForMining` set to `true` (the default behavior):
+
+```js
+
+{
+  // Boolean flag for whether the transaction was executed successfully or not
+  successful: true,
+
+  // Contains all of the data from events logged when the transaction
+  // was executed.
+  eventData: {
+    colonyId: 2,
+    colonyAddress: '0xe2D17cA03387f6DaFbA77FaA3De5F6cf41E371Fe',
+    ColonyAdded: {
+        colonyId: 2,
+        colonyAddress: '0xe2D17cA03387f6DaFbA77FaA3De5F6cf41E371Fe',
+    },
+  },
+
+  // Metadata for the transaction
+  meta: {
+
+    // The transaction receipt (received from the Adapter)
+    receipt: {
+      contractAddress: null,
+      transactionIndex: 0,
+      gasUsed: { _bn: '1f29f3' },
+      logsBloom: '0x...',
+      blockHash: '0x6e6eaac9f367c646278f313a48e02fba59c2e1ca9ccf9d96281e3ebd9614b0a2',
+      transactionHash: '0x7c1f5b4481fc17f44cb3a42ce09d4fe05202719e411df8c6e7af455a79bbcca4',
+      logs: [ /* series of logs */ ],
+      blockNumber: 101,
+      cumulativeGasUsed: { _bn: '1f29f3' },
+      status: 1,
+      byzantium: true,
+    },
+
+    // The transaction that was sent (received from the Adapter)
+    transaction: {
+      nonce: 100,
+      gasPrice: { _bn: '4a817c800' },
+      gasLimit: { _bn: '2625a0' },
+      to: '0x76D508Fa65654654Ffdb334a3023353587112e09',
+      value: { _bn: 0 },
+      data: '0x...',
+      v: 38,
+      r: '0xd7d6078c30635e86ca025f382c04592556b0ab77e78abcd04bc3c95c55260698',
+      s: '0x4656efd201b0032c0b7eb5feb9952927e9914aed0bbfe335d71c3af4fd7a08c1',
+      chainId: 1,
+      from: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+      hash: '0x7c1f5b4481fc17f44cb3a42ce09d4fe05202719e411df8c6e7af455a79bbcca4',
+    },
+  }
+}
+
+```
+
+With `waitForMining` set to `false`:
+
+```js
+
+{
+  // Resolves to the `successful` value above
+  successfulPromise: Promise,
+
+  // Resolves to the `eventData` value above
+  eventDataPromise: Promise,
+
+  meta: {
+    // Resolves to the `receipt` value above
+    receiptPromise: Promise,
+
+    // The same as the `transaction` value above
+    transaction: {
+      nonce: 101,
+      gasPrice: {
+        _bn: '4a817c800',
+      },
+      gasLimit: {
+        _bn: '2625a0',
+      },
+      to: '0x76D508Fa65654654Ffdb334a3023353587112e09',
+      value: {
+        _bn: 0,
+      },
+      data: '0x...',
+      v: 37,
+      r: '0x5043a8f99914e6a24e768b367f6286bbf98539fe0fa67ce4d8f19dba7194067f',
+      s: '0x783e96b415e4684c6b96041273c37e847eb9dad0a41a4f4fa468da07139d6a3a',
+      chainId: 1,
+      from: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+      hash: '0x952ed7494e8867c9bbc8cf1c6bf9946df1a5ba691596835096e8795248a5db51',
+    },
+  },
+}
+
+```

--- a/docs/_API_ContractClient.md
+++ b/docs/_API_ContractClient.md
@@ -6,358 +6,109 @@ order: 0
 
 `ContractClient` is a superclass for all implementations of [clients](/colonyjs/components-clients/). Each client contains abstractions such as `Caller`, `Sender`, and `MulitisigSender` which are inherited from the `ContractClient` superclass. The `ContractClient` superclass also contains tools for listening to events and interacting with the reputation mining system.
 
+## Table of Contents
+
 ==TOC==
 
-## Callers
+## Caller
 
-Callers passively interacts with objects on the blockchain and do not produce transactions. They are associated with a single contract method. Callers will usually expect certain parameters and return a promise that resolves to an object.
+The `Caller` class passively interacts with the blockchain and does not produce transactions. Each `Caller` method is associated with a single contract method. `Caller` methods may require certain input parameters and they always return a promise.
 
 ### `call(input)`
 
-The `call` method performs the associated call method on the contract and returns the output values.
+Given the input parameters for the named method, the `call` method performs the associated contract method and returns a promise that resolves to an object containing its return values.
 
-#### Input Values
+**Input**
 
-`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+`{ [string]: any }` - An object containing the key value pairs of the input parameters.
 
-#### Output Values
+**Response**
 
-`Promise<{ [string]: any }>` - A promise that resolves to an object containing the key value pairs of the output.
+`Promise<{ [string]: any }>` - A promise that resolves to an object containing the key value pairs of the return values.
 
-#### Example
+## Sender
 
-Callers usually accept an object of named parameters (e.g. `taskId`) and return an object with named values (e.g. `dueDate`).
-
-```js
-
-const task = await colonyClient.getTask.call({ taskId: 1 });
-
-// -> {
-//      cancelled: false,
-//      deliverableDate: Date(...),
-//      deliverableHash: '0x...',
-//      domainId: 1,
-//      dueDate: Date(...),
-//      finalized: false,
-//      id: 1,
-//      skillId: 4,
-//      specificationHash: '0x...',
-//    }
-
-```
-
-Some callers do not accept an object of named parameters.
-
-```js
-
-const tasks = await colonyClient.getTaskCount.call();
-
-// -> { count: 201 }
-
-```
-
-## Senders
-
-Senders are used to create blockchain transactions. Like callers, they associated with a single contract method. A sender can either be used to call `send()`, which will parse a transaction and execute it on the underlying contract, or `estimate()`, which will simply return an estimate of the transaction gas cost.
-
+The `Sender` class is used to estimate and create blockchain transactions. Each `Sender` method is associated with a single contract method. `Sender` methods may require certain input parameters and they always return a promise.
 
 ### `estimate(input)`
 
-The `estimate` method will estimate the Gas cost of the transaction for the associated smart contract method.
+Given the input parameters for the named method, the `estimate` method performs an estimation of the gas cost to perform the associated smart contract method and returns a promise that resolves to a `BigNumber` object containing the estimate.
 
-#### Input Values
+**Input**
 
-`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+`{ [string]: any }` - An object containing the key value pairs of the input parameters.
 
-#### Output Values
+**Response**
 
-`Promise<BigNumber>` - A promise that resolves to a `BigNumber` object which represents the estimated gas cost.
-
-#### Example
-
-```js
-
-const estimate = await networkClient.createColony.estimate({
-  tokenAddress: '0x...',
-});
-
-// -> BigNumber(2501852)
-
-```
+`Promise<BigNumber>` - A promise that resolves to a `BigNumber` object containing the estimated gas cost.
 
 ### `send(input, options)`
 
-The `send` method signs and sends off a transaction for the associated contract method. It returns a `ContractResponse` object which contains the transaction metadata as well as event data (if applicable).
+Given the input parameters for the named method, the `send` method sends a transaction for the associated contract method and returns a promise that resolves to a `ContractResponse` object containing the transaction metadata and, if applicable, the event data for any events emitted when the transaction was mined.
 
-#### Input Values
+**Input**
 
-**input**
+`{ [string]: any }` - An object containing the key value pairs of the input parameters.
 
-`{ [string]: any }` - An object containing the key value pairs of the required input parameters.
+**Options**
 
-**options**
-
-|Option|Type|Description|
+|Name|Type|Description|
 |---|---|---|
-|timeoutMs|number|Milliseconds to wait until this transaction will time out|
-|waitForMining|boolean|If true, it will wait for the transaction to be mined before resolving the resulting promise (default: true)|
-|gasLimit|BigNumber|Sets the maximum gas limit for the transaction
-|gasPrice|BigNumber|The price in wei per gas unit
-|nonce|number|The transaction nonce
-|value|BigNumber|The amount in wei that the transaction will send
+|timeoutMs|number|The number of milliseconds to wait until this transaction will time out.|
+|waitForMining|boolean|A boolean indicating whether or not to wait for the transaction to be mined before resolving the resulting promise. The default value is `true`.|
+|gasLimit|BigNumber|The maximum gas limit for the transaction.|
+|gasPrice|BigNumber|The price in wei per gas unit.|
+|nonce|number|The transaction nonce.|
+|value|BigNumber|The amount of ETH in wei that the transaction will send.|
 
-#### Output Values
+**Response**
 
-`Promise<ContractResponse>` - With [ContractResponse](#contractresponse) being an object with the following properties:
+`Promise<ContractResponse>` - A promise that resolves to a `ContractResponse` object. The properties of the `ContractResponse` object vary based on whether the `waitForMining` option is set to `true` (the default setting) or `false`.
 
-with `waitForMining` set to `true`:
+With `waitForMining` set to `true`:
 
-|Property|Type|Description|
+|Name|Type|Description|
 |---|---|---|
-|successful|boolean|Indicates whether the transaction was executed successfully|
-|eventData|Object|Contains eventData emitted by the smart contract (see docs of the particular contract client)|
-|meta|Object|Contains the `transaction` and a `receipt` object passed on by the used ethereum adapter|
-
-with `waitForMining` set to `false`:
-
-|Property|Type|Description|
-|---|---|---|
-|successfulPromise|Promise<boolean>|Just like above but will only be resolved when mined|
-|eventDataPromise|Object|Just like above but will only be resolved when event data is emitted|
-|meta|Object|Just like above execpt the `receipt` is `receiptPromise` and will be resolved when mined|
-
-#### Example
-
-```js
-
-const response = await networkClient.createColony.send({
-  tokenAddress: '0x...',
-});
-
-// -> {
-//      successful: true,
-//      eventData: { colonyId: 21, colonyAddress: '0x...' },
-//      meta: {
-//        receipt: { /* ...receipt properties  */ },
-//        transaction: { /* ...transaction properties  */ },
-//      },
-//    }
-
-```
-
-The `send` method also accepts `options` as an optional second parameter.
-
-```js
-
-await networkClient.createColony.send({
-  tokenAddress: '0x...',
-}, {
-  gasLimit: 400000,
-  timeoutMs: 1000 * 60 * 2,
-  waitForMining: true,
-});
-
-// -> {
-//      successful: true,
-//      eventData: { colonyId: 21, colonyAddress: '0x...' },
-//      meta: {
-//        receipt: { /* ...receipt properties  */ },
-//        transaction: { /* ...transaction properties  */ },
-//      },
-//    }
-
-```
-
-## MultisigSender
-
-The `MutlisigSender` class is a used to create multisignature transactions. They are associated with a method on the smart contract which requires more than one signature to be executed. For more information see [Using Multisignature](/colonyjs/topics-usingmultisignature/).
-
-### `startOperation(input)`
-
-Given named input values, it will generate the `MultisigOperation` needed to gather all signatures to send off this transaction.
-
-#### Input Values
-
-**`input`** `{ [string]: any }` - Any key value pair of contract input parameters
-
-#### Output Values
-
-`Promise<MultisigOperation>` - Promise that resolves to a `MultisigOperation` instance.
-
-### `restoreOperation(json)`
-
-Given a serialized operation object as a valid json string, it restores the given operation.
-
-#### Input Values
-
-**`json`** `string` - A serialized operation created via a MultisigOperation instance's .toJSON() method
-
-#### Output Values
-
-`Promise<MultisigOperation>` - Promise that resolves to a `MultisigOperation` instance.
-
-## MultisigOperation
-
-The `MultisigOperation` class is a part of the `ContractClient` to handle Multisignature transactions. They are usually created by a `MultisigSender` class and are associated with the sender which created them.
-
-### `requiredSignees`
-
-`[Address]` - Array of all addresses which are needed to sign off this transaction.
-
-### `missingSignees`
-
-`[Address]` - Array of all addresses which are still missing to sign off this transaction.
-
-### `sign()`
-
-Sign the message hash with the current wallet or provider and add the signature. This method is asynchronous.
-
-#### Output Values
-
-The `MultisigOperation` instance.
-
-### `refresh()`
-
-Refresh the nonce value, required signees, and message hash. This method is asyncrhonous.
-
-If there was no nonce value, a new one will be set; otherwise, if the nonce value changed, the it will be updated, and the `_signers` will be reset. This is done because when the nonce values changes, the signatures that were collected will not work, and the operation will need to be re-signed by all parties.
-
-#### Output Values
-
-The `MultisigOperation` instance.
-
-### `addSignersFromJSON(json)`
-
-Given the state of an operation as JSON, validate the parsed state and add in the signers.
-
-#### Input Values
-
-**`json`** `string` - A serialized `MultisigOperation`.
-
-#### Output Values
-
-The `MultisigOperation` instance with the added signature(s).
-
-### `toJSON()`
-
-Serializes this operation.
-
-#### Output Values
-
-`string` - The serialized `MultisigOperation`
-
-### `send(input, options)`
-
-Given named input values it sends off the MultisigOperation to the contract. Has the same API and return values as [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options).
-
-#### Input Values
-
-**`input`** `{ [string]: any }` - Any key value pair of contract input parameters
-
-**`options`** `SendOptions` - Custom options to use for this transaction. See [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options)
-
-#### Output Values
-
-`Promise<ContractResponse>` - See [`ContractMethodSender.send()`](/colonyjs/api-contractmethodsender/#sendinputvalues-options)
-
-## ContractResponse
-
-A `ContractResponse` is an object with properties that vary based on the `waitForMining` option.
-
-With `waitForMining` set to `true` (the default behavior):
-
-```js
-
-{
-  // Boolean flag for whether the transaction was executed successfully or not
-  successful: true,
-
-  // Contains all of the data from events logged when the transaction
-  // was executed.
-  eventData: {
-    colonyId: 2,
-    colonyAddress: '0xe2D17cA03387f6DaFbA77FaA3De5F6cf41E371Fe',
-    ColonyAdded: {
-        colonyId: 2,
-        colonyAddress: '0xe2D17cA03387f6DaFbA77FaA3De5F6cf41E371Fe',
-    },
-  },
-
-  // Metadata for the transaction
-  meta: {
-
-    // The transaction receipt (received from the Adapter)
-    receipt: {
-      contractAddress: null,
-      transactionIndex: 0,
-      gasUsed: { _bn: '1f29f3' },
-      logsBloom: '0x...',
-      blockHash: '0x6e6eaac9f367c646278f313a48e02fba59c2e1ca9ccf9d96281e3ebd9614b0a2',
-      transactionHash: '0x7c1f5b4481fc17f44cb3a42ce09d4fe05202719e411df8c6e7af455a79bbcca4',
-      logs: [ /* series of logs */ ],
-      blockNumber: 101,
-      cumulativeGasUsed: { _bn: '1f29f3' },
-      status: 1,
-      byzantium: true,
-    },
-
-    // The transaction that was sent (received from the Adapter)
-    transaction: {
-      nonce: 100,
-      gasPrice: { _bn: '4a817c800' },
-      gasLimit: { _bn: '2625a0' },
-      to: '0x76D508Fa65654654Ffdb334a3023353587112e09',
-      value: { _bn: 0 },
-      data: '0x...',
-      v: 38,
-      r: '0xd7d6078c30635e86ca025f382c04592556b0ab77e78abcd04bc3c95c55260698',
-      s: '0x4656efd201b0032c0b7eb5feb9952927e9914aed0bbfe335d71c3af4fd7a08c1',
-      chainId: 1,
-      from: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-      hash: '0x7c1f5b4481fc17f44cb3a42ce09d4fe05202719e411df8c6e7af455a79bbcca4',
-    },
-  }
-}
-
-```
+|successful|boolean|A boolean indicating whether or not the transaction was executed successfully.|
+|eventData|Object|The event data emitted by the smart contract.|
+|meta|Object|An object containing the `transaction` and a `receipt` object.|
 
 With `waitForMining` set to `false`:
 
-```js
+|Name|Type|Description|
+|---|---|---|
+|successfulPromise|Promise<boolean>|A promise that will resolve to a boolean that will indicate whether or not the transaction was executed successfully. The promise will be resolved when the transaction is mined.|
+|eventDataPromise|Object|A promise that will resolve to event data that will be emitted by the smart contract. The promise will be resolved when the transaction is mined.|
+|meta|Object|An object containing the `transaction` and a `receiptPromise`. The promise will be resolved when the transaction is mined.|
 
-{
-  // Resolves to the `successful` value above
-  successfulPromise: Promise,
+## MultisigSender
 
-  // Resolves to the `eventData` value above
-  eventDataPromise: Promise,
+The `MutlisigSender` class is a used to start and restore instances of `MultisigOperation`. Each `MutlisigSender` method is associated with a single contract method which requires more than one signature to be executed.
 
-  meta: {
-    // Resolves to the `receipt` value above
-    receiptPromise: Promise,
+### `startOperation(input)`
 
-    // The same as the `transaction` value above
-    transaction: {
-      nonce: 101,
-      gasPrice: {
-        _bn: '4a817c800',
-      },
-      gasLimit: {
-        _bn: '2625a0',
-      },
-      to: '0x76D508Fa65654654Ffdb334a3023353587112e09',
-      value: {
-        _bn: 0,
-      },
-      data: '0x...',
-      v: 37,
-      r: '0x5043a8f99914e6a24e768b367f6286bbf98539fe0fa67ce4d8f19dba7194067f',
-      s: '0x783e96b415e4684c6b96041273c37e847eb9dad0a41a4f4fa468da07139d6a3a',
-      chainId: 1,
-      from: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-      hash: '0x952ed7494e8867c9bbc8cf1c6bf9946df1a5ba691596835096e8795248a5db51',
-    },
-  },
-}
+Given the input parameters for the named method, the `startOperation` method generates a `MultisigOperation` instance.
 
-```
+**Input**
+
+`{ [string]: any }` - An object containing the key value pairs of the input parameters.
+
+**Response**
+
+`Promise<MultisigOperation>` - A promise that resolves to a `MultisigOperation` instance.
+
+See [MultisigOperation](/api-multisigoperation/) for more information and [Using Multisignature](/topics-using-multisignature/) for examples.
+
+### `restoreOperation(input)`
+
+Given a `MultisigOperation` in JSON format, the `restoreOperation` method restores a `MultisigOperation` instance.
+
+**Input**
+
+`string` - A `MultisigOperation` serialized into JSON format.
+
+**Response**
+
+`Promise<MultisigOperation>` - A promise that resolves to a `MultisigOperation` instance.
+
+See [MultisigOperation](/api-multisigoperation/) for more information and [Using Multisignature](/topics-using-multisignature/) for examples.

--- a/docs/_API_ContractClient.md
+++ b/docs/_API_ContractClient.md
@@ -4,7 +4,7 @@ section: API
 order: 0
 ---
 
-`ContractClient` is a superclass for all implementations of [clients](/colonyjs/components-clients/). Each client contains abstractions such as `Caller`, `Sender`, and `MulitisigSender` which are inherited from the `ContractClient` superclass. The `ContractClient` superclass also contains tools for listening to events and interacting with the reputation mining system.
+`ContractClient` is a superclass for all implementations of [Clients](/colonyjs/components-clients/). Each client contains abstractions such as `Caller`, `Sender`, and `MulitisigSender` which are inherited from the `ContractClient` superclass. The `ContractClient` superclass also contains tools for listening to events and interacting with the reputation mining system.
 
 ## Table of Contents
 

--- a/docs/_API_MultisigOperation.md
+++ b/docs/_API_MultisigOperation.md
@@ -66,4 +66,4 @@ Serialize the `MultisigOperation` into JSON format.
 
 This method is the same method used in the `ContractClient` superclass.
 
-See [Sender](colonyjs/api-contractclient/#sendinput-options) for more information about the input, options, and response.
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about the input, options, and response.

--- a/docs/_API_MultisigOperation.md
+++ b/docs/_API_MultisigOperation.md
@@ -1,0 +1,69 @@
+---
+title: MultisigOperation
+section: API
+order: 6
+---
+
+`MultisigOperation` is a special class associated with the [ContractClient](/colonyjs/api-contractclient) superclass. `MultisigOperation` is used to handle multisignature transactions. An instance of the `MultisigOperation` class can be created and restored using `MultisigSender` and each instance is associated with a single contract method.
+
+For more information about creating and restoring an instance of `MultisigOperation` see [MultisigSender](/colonyjs/api-contractclient/#multisigsender).
+
+## Table of Contents
+
+==TOC==
+
+## Properties
+
+### `requiredSignees`
+
+`[Address]` - Array of all addresses which are needed to sign off this transaction.
+
+### `missingSignees`
+
+`[Address]` - Array of all addresses which are still missing to sign off this transaction.
+
+## Instance Methods
+
+### `sign()`
+
+Sign the message hash with the current wallet or provider and add the signature.
+
+**Response**
+
+`Promise<MultisigOperation>` - A promise that resolves to the updated `MultisigOperation` instance.
+
+### `refresh()`
+
+Refresh the nonce value, required signees, and message hash.
+
+If there was no nonce value, a new nonce value will be set. If the nonce value changed, the nonce value will be updated and the signers will be reset. The signers are reset is because the signatures that were collected will no longer be valid once the nonce value has changed, therefore, the `MultisigOperation` will need to be signed again by all required signees.
+
+**Response**
+
+`Promise<MultisigOperation>` - A promise that resolves to the updated `MultisigOperation` instance.
+
+### `addSignersFromJSON(input)`
+
+Given the `MultisigOperation` serialized into JSON format, validate the parsed state and add in the signers.
+
+**Input**
+
+`string` - The `MultisigOperation` serialized into JSON format.
+
+**Response**
+
+`Promise<MultisigOperation>` - A promise that resolves to the updated `MultisigOperation` instance.
+
+### `toJSON()`
+
+Serialize the `MultisigOperation` into JSON format.
+
+**Response**
+
+`string` - The `MultisigOperation` serialized into JSON format.
+
+### `send(input, options)`
+
+This method is the same method used in the `ContractClient` superclass.
+
+See [Sender](colonyjs/api-contractclient/#sendinput-options) for more information about the input, options, and response.

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -17,7 +17,7 @@ See [ContractClient](/colonyjs/api-contractclient) for more information about th
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.**.
+**All callers return promises which resolve to an object containing the given return values.**
 
 ### `getAllowance.call({ sourceAddress, user })`
 
@@ -148,7 +148,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |owner|address|The address that approved the allowance (the token `owner`).|
 |spender|address|The address that was approved for the allowance (the token `spender`).|
 |value|big number|The amount of tokens that were approved (the amount `allowed`).|
-|Approval|object|Contains the data defined in [Approval](#eventsapprovaladdlistener-owner-spender-value-------)|
+|Approval|object|Contains the data defined in [Approval](#eventsapproval)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -182,7 +184,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address from which the tokens were burned.|
 |amount|big number|The amount of tokens that were burned.|
-|Burn|object|Contains the data defined in [Burn](#eventsburnaddlistener-address-amount-------)|
+|Burn|object|Contains the data defined in [Burn](#eventsburn)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -216,7 +220,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address to which the minted tokens were sent.|
 |amount|big number|The amount of tokens that were minted.|
-|Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
+|Mint|object|Contains the data defined in [Mint](#eventsmint)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -248,7 +254,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |authority|address|The address that was assigned an authority role.|
-|LogSetAuthority|object|Contains the data defined in [LogSetAuthority](#eventslogsetauthorityaddlistener-authority-------)|
+|LogSetAuthority|object|Contains the data defined in [LogSetAuthority](#eventslogsetauthority)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -275,9 +283,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -309,7 +319,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |owner|address|The address that was assigned as the new owner.|
-|LogSetOwner|object|Contains the data defined in [LogSetOwner](#eventslogsetowneraddlistener-owner-------)|
+|LogSetOwner|object|Contains the data defined in [LogSetOwner](#eventslogsetowner)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -337,9 +349,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -375,7 +389,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
-|Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
+|Transfer|object|Contains the data defined in [Transfer](#eventstransfer)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -8,6 +8,10 @@ The `TokenClient` is a standard interface for interactions with methods and even
 
 See [Clients](/colonyjs/components-clients) for information about initializing `TokenClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==
 
   
@@ -19,22 +23,22 @@ See [Clients](/colonyjs/components-clients) for information about initializing `
 
 Get the token allowance of an address. The allowance is the amount of tokens that the `spender` is authorized to transfer using the `transferFrom` function.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |sourceAddress|address|The address that approved the allowance (the token `owner`).|
 |user|address|The address that was approved for the allowance (the token `spender`).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The amount of tokens that were approved (the amount `allowed`).|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `allowance`
@@ -47,21 +51,21 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Get the the token balance of an address.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |sourceAddress|address|The address that will be checked.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The balance of tokens for the address.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `balanceOf`
@@ -75,17 +79,17 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 Get information about the token.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |name|string|The name of the token.|
 |symbol|string|The symbol of the token.|
 |decimals|number|The number of decimals.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -99,15 +103,15 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 Get the total supply of the token.
 
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |amount|big number|The total supply of the token.|
 
-#### Contract Information
+**Contract Information**
 
 
   Function: `totalSupply`
@@ -124,25 +128,25 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Approve a token allowance. This function can only be called by the token `owner`. The allowance is the amount of tokens that the `spender` is authorized to transfer using the `transferFrom` function.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be approved for the allowance (the token `spender`).|
 |amount|big number|The amount of tokens that will be approved (the amount `allowed`).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |owner|address|The address that approved the allowance (the token `owner`).|
 |spender|address|The address that was approved for the allowance (the token `spender`).|
 |value|big number|The amount of tokens that were approved (the amount `allowed`).|
 |Approval|object|Contains the data defined in [Approval](#eventsapprovaladdlistener-owner-spender-value-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -155,24 +159,24 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Burn tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address from which the tokens will be burned.|
 |amount|big number|The amount of tokens that will be burned.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address from which the tokens were burned.|
 |amount|big number|The amount of tokens that were burned.|
 |Burn|object|Contains the data defined in [Burn](#eventsburnaddlistener-address-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -185,24 +189,24 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Mint new tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |user|address|The address that will receive the minted tokens.|
 |amount|big number|The amount of tokens that will be minted.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address to which the minted tokens were sent.|
 |amount|big number|The amount of tokens that were minted.|
 |Mint|object|Contains the data defined in [Mint](#eventsmintaddlistener-address-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -215,22 +219,22 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Assign an account the `ADMIN` authority role within a colony.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |authority|address|The address that will be assigned the `ADMIN` authority role.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |authority|address|The address that was assigned an authority role.|
 |LogSetAuthority|object|Contains the data defined in [LogSetAuthority](#eventslogsetauthorityaddlistener-authority-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -243,19 +247,19 @@ Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5
 
 Set the `name` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |name|string|The name of the token that will be set.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -268,22 +272,22 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/tree/de9114c
 
 Set the `owner` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |owner|address|The address that will be assigned as the new owner.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |owner|address|The address that was assigned as the new owner.|
 |LogSetOwner|object|Contains the data defined in [LogSetOwner](#eventslogsetowneraddlistener-owner-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -296,20 +300,20 @@ Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5
 
 Transfer tokens from the address calling the function to another address. The current address must have a sufficient token balance.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |destinationAddress|address|The address to which tokens will be transferred.|
 |amount|big number|The amount of tokens that will be transferred.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -322,26 +326,26 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Transfer tokens from one address to another address. The address the tokens are transferred from must have a sufficient token balance and it must have a sufficient token allowance approved by the token owner.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |sourceAddress|address|The address from which tokens will be transferred.|
 |destinationAddress|address|The address to which tokens will be transferred.|
 |amount|big number|The amount of tokens that will be transferred.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
 |Transfer|object|Contains the data defined in [Transfer](#eventstransferaddlistener-from-to-value-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -359,9 +363,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |owner|address|The address that approved the allowance (the token `owner`).|
 |spender|address|The address that was approved for the allowance (the token `spender`).|
@@ -372,9 +376,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address from which the tokens were burned.|
 |amount|big number|The amount of tokens that were burned.|
@@ -384,9 +388,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |authority|address|The address that was assigned an authority role.|
 
@@ -395,9 +399,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |owner|address|The address that was assigned as the new owner.|
 
@@ -406,9 +410,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |address|address|The address to which the minted tokens were sent.|
 |amount|big number|The amount of tokens that were minted.|
@@ -418,9 +422,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract.|
 |lockCount|number|The total lock count for the token.|
@@ -430,9 +434,9 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -6,9 +6,9 @@ order: 3
 
 The `TokenClient` is a standard interface for interactions with methods and events described in `Token.sol`. These interactions are extended from the ERC20 and DSToken standard token interfaces and are generally concerned with managing the native token assigned to a colony. This includes operations such as minting tokens, burning tokens, and transferring tokens.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `TokenClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `TokenClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ See [ContractClient](/colonyjs/api-contractclient) for information about the `Co
 
 Get the token allowance of an address. The allowance is the amount of tokens that the `spender` is authorized to transfer using the `transferFrom` function.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -51,7 +51,7 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Get the the token balance of an address.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -128,12 +128,16 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Approve a token allowance. This function can only be called by the token `owner`. The allowance is the amount of tokens that the `spender` is authorized to transfer using the `transferFrom` function.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will be approved for the allowance (the token `spender`).|
 |amount|big number|The amount of tokens that will be approved (the amount `allowed`).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -159,12 +163,16 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Burn tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address from which the tokens will be burned.|
 |amount|big number|The amount of tokens that will be burned.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -189,12 +197,16 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Mint new tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |user|address|The address that will receive the minted tokens.|
 |amount|big number|The amount of tokens that will be minted.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -219,11 +231,15 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Assign an account the `ADMIN` authority role within a colony.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |authority|address|The address that will be assigned the `ADMIN` authority role.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -247,11 +263,15 @@ Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5
 
 Set the `name` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |name|string|The name of the token that will be set.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -272,11 +292,15 @@ Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/tree/de9114c
 
 Set the `owner` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |owner|address|The address that will be assigned as the new owner.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -300,12 +324,16 @@ Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5
 
 Transfer tokens from the address calling the function to another address. The current address must have a sufficient token balance.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |destinationAddress|address|The address to which tokens will be transferred.|
 |amount|big number|The amount of tokens that will be transferred.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -326,13 +354,17 @@ Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c
 
 Transfer tokens from one address to another address. The address the tokens are transferred from must have a sufficient token balance and it must have a sufficient token allowance approved by the token owner.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |sourceAddress|address|The address from which tokens will be transferred.|
 |destinationAddress|address|The address to which tokens will be transferred.|
 |amount|big number|The amount of tokens that will be transferred.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -363,7 +395,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -376,7 +408,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -388,7 +420,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -399,7 +431,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -410,7 +442,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -422,7 +454,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -434,7 +466,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -8,7 +8,7 @@ The `TokenClient` is a standard interface for interactions with methods and even
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `TokenClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 
@@ -391,11 +391,18 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 ## Events
 
 
-### `events.Approval.addListener(({ owner, spender, value }) => { /* ... */ })`
+### `events.Approval`
+
+**Methods**
+
+`.addListener(({ owner, spender, value }) => { /* ... */ })`
+
+`.removeListener(({ owner, spender, value }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -404,11 +411,18 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 |value|big number|The amount of tokens that were approved (the amount `allowed`).|
 
 
-### `events.Burn.addListener(({ address, amount }) => { /* ... */ })`
+### `events.Burn`
+
+**Methods**
+
+`.addListener(({ address, amount }) => { /* ... */ })`
+
+`.removeListener(({ address, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -416,33 +430,54 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 |amount|big number|The amount of tokens that were burned.|
 
 
-### `events.LogSetAuthority.addListener(({ authority }) => { /* ... */ })`
+### `events.LogSetAuthority`
+
+**Methods**
+
+`.addListener(({ authority }) => { /* ... */ })`
+
+`.removeListener(({ authority }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |authority|address|The address that was assigned an authority role.|
 
 
-### `events.LogSetOwner.addListener(({ owner }) => { /* ... */ })`
+### `events.LogSetOwner`
+
+**Methods**
+
+`.addListener(({ owner }) => { /* ... */ })`
+
+`.removeListener(({ owner }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
 |owner|address|The address that was assigned as the new owner.|
 
 
-### `events.Mint.addListener(({ address, amount }) => { /* ... */ })`
+### `events.Mint`
+
+**Methods**
+
+`.addListener(({ address, amount }) => { /* ... */ })`
+
+`.removeListener(({ address, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -450,11 +485,18 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 |amount|big number|The amount of tokens that were minted.|
 
 
-### `events.TokenLocked.addListener(({ token, lockCount }) => { /* ... */ })`
+### `events.TokenLocked`
+
+**Methods**
+
+`.addListener(({ token, lockCount }) => { /* ... */ })`
+
+`.removeListener(({ token, lockCount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -462,11 +504,18 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7359eedaada
 |lockCount|number|The total lock count for the token.|
 
 
-### `events.Transfer.addListener(({ from, to, value }) => { /* ... */ })`
+### `events.Transfer`
+
+**Methods**
+
+`.addListener(({ from, to, value }) => { /* ... */ })`
+
+`.removeListener(({ from, to, value }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_TokenLockingClient.md
+++ b/docs/_API_TokenLockingClient.md
@@ -8,6 +8,10 @@ The `TokenLockingClient` is a standard interface for interactions with methods a
 
 See [Clients](/colonyjs/components-clients) for information about initializing `TokenLockingClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==
 
   
@@ -19,21 +23,21 @@ See [Clients](/colonyjs/components-clients) for information about initializing `
 
 Get the total number of locked tokens.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|number|The total number of locked tokens in the colony.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -47,22 +51,22 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Get the total number of locked tokens for a given user.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |user|address|The address of the user.|
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
-|Return Value|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |count|big number|The total number of locked tokens.|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -80,18 +84,18 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Deposit tokens. This function only be called if the tokens that the user is attempting to deposit are not locked and if the user has allowed the token locking contract to transfer the tokens.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract receiving the deposit.|
 |user|address|The address of the user that deposited tokens.|
@@ -99,7 +103,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |timestamp|date|The timestamp when the tokens were deposited.|
 |UserTokenDeposited|object|Contains the data defined in [UserTokenDeposited](#eventsusertokendepositedaddlistener-token-user-amount-timestamp-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -113,23 +117,23 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Lock all tokens for a given token contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract that was locked.|
 |lockCount|big number|The address of the token contract that was assigned.|
 |TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlockedaddlistener-token-lockcount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -143,20 +147,20 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Increment the token lock counter. This method allows users to waive reward payouts for past reward payout cycles, unlocking the tokens that were locked in previous reward payout cycles.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |lockId|number|The ID of the lock count that will be set.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse`
 
 
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -170,26 +174,26 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Unlock all tokens for a user on a given token contract.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |user|address|The address of the user.|
 |lockId|number|The ID of the lock count that will be set.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract that was unlocked.|
 |user|address|The address of the user that the tokens were unlocked for.|
 |lockId|number|The ID of the lock that the was set for the user.|
 |UserTokenUnlocked|object|Contains the data defined in [UserTokenUnlocked](#eventsusertokenunlockedaddlistener-token-user-lockid-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -203,25 +207,25 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Withdraw tokens. This function only be called if the tokens that the user is attempting to withdraw are not locked.
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
 
-#### Response
+**Response**
 
 An instance of a `ContractResponse` which will eventually receive the following event data:
 
-|Event Data|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract from which tokens were withdrawn.|
 |user|address|The address of the user that withdrew tokens.|
 |amount|big number|The amount of tokens that were withdrawn.|
 |UserTokenWithdrawn|object|Contains the data defined in [UserTokenWithdrawn](#eventsusertokenwithdrawnaddlistener-token-user-amount-------)|
 
-#### Contract Information
+**Contract Information**
 
 
   
@@ -240,9 +244,9 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract that was locked.|
 |lockCount|big number|The address of the token contract that was assigned.|
@@ -252,9 +256,9 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract receiving the deposit.|
 |user|address|The address of the user that deposited tokens.|
@@ -266,9 +270,9 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract that was unlocked.|
 |user|address|The address of the user that the tokens were unlocked for.|
@@ -279,9 +283,9 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-#### Arguments
+**Arguments**
 
-|Argument|Type|Description|
+|Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract from which tokens were withdrawn.|
 |user|address|The address of the user that withdrew tokens.|

--- a/docs/_API_TokenLockingClient.md
+++ b/docs/_API_TokenLockingClient.md
@@ -17,7 +17,7 @@ See [ContractClient](/colonyjs/api-contractclient) for more information about th
   
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.**.
+**All callers return promises which resolve to an object containing the given return values.**
 
 ### `getTotalLockCount.call({ token })`
 
@@ -105,7 +105,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |user|address|The address of the user that deposited tokens.|
 |amount|big number|The amount of tokens that were deposited.|
 |timestamp|date|The timestamp when the tokens were deposited.|
-|UserTokenDeposited|object|Contains the data defined in [UserTokenDeposited](#eventsusertokendepositedaddlistener-token-user-amount-timestamp-------)|
+|UserTokenDeposited|object|Contains the data defined in [UserTokenDeposited](#eventsusertokendeposited)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -139,7 +141,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |token|address|The address of the token contract that was locked.|
 |lockCount|big number|The address of the token contract that was assigned.|
-|TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlockedaddlistener-token-lockcount-------)|
+|TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlocked)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -168,9 +172,11 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 **Response**
 
-An instance of a `ContractResponse`
+An instance of a `ContractResponse`.
 
 
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -207,7 +213,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|address|The address of the token contract that was unlocked.|
 |user|address|The address of the user that the tokens were unlocked for.|
 |lockId|number|The ID of the lock that the was set for the user.|
-|UserTokenUnlocked|object|Contains the data defined in [UserTokenUnlocked](#eventsusertokenunlockedaddlistener-token-user-lockid-------)|
+|UserTokenUnlocked|object|Contains the data defined in [UserTokenUnlocked](#eventsusertokenunlocked)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 
@@ -243,7 +251,9 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |token|address|The address of the token contract from which tokens were withdrawn.|
 |user|address|The address of the user that withdrew tokens.|
 |amount|big number|The amount of tokens that were withdrawn.|
-|UserTokenWithdrawn|object|Contains the data defined in [UserTokenWithdrawn](#eventsusertokenwithdrawnaddlistener-token-user-amount-------)|
+|UserTokenWithdrawn|object|Contains the data defined in [UserTokenWithdrawn](#eventsusertokenwithdrawn)|
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
 
 **Contract Information**
 

--- a/docs/_API_TokenLockingClient.md
+++ b/docs/_API_TokenLockingClient.md
@@ -8,7 +8,7 @@ The `TokenLockingClient` is a standard interface for interactions with methods a
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `TokenLockingClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 
@@ -260,11 +260,18 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 ## Events
 
 
-### `events.TokenLocked.addListener(({ token, lockCount }) => { /* ... */ })`
+### `events.TokenLocked`
+
+**Methods**
+
+`.addListener(({ token, lockCount }) => { /* ... */ })`
+
+`.removeListener(({ token, lockCount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -272,11 +279,18 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 |lockCount|big number|The address of the token contract that was assigned.|
 
 
-### `events.UserTokenDeposited.addListener(({ token, user, amount, timestamp }) => { /* ... */ })`
+### `events.UserTokenDeposited`
+
+**Methods**
+
+`.addListener(({ token, user, amount, timestamp }) => { /* ... */ })`
+
+`.removeListener(({ token, user, amount, timestamp }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -286,11 +300,18 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 |timestamp|date|The timestamp when the tokens were deposited.|
 
 
-### `events.UserTokenUnlocked.addListener(({ token, user, lockId }) => { /* ... */ })`
+### `events.UserTokenUnlocked`
+
+**Methods**
+
+`.addListener(({ token, user, lockId }) => { /* ... */ })`
+
+`.removeListener(({ token, user, lockId }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|
@@ -299,11 +320,18 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 |lockId|number|The ID of the lock that the was set for the user.|
 
 
-### `events.UserTokenWithdrawn.addListener(({ token, user, amount }) => { /* ... */ })`
+### `events.UserTokenWithdrawn`
+
+**Methods**
+
+`.addListener(({ token, user, amount }) => { /* ... */ })`
+
+`.removeListener(({ token, user, amount }) => { /* ... */ })`
 
 
 
-**Input**
+
+**Event Data**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_API_TokenLockingClient.md
+++ b/docs/_API_TokenLockingClient.md
@@ -6,9 +6,9 @@ order: 4
 
 The `TokenLockingClient` is a standard interface for interactions with methods and events described in `ITokenLocking.sol`. These interactions are generally concerned token locking, such as locking and unlocking tokens.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `TokenLockingClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `TokenLockingClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ See [ContractClient](/colonyjs/api-contractclient) for information about the `Co
 
 Get the total number of locked tokens.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -51,7 +51,7 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Get the total number of locked tokens for a given user.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -84,12 +84,16 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Deposit tokens. This function only be called if the tokens that the user is attempting to deposit are not locked and if the user has allowed the token locking contract to transfer the tokens.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -117,11 +121,15 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Lock all tokens for a given token contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -147,12 +155,16 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Increment the token lock counter. This method allows users to waive reward payouts for past reward payout cycles, unlocking the tokens that were locked in previous reward payout cycles.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |lockId|number|The ID of the lock count that will be set.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -174,13 +186,17 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Unlock all tokens for a user on a given token contract.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |user|address|The address of the user.|
 |lockId|number|The ID of the lock count that will be set.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -207,12 +223,16 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 Withdraw tokens. This function only be called if the tokens that the user is attempting to withdraw are not locked.
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
 
 **Response**
 
@@ -244,7 +264,7 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -256,7 +276,7 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -270,7 +290,7 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|
@@ -283,7 +303,7 @@ Interface: [ITokenLocking.sol](https://github.com/JoinColony/colonyNetwork/tree/
 
 
 
-**Arguments**
+**Input**
 
 |Name|Type|Description|
 |---|---|---|

--- a/docs/_Components_Adapters.md
+++ b/docs/_Components_Adapters.md
@@ -20,7 +20,7 @@ Adapters require the following parameters:
 
 ```
 
-## Initialize an adapter
+## Initialization
 
 An example of initializing an adapter might look like this:
 
@@ -55,10 +55,6 @@ const adapter = new EthersAdapter({
 
 ```
 
-## Supported adapters
+## Future Adapters
 
-- [ethers](https://github.com/JoinColony/colony-js/tree/master/packages/colony-js-adapter-ethers)
-
-## Future adapters
-
-- Check out [tailor](/tailor/docs-overview/) to learn more about adapters we plan to support in the future.
+Check out [tailor](/tailor/docs-overview/) to learn more about adapters we plan to support in the future.

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -6,27 +6,27 @@ order: 1
 
 Clients are aggregations of all the interactions possible with the colonyNetwork smart contracts that can be used to easily integrate Colony into your JavaScript application or service.
 
-## ColonyNetworkClient
+## Network Client
 
 Use `getNetworkClient` to get an instance of `ColonyNetworkClient`:
 
 ```js
 
 // Get the network client using the rinkeby network
-const networkClient = getNetworkClient(`rinkeby`, wallet);
+const networkClient = getNetworkClient('rinkeby', wallet);
 
 ```
 
 ```js
 
 // Get the network client using the local network
-const networkClient = getNetworkClient(`local`, wallet);
+const networkClient = getNetworkClient('local', wallet);
 
 ```
 
-See [purser](/purser/docs-overview) to learn how to create a wallet instance. If you are using this method with the "local" option, you will need to have [TrufflePig](https://github.com/JoinColony/trufflepig) installed and running.
+If you are using this method with the `local` option, you will need to have [TrufflePig](https://github.com/JoinColony/trufflepig) installed and running. We recommend using [Purser](/purser/docs-overview) to create a wallet instance but you can also use `ethers` (see the example in [Adapters](/colonyjs/components-adapters)).
 
-Another way to create an instance of `ColonyNetworkClient` is by providing an adapter:
+Alternatively, you can create an instance of `ColonyNetworkClient` by instantiating the `ColonyNetworkClient` class using an adapter and then initializing it using the `init` method:
 
 ```js
 
@@ -36,9 +36,9 @@ await networkClient.init();
 
 ```
 
-See [Adapters](/colonyjs/components-adapters) for more information about setting up an adapter.
+See [Adapters](/colonyjs/components-adapters) for more information about adapters.
 
-## ColonyClient
+## Colony Client
 
 Ask the `ColonyNetworkClient` for an instance of `ColonyClient`:
 
@@ -48,7 +48,7 @@ const colonyClient = await networkClient.getColonyClient(colonyId);
 
 ```
 
-Or create an instance of `ColonyClient` by providing an adapter and the contract address:
+Alternatively, you can create an instance of `ColonyClient` by instantiating the `ColonyClient` class using an adapter and query and then initializing it using the `init` method:
 
 ```js
 
@@ -63,11 +63,11 @@ await colonyClient.init();
 
 ```
 
-See [Adapters](/colonyjs/components-adapters) for more information about setting up an adapter.
+See [Adapters](/colonyjs/components-adapters) for more information about adapters.
 
-## ColonyClient (Meta Colony)
+## Colony Client [ Meta Colony ]
 
-Ask the `ColonyNetworkClient` for an instance of `ColonyClient` for the Meta Colony:
+Ask the `NetworkClient` for an instance of `ColonyClient` for the Meta Colony:
 
 ```js
 
@@ -75,7 +75,7 @@ const metaColonyClient = await networkClient.getMetaColonyClient();
 
 ```
 
-Or create an instance of `ColonyClient` by providing an adapter and the contract address:
+Alternatively, you can create an instance of `ColonyClient` by instantiating the `ColonyClient` class using an adapter and query and then initializing it using the `init` method:
 
 ```js
 
@@ -90,9 +90,9 @@ await metaColonyClient.init();
 
 ```
 
-See [Adapters](/colonyjs/components-adapters) for more information about setting up an adapter.
+See [Adapters](/colonyjs/components-adapters) for more information about adapters.
 
-## TokenClient
+## Token Client
 
 The `TokenClient` is initialized for you when you ask for a new instance of `ColonyClient`:
 
@@ -102,7 +102,7 @@ const tokenClient = colonyClient.tokenClient;
 
 ```
 
-Or create an instance of `TokenClient` by providing an adapter and the contract address:
+Alternatively, you can create an instance of `TokenClient` by instantiating the `TokenClient` class using an adapter and query and then initializing it using the `init` method:
 
 ```js
 
@@ -117,9 +117,9 @@ await tokenClient.init();
 
 ```
 
-See [Adapters](/colonyjs/components-adapters) for more information about setting up an adapter.
+See [Adapters](/colonyjs/components-adapters) for more information about adapters.
 
-## TokenLockingClient
+## Token Locking Client
 
 The `TokenLockingClient` is initialized for you when you ask for a new instance of `ColonyClient`:
 
@@ -129,7 +129,7 @@ const tokenLockingClient = colonyClient.tokenLockingClient;
 
 ```
 
-Or create an instance of `TokenLockingClient` by providing an adapter and the contract address:
+Alternatively, you can create an instance of `TokenLockingClient` by instantiating the `TokenLockingClient` class using an adapter and query and then initializing it using the `init` method:
 
 ```js
 
@@ -144,4 +144,4 @@ await tokenLockingClient.init();
 
 ```
 
-See [Adapters](/colonyjs/components-adapters) for more information about setting up an adapter.
+See [Adapters](/colonyjs/components-adapters) for more information about adapters.

--- a/docs/_Components_Loaders.md
+++ b/docs/_Components_Loaders.md
@@ -8,7 +8,7 @@ Loaders make it possible to easily access and load Ethereum smart contracts. To 
 
 Loaders provide a simple way to get the address and ABI of a deployed contract, in a certain version, at a particular location. This information is passed as an object to the [adapter](/colonyjs/components-adapters/), which initialize the contract for use.
 
-## NetworkLoader
+## Network Loader
 
 Install `@colony/colony-js-contract-loader-network`:
 
@@ -26,7 +26,7 @@ const loader = new NetworkLoader({ network: 'rinkeby' });
 
 ```
 
-## TrufflePigLoader
+## Trufflepig Loader
 
 For local development, colonyJS provides a loader that accepts a contract name and returns the contract's ABI from truffle-generated contract files being sniffed out by our very own [TrufflePig](https://github.com/JoinColony/trufflepig).
 
@@ -46,6 +46,6 @@ const loader = new TrufflepigLoader();
 
 ```
 
-## Future loaders
+## Future Loaders
 
 - Check out [tailor](/tailor/docs-overview/) to learn more about loaders we plan to support in the future.

--- a/docs/_Intro_LocalSetup.md
+++ b/docs/_Intro_LocalSetup.md
@@ -51,6 +51,8 @@ git init
 
 This will initialize your project as a Git repository, which will allow you to add colonyNetwork as a submodule, switch between colonyNetwork versions, and save the colonyNetwork version that you will be using in your local development environment.
 
+Also, now would be a good time to add a `.gitignore` file in the root of your repository and ignore `node_modules`.
+
 ### Initialize Yarn
 
 Within the root directory, run the following command and follow the prompt:
@@ -82,7 +84,7 @@ In preparation for the launch of the colonyNetwork smart contracts on `mainnet`,
 Within the colonyNetwork directory, run the following command:
 
 ```
-git checkout 9bba127b0286708d4f8919526a943b0e916cfd7c
+git checkout 543423abb133119a4029ac2adcc8cebb16a8c6d9
 ```
 
 At this point, you will need to move back into the root directory and make your first commit (or your next commit if you added the submodule to an existing project). If you do not commit your changes, the version will not be saved.

--- a/docs/_Topics_DomainsAndSkills.md
+++ b/docs/_Topics_DomainsAndSkills.md
@@ -23,7 +23,9 @@ Creating a domain is simple using an instance of the [ColonyClient](/colonyjs/ap
 ```js
 
 // Create a domain
-await colonyClient.addDomain.send({ parentDomainId });
+await colonyClient.addDomain.send({
+  parentDomainId: 1,
+});
 
 ```
 
@@ -38,7 +40,9 @@ Creating a skill is simple using an instance of the [ColonyClient](/colonyjs/api
 ```js
 
 // Create a skill
-await metaColonyClient.addGlobalSkill.send({ parentSkillId });
+await metaColonyClient.addGlobalSkill.send({
+  parentSkillId: 1,
+});
 
 ```
 
@@ -51,8 +55,8 @@ Looking up the parent skill of a global skill is simple:
 ```js
 
 await networkClient.getParentSkillId.call({
-  skillId,
-  parentSkillIndex,
+  skillId: 1,
+  parentSkillIndex: 0,
 });
 
 ```
@@ -65,9 +69,9 @@ Looking up the child skill of a global skill is simple:
 
 ```js
 
-await networkClient.getParentSkillId.call({
-  skillId,
-  childSkillIndex,
+await networkClient.getChildSkillId.call({
+  skillId: 1,
+  childSkillIndex: 0,
 });
 
 ```

--- a/docs/_Topics_ManagingPermissions.md
+++ b/docs/_Topics_ManagingPermissions.md
@@ -76,7 +76,9 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to set 
 ```js
 
 // Set admin role
-await colonyClient.setAdminRole.send({ user })
+await colonyClient.setAdminRole.send({
+  user: '0x0...',
+});
 
 ```
 
@@ -87,7 +89,9 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to remo
 ```js
 
 // Remove admin role
-await colonyClient.removeAdminRole.send({ user })
+await colonyClient.removeAdminRole.send({
+  user: '0x0...',
+});
 
 ```
 
@@ -98,7 +102,9 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to set 
 ```js
 
 // Set admin role
-await colonyClient.setRecoveryRole.send({ user })
+await colonyClient.setRecoveryRole.send({
+  user: '0x0...',
+});
 
 ```
 
@@ -109,7 +115,9 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to remo
 ```js
 
 // Remove admin role
-await colonyClient.removeRecoveryRole.send({ user })
+await colonyClient.removeRecoveryRole.send({
+  user: '0x0...',
+});
 
 ```
 
@@ -120,7 +128,9 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to set 
 ```js
 
 // Set founder role
-await colonyClient.setFounderRole.send({ user })
+await colonyClient.setFounderRole.send({
+  user: '0x0...',
+});
 
 ```
 
@@ -134,8 +144,8 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to chec
 
 // Check user role
 await colonyClient.hasUserRole.call({
-  user,
-  role,
+  user: '0x0...',
+  role: 'ADMIN',
 });
 
 ```

--- a/docs/_Topics_ManagingPermissions.md
+++ b/docs/_Topics_ManagingPermissions.md
@@ -4,55 +4,66 @@ section: Topics
 order: 7
 ---
 
-In the current implementation of the colonyNetwork smart contracts, some events on-chain are not mediated by reputation scores as described in the [Whitepaper](https://colony.io/whitepaper.pdf). For now, certain actions within a colony that would ordinarily require some minimum reputation are assigned an "authority role".
+In the current implementation of the colonyNetwork smart contracts, some events on-chain are not mediated by reputation scores as described in the [Whitepaper](https://colony.io/whitepaper.pdf). For now, certain actions within a colony that would require some minimum reputation are instead assigned authority roles.
 
 ==TOC==
 
 ## Authority Roles
 
-There are two "authority roles": `FOUNDER` and `ADMIN`. Each authority role can call certain colonyNetwork methods, which are not permitted by addresses without an authority role. This includes actions such as minting new colony tokens, setting and removing authority roles, adding domains, creating tasks, and much more.
+There are three "authority roles": `FOUNDER`,  `ADMIN`, and `RECOVERY`. Each authority role can call certain colonyNetwork methods, which are not permitted by addresses without an authority role. This includes actions such as minting new colony tokens, setting and removing authority roles, adding domains, creating tasks, and much more.
 
 *Note: The "authority roles" described here are distinct from "task roles" (`MANAGER`, `WORKER`, and `EVALUATOR`). You can learn more about task roles and their permissions in [Task Lifecycle](/colonyjs/topics-task-lifecycle).*
 
 ### Permissions for `ColonyClient` methods
 
-|                                   | Founder       | Admin         |
-|-----------------------------------|---------------|---------------|
-| addDomain                         | X             | X             |
-| addNetworkColonyVersion           | X             |               |
-| bootstrapColony                   | X             |               |
-| createTask                        | X             | X             |
-| mintTokens                        | X             |               |
-| moveFundsBetweenPots              | X             | X             |
-| registerColonyLabel               | X             |               |
-| removeAdminRole                   | X             |               |
-| removeRecoveryRole                | X             |               |
-| setAdminRole                      | X             | X             |
-| setFounderRole                    | X             |               |
-| setRecoveryRole                   | X             |               |
-| setRewardInverse                  | X             |               |
-| setToken                          | X             |               |
-| startNextRewardPayout             | X             | X             |
-| upgrade                           | X             |               |
+|                                   | Founder       | Admin         | Recovery      |
+|-----------------------------------|---------------|---------------|---------------|
+| addDomain                         | X             | X             |               |
+| addNetworkColonyVersion           | X             |               |               |
+| approveExitRecovery               |               |               | X             |
+| bootstrapColony                   | X             |               |               |
+| createTask                        | X             | X             |               |
+| enterRecoveryMode                 |               |               | X             |
+| exitRecoveryMode                  |               |               | X             |
+| mintTokens                        | X             |               |               |
+| moveFundsBetweenPots              | X             | X             |               |
+| registerColonyLabel               | X             |               |               |
+| removeAdminRole                   | X             |               |               |
+| removeRecoveryRole                | X             |               |               |
+| setAdminRole                      | X             | X             |               |
+| setFounderRole                    | X             |               |               |
+| setRecoveryRole                   | X             |               |               |
+| setRewardInverse                  | X             |               |               |
+| setStorageSlotRecovery            |               |               | X             |
+| setToken                          | X             |               |               |
+| startNextRewardPayout             | X             | X             |               |
+| upgrade                           | X             |               |               |
+
 
 *See [ColonyClient](/colonyjs/api-colonyclient) for more information about each method.*
 
 ### Permissions for `ColonyClient` methods (Meta Colony)
 
-|                                   | Founder       | Admin         |
-|-----------------------------------|---------------|---------------|
-| addGlobalSkill                    | X             |               |
-| mintTokensForColonyNetwork        | X             |               |
-| setNetworkFeeInverse              | X             |               |
+The following permissions are in addition to those defined above.
+
+|                                   | Founder       | Admin         | Recovery      |
+|-----------------------------------|---------------|---------------|---------------|
+| addGlobalSkill                    | X             |               |               |
+| mintTokensForColonyNetwork        | X             |               |               |
+| setNetworkFeeInverse              | X             |               |               |
 
 *See [ColonyClient](/colonyjs/api-colonyclient) for more information about each method.*
 
 ### Permissions for `ColonyNetworkClient` methods
 
-|                                   | Founder       | Admin         |
-|-----------------------------------|---------------|---------------|
-| removeRecoveryRole                | X             |               |
-| setRecoveryRole                   | X             |               |
+|                                   | Founder       | Admin         | Recovery      |
+|-----------------------------------|---------------|---------------|---------------|
+| approveExitRecovery               |               |               | X             |
+| enterRecoveryMode                 |               |               | X             |
+| exitRecoveryMode                  |               |               | X             |
+| removeRecoveryRole                | X             |               |               |
+| setRecoveryRole                   | X             |               |               |
+| setStorageSlotRecovery            |               |               | X             |
 
 *See [ColonyNetworkClient](/colonyjs/api-colonynetworkclient) for more information about each method.*
 
@@ -77,6 +88,28 @@ We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to remo
 
 // Remove admin role
 await colonyClient.removeAdminRole.send({ user })
+
+```
+
+### Set Recovery Role
+
+We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to set a user's role to `RECOVERY`:
+
+```js
+
+// Set admin role
+await colonyClient.setRecoveryRole.send({ user })
+
+```
+
+### Remove Recovery Role
+
+We can use an instance of the [ColonyClient](/colonyjs/api-colonyclient) to remove a user's role as `RECOVERY`:
+
+```js
+
+// Remove admin role
+await colonyClient.removeRecoveryRole.send({ user })
 
 ```
 

--- a/docs/_Topics_TaskLifecycle.md
+++ b/docs/_Topics_TaskLifecycle.md
@@ -200,6 +200,7 @@ Changing or setting the managers's payout (`MANAGER` and `WORKER`):
 // Set the task manager payout
 await colonyClient.setTaskManagerPayout.startOperation({
   taskId,
+  token,
   amount,
 });
 
@@ -212,6 +213,7 @@ Changing or setting the evaluator's payout (`MANAGER` and `EVALUATOR`):
 // Set the task evaluator payout
 await colonyClient.setTaskEvaluatorPayout.startOperation({
   taskId,
+  token,
   amount,
 });
 
@@ -224,6 +226,7 @@ Changing or setting the worker's payout (`MANAGER` and `WORKER`):
 // Set the task worker payout
 await colonyClient.setTaskWorkerPayout.startOperation({
   taskId,
+  token,
   amount,
 });
 

--- a/docs/_Topics_TaskLifecycle.md
+++ b/docs/_Topics_TaskLifecycle.md
@@ -53,8 +53,8 @@ When creating a task, the task must be assigned a `specificationHash` and a `dom
 
 // Create a task
 await colonyClient.createTask.send({
-  specificationHash,
-  domainId,
+  specificationHash: 'Qm...',
+  domainId: 1,
 });
 
 ```
@@ -69,10 +69,10 @@ When creating a task, the task can also be assigned a `skillId` and a `dueDate`.
 
 // Create a task
 await colonyClient.createTask.send({
-  specificationHash,
-  domainId,
-  skillId,
-  dueDate,
+  specificationHash: 'Qm...',
+  domainId: 1,
+  skillId: 1,
+  dueDate: new Date('...'),
 });
 
 ```
@@ -88,24 +88,26 @@ Once a task has been created, we can view the task using the `getTask` method.
 ```js
 
 // Get the task
-await colonyClient.getTask.call({ taskId });
+await colonyClient.getTask.call({
+  taskId: 1,
+});
 
 ```
 
 Let's take a quick look at an example of the returned task object from the `getTask` method.
 
-```
+```js
 
 {
   specificationHash: 'QmWvM3isCmEY8bsixThuFeUJmE5MN2he1UxaPzMngLZ7Wq',
   deliverableHash: null,
   status: 'ACTIVE',
-  dueDate: 2019-01-01T00:00:00.000Z,
+  dueDate: '2019-01-01T00:00:00.000Z',
   payoutsWeCannotMake: 0,
   potId: 2,
   completionDate: null,
   domainId: 1,
-  skillId: 0,
+  skillId: 1,
   id: 1,
 }
 
@@ -125,11 +127,11 @@ In order to fund a task, we will need the `potId` of the task (which will be our
 
 // Move funds between pots
 await colonyClient.moveFundsBetweenPots.send({
-  fromPot,
-  toPot,
-  amount,
-  token,
-})
+  fromPot: 1,
+  toPot: 2,
+  amount: new BN('1000000000000000000'),
+  token: '0x...',
+});
 
 ```
 
@@ -151,8 +153,8 @@ Changing the task brief (`MANAGER` and `WORKER`):
 
 // Set the task brief
 await colonyClient.setTaskBrief.startOperation({
-  taskId,
-  specificationHash,
+  taskId: 1,
+  specificationHash: 'Qm...',
 });
 
 ```
@@ -163,8 +165,8 @@ Changing or setting the task domain (`MANAGER` and `WORKER`):
 
 // Set the task domain
 await colonyClient.setTaskDomain.startOperation({
-  taskId,
-  domainId,
+  taskId: 1,
+  domainId: 1,
 });
 
 ```
@@ -175,8 +177,8 @@ Changing or setting the task skill (`MANAGER` and `WORKER`):
 
 // Set the task skill
 await colonyClient.setTaskSkill.startOperation({
-  taskId,
-  skillId,
+  taskId: 1,
+  skillId: 1,
 });
 
 ```
@@ -187,8 +189,8 @@ Changing or setting the task due date (`MANAGER` and `WORKER`):
 
 // Set the task due date
 await colonyClient.setTaskDueDate.startOperation({
-  taskId,
-  dueDate,
+  taskId: 1,
+  dueDate: new Date('...'),
 });
 
 ```
@@ -199,9 +201,9 @@ Changing or setting the managers's payout (`MANAGER` and `WORKER`):
 
 // Set the task manager payout
 await colonyClient.setTaskManagerPayout.startOperation({
-  taskId,
-  token,
-  amount,
+  taskId: 1,
+  token: '0x0...',
+  amount: new BN('1000000000000000000'),
 });
 
 ```
@@ -212,9 +214,9 @@ Changing or setting the evaluator's payout (`MANAGER` and `EVALUATOR`):
 
 // Set the task evaluator payout
 await colonyClient.setTaskEvaluatorPayout.startOperation({
-  taskId,
-  token,
-  amount,
+  taskId: 1,
+  token: '0x0...',
+  amount: new BN('1000000000000000000'),
 });
 
 ```
@@ -225,9 +227,9 @@ Changing or setting the worker's payout (`MANAGER` and `WORKER`):
 
 // Set the task worker payout
 await colonyClient.setTaskWorkerPayout.startOperation({
-  taskId,
-  token,
-  amount,
+  taskId: 1,
+  token: '0x0...',
+  amount: new BN('1000000000000000000'),
 });
 
 ```
@@ -238,8 +240,8 @@ Changing the manager's role (`MANAGER` and proposed `MANAGER`):
 
 // Set the task manager role
 await colonyClient.setTaskManagerRole.startOperation({
-  taskId,
-  user,
+  taskId: 1,
+  user: '0x0...',
 });
 
 ```
@@ -250,8 +252,8 @@ Setting the evaluator's role (`MANAGER` and proposed `EVALUATOR`):
 
 // Set the task evaluator role
 await colonyClient.setTaskEvaluatorRole.startOperation({
-  taskId,
-  user,
+  taskId: 1,
+  user: '0x0...',
 });
 
 ```
@@ -262,8 +264,8 @@ Setting the worker's role (`MANAGER` and proposed `WORKER`):
 
 // Set the task worker role
 await colonyClient.setTaskWorkerRole.startOperation({
-  taskId,
-  user,
+  taskId: 1,
+  user: '0x0...',
 });
 
 ```
@@ -274,8 +276,8 @@ Removing the evaluator's role (`MANAGER` and `EVALUATOR`):
 
 // Remove the task evaluator role
 await colonyClient.removeTaskEvaluatorRole.startOperation({
-  taskId,
-  user,
+  taskId: 1,
+  user: '0x0...',
 });
 
 ```
@@ -286,8 +288,8 @@ Removing the worker's role (`MANAGER` and `WORKER`):
 
 // Remove the task worker role
 await colonyClient.removeTaskWorkerRole.startOperation({
-  taskId,
-  user,
+  taskId: 1,
+  user: '0x0...',
 });
 
 ```
@@ -301,7 +303,9 @@ Any time before a task is completed, the task can be cancelled, which allows any
 ```js
 
 // Cancel the task
-await colonyClient.cancelTask.startOperation({ taskId });
+await colonyClient.cancelTask.startOperation({
+  taskId: 1,
+});
 
 ```
 
@@ -315,8 +319,8 @@ Like the `specificationHash`, the `deliverableHash` can be any arbitrary hash st
 
 // Submit the task work
 await colonyClient.submitTaskDeliverable.send({
-  taskId,
-  deliverableHash,
+  taskId: 1,
+  deliverableHash: 'Qm...',
 });
 
 ```
@@ -338,14 +342,14 @@ During the "commit period", ratings are submitted to the blockchain and hidden u
 
 // Generate secret
 const { secret } = await colonyClient.generateSecret.call({
-  salt,
-  value,
+  salt: 'secret',
+  value: 2,
 });
 
 // Submit work rating
 await colonyClient.submitTaskWorkRating.send({
-  taskId,
-  role,
+  taskId: 1,
+  role: 'WORKER',
   secret,
 });
 
@@ -357,10 +361,10 @@ During the "reveal period", users submit a transaction to reveal their rating. T
 
 // Reveal work rating
 await colonyClient.revealTaskWorkRating.send({
-  taskId,
-  role,
-  rating,
-  salt,
+  taskId: 1,
+  role: 'WORKER',
+  rating: 2,
+  salt: 'secret',
 });
 
 ```
@@ -372,7 +376,9 @@ It's easy to check the status of a task during the "rating period":
 ```js
 
 // Get work ratings
-await colonyClient.getTaskWorkRatings.call({ taskId });
+await colonyClient.getTaskWorkRatings.call({
+  taskId: 1,
+});
 
 ```
 
@@ -383,7 +389,9 @@ After the "rating period" has finished, the task may be finalized, which prevent
 ```js
 
 // Finalize task
-await colonyClient.finalizeTask.send({ taskId });
+await colonyClient.finalizeTask.send({
+  taskId: 1,
+});
 
 ```
 
@@ -395,9 +403,9 @@ Once a task is finalized, each "task role" can then claim their payout:
 
 // Claim payout
 await colonyClient.claimPayout.send({
-  taskId,
-  role,
-  token,
+  taskId: 1,
+  role: 'WORKER',
+  token: '0x0...',
 });
 
 ```

--- a/docs/_Topics_TokensAndFunding.md
+++ b/docs/_Topics_TokensAndFunding.md
@@ -22,8 +22,7 @@ Creating a new token is simple using an instance of the [ColonyNetworkClient](/c
 
 // Create a token
 await networkClient.createToken.send({
-  name,
-  symbol,
+  symbol: 'TKN',
 });
 
 ```
@@ -48,7 +47,9 @@ We can set the `owner` of the token contract using an instance of the [TokenClie
 ```js
 
 // Set token owner
-await colonyClient.tokenClient.setOwner.send({ owner });
+await colonyClient.tokenClient.setOwner.send({
+  owner: '0x0...',
+});
 
 ```
 
@@ -61,7 +62,9 @@ We can mint tokens using an instance of the [ColonyClient](/colonyjs/api-colonyc
 ```js
 
 // Mint tokens
-await colonyClient.mintTokens.send({ amount });
+await colonyClient.mintTokens.send({
+  amount: new BN('10000000000000000000'),
+});
 
 ```
 
@@ -74,7 +77,9 @@ We can burn tokens using an instance of the [ColonyClient](/colonyjs/api-colonyc
 ```js
 
 // Burn tokens
-await colonyClient.burnTokens.send({ amount });
+await colonyClient.burnTokens.send({
+  amount: new BN('10000000000000000000'),
+});
 
 ```
 
@@ -102,7 +107,9 @@ We can claim colony funds using an instance of the [ColonyClient](/colonyjs/api-
 ```js
 
 // Claim colony funds
-await colonyClient.claimColonyFunds.send({ token })
+await colonyClient.claimColonyFunds.send({
+  token: '0x0...',
+});
 
 ```
 
@@ -114,11 +121,11 @@ We can move funds between pots using an instance of the [ColonyClient](/colonyjs
 
 // Move funds between pots
 await colonyClient.moveFundsBetweenPots.send({
-  fromPot,
-  toPot,
-  amount,
-  token,
-})
+  fromPot: 1,
+  toPot: 2,
+  amount: new BN('1000000000000000000'),
+  token: '0x0...',
+});
 
 ```
 
@@ -132,8 +139,8 @@ We can get the balance of a pot using an instance of the [ColonyClient](/colonyj
 
 // Get pot balance
 await colonyClient.getFundingPotBalance.call({
-  potId,
-  token,
-})
+  potId: 2,
+  token: '0x0...',
+});
 
 ```

--- a/docs/_Topics_UsingIPFS.md
+++ b/docs/_Topics_UsingIPFS.md
@@ -1,7 +1,7 @@
 ---
 title: Using IPFS
 section: Topics
-order: 9
+order: 10
 ---
 
 A natural way to use the `specificationHash` and `deliverableHash` properties within a task is to point to a file hosted on IPFS. This leaves open the format for the task specification (the description of the work to be done) and the task deliverable (the work done) and provides the opportunity to use text files, PDFs, or other forms of media.

--- a/docs/_Topics_UsingMultisignature.md
+++ b/docs/_Topics_UsingMultisignature.md
@@ -1,7 +1,7 @@
 ---
 title: Using Multisignature
 section: Topics
-order: 8
+order: 9
 ---
 
 Important changes to a task within a colony must be approved by multiple "task roles". Most of the methods that modify a task require multiple signatures before the modification will take affect and the transaction will be executed. We achieve this process with something known as "multisgnature".

--- a/docs/_Topics_ViewingReputation.md
+++ b/docs/_Topics_ViewingReputation.md
@@ -1,0 +1,30 @@
+---
+title: Viewing Reputation
+section: Topics
+order: 8
+---
+
+Whenever a user earns native tokens from a colony by completing a task or receiving a payment, the address associated with the account earns a reputation score equivalent to the token amount. See [Reputation](https://docs.colony.io/colonynetwork/whitepaper-tldr-reputation/) as defined in the colonyNetwork documentation for more information.
+
+## Get Reputation
+
+Getting the reputation for an address is simple. You can use either the `ColonyClient` or `ColonyNetworkClient`.
+
+```js
+
+// Get reputation using colony client
+await colonyClient.getReputation.send({
+  skillId: 1,
+  user: '0x0...',
+});
+
+// Get reputation using network client
+await networkClient.getReputation.send({
+  colonyAddress: '0x0...',
+  skillId: 1,
+  user: '0x0...',
+});
+
+```
+
+*Note: Currently this method is only supported on rinkeby. We will be adding instructions for running the reputation miner and viewing reputation in a local environment in the near future.*

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -2,11 +2,14 @@
 title: ColonyClient
 section: API
 order: 1
-tocdepth: 1
 ---
 
 The `ColonyClient` class is a standard interface for interactions with the methods and events described in both `IColony.sol` and `IMetaColony.sol`. These interactions are generally concerned with actions within a colony, such as adding a new domain, creating a task, moving funds between pots, and managing permissions.
 
 See [Clients](/colonyjs/components-clients) for information about initializing `ColonyClient`.
+
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
 
 ==TOC==

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -8,7 +8,7 @@ The `ColonyClient` class is a standard interface for interactions with the metho
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_ColonyClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyClient.template.md
@@ -6,9 +6,9 @@ order: 1
 
 The `ColonyClient` class is a standard interface for interactions with the methods and events described in both `IColony.sol` and `IMetaColony.sol`. These interactions are generally concerned with actions within a colony, such as adding a new domain, creating a task, moving funds between pots, and managing permissions.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `ColonyClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
@@ -6,9 +6,9 @@ order: 2
 
 The `ColonyNetworkClient` is a standard interface for interactions with methods and events described in `IColonyNetwork.sol`. These interactions are generally concerned with the colony network as a whole. This includes operations like getting a count of all colonies on the network, querying for information about a skill, or registering an ENS label for a user.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `ColonyNetworkClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyNetworkClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
@@ -8,6 +8,10 @@ The `ColonyNetworkClient` is a standard interface for interactions with methods 
 
 See [Clients](/colonyjs/components-clients) for information about initializing `ColonyNetworkClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==
 
 ## Instance methods
@@ -18,14 +22,14 @@ See [Clients](/colonyjs/components-clients) for information about initializing `
 
 Get the address of a Colony for the specified id of a deployed colony contract.
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |key|string|Name of the Colony to get|
 |id|number|Integer number of the Colony|
 
-#### Response
+**Response**
 
 `Promise<Address>`. The address of the given Colony contract
 
@@ -33,14 +37,14 @@ Get the address of a Colony for the specified id of a deployed colony contract.
 
 Returns an initialized ColonyClient for the specified id of a deployed colony contract.
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |key|string|Name of the Colony to get|
 |id|number|Integer number of the Colony|
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
@@ -48,13 +52,13 @@ Returns an initialized ColonyClient for the specified id of a deployed colony co
 
 Returns an initialized ColonyClient for the contract at address `contractAddress`
 
-#### Arguments
+**Input**
 
-|Argument|Type|Description|
+|Property|Type|Description|
 |---|---|---|
 |contractAddress|Adress|Address of a deployed Colony contract|
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the given Colony contract
 
@@ -62,6 +66,6 @@ Returns an initialized ColonyClient for the contract at address `contractAddress
 
 Gets the Meta Colony as an initialized ColonyClient
 
-#### Response
+**Response**
 
 `Promise<ColonyClient>`. An instance of a `ColonyClient` associated with the MetaColony contract

--- a/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
+++ b/packages/colony-js-client/docs/_API_ColonyNetworkClient.template.md
@@ -8,7 +8,7 @@ The `ColonyNetworkClient` is a standard interface for interactions with methods 
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `ColonyNetworkClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_TokenClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenClient.template.md
@@ -6,9 +6,9 @@ order: 3
 
 The `TokenClient` is a standard interface for interactions with methods and events described in `Token.sol`. These interactions are extended from the ERC20 and DSToken standard token interfaces and are generally concerned with managing the native token assigned to a colony. This includes operations such as minting tokens, burning tokens, and transferring tokens.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `TokenClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `TokenClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_TokenClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenClient.template.md
@@ -8,7 +8,7 @@ The `TokenClient` is a standard interface for interactions with methods and even
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `TokenClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_TokenClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenClient.template.md
@@ -8,4 +8,8 @@ The `TokenClient` is a standard interface for interactions with methods and even
 
 See [Clients](/colonyjs/components-clients) for information about initializing `TokenClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==

--- a/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
@@ -6,9 +6,9 @@ order: 4
 
 The `TokenLockingClient` is a standard interface for interactions with methods and events described in `ITokenLocking.sol`. These interactions are generally concerned token locking, such as locking and unlocking tokens.
 
-See [Clients](/colonyjs/components-clients) for information about initializing `TokenLockingClient`.
+See [Clients](/colonyjs/components-clients) for more information about initializing `TokenLockingClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
@@ -8,7 +8,7 @@ The `TokenLockingClient` is a standard interface for interactions with methods a
 
 See [Clients](/colonyjs/components-clients) for more information about initializing `TokenLockingClient`.
 
-See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` class.
+See [ContractClient](/colonyjs/api-contractclient) for more information about the `ContractClient` superclass.
 
 ## Table of Contents
 

--- a/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
+++ b/packages/colony-js-client/docs/_API_TokenLockingClient.template.md
@@ -8,4 +8,8 @@ The `TokenLockingClient` is a standard interface for interactions with methods a
 
 See [Clients](/colonyjs/components-clients) for information about initializing `TokenLockingClient`.
 
+See [ContractClient](/colonyjs/api-contractclient) for information about the `ContractClient` class.
+
+## Table of Contents
+
 ==TOC==

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -130,13 +130,13 @@ function printCallers(callers) {
 ### \`${caller.name}.call(${printArgs(caller.args, false)})\`
 
 ${caller.description}
-${caller.args && caller.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', caller.args)}
+${caller.args && caller.args.length ? '\n**Input**\n\n' : ''}${printProps(caller.args)}
 
 **Response**
 
 A promise which resolves to an object containing the following properties:
 
-${printProps('Return Value', caller.returns)}
+${printProps(caller.returns)}
 
 **Contract Information**
 
@@ -159,7 +159,7 @@ function printSenders(senders, events) {
 ### \`${sender.name}.send(${printArgs(sender.args, true)})\`
 
 ${sender.description}
-${sender.args && sender.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', sender.args)}
+${sender.args && sender.args.length ? '\n**Input**\n\n' : ''}${printProps(sender.args)}
 
 **Options**
 
@@ -178,7 +178,7 @@ An instance of a \`ContractResponse\`${
       )
 }
 
-${printProps('Event Data', getEventProps(events, sender.events))}
+${printProps(getEventProps(events, sender.events))}
 
 **Contract Information**
 
@@ -195,10 +195,17 @@ function printEvents(events) {
 ## Events
 
 ` + events.map(event => `
-### \`events.${event.name}.addListener((${printArgs(event.args)}) => { /* ... */ })\`
+### \`events.${event.name}\`
+
+**Methods**
+
+\`.addListener((${printArgs(event.args)}) => { /* ... */ })\`
+
+\`.removeListener((${printArgs(event.args)}) => { /* ... */ })\`
 
 ${event.description}
-${event.args && event.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', event.args)}
+
+${event.args && event.args.length ? '\n**Event Data**\n\n' : ''}${printProps(event.args)}
 
 `).join('');
 }
@@ -216,13 +223,13 @@ function printMultiSig(multisig, events) {
 ### \`${ms.name}.startOperation(${printArgs(ms.args, false)})\`
 
 ${ms.description}
-${ms.args && ms.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', ms.args)}
+${ms.args && ms.args.length ? '\n**Input**\n\n' : ''}${printProps(ms.args)}
 
 **Response**
 
 An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose sender will eventually receive the following event data:' : ''}
 
-${printProps('Event Data', getEventProps(events, ms.events))}
+${printProps(getEventProps(events, ms.events))}
 
 **Contract Information**
 
@@ -242,7 +249,7 @@ function printContractData(data) {
   `
 }
 
-function printProps(title, props) {
+function printProps(props) {
   if (props && props.length) {
     return `|Name|Type|Description|
 |---|---|---|

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -122,7 +122,7 @@ function printCallers(callers) {
   return `
 ## Callers
 
-**All callers return promises which resolve to an object containing the given return values.**.
+**All callers return promises which resolve to an object containing the given return values.**
 ` +
     callers
       .map(
@@ -170,15 +170,17 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 An instance of a \`ContractResponse\`${
   // XXX If this gets even more complicated, find another way!
   sender.name === 'createToken'
-    ? ' which will receive a receipt with a \`contractAddress\` property (the address of the newly-deployed contract)'
+    ? ' which will receive a receipt with a \`contractAddress\` property.'
     : (
         sender.events && sender.events.length
           ? ' which will eventually receive the following event data:'
-          : ''
+          : '.'
       )
 }
 
 ${printProps(getEventProps(events, sender.events))}
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about \`ContractResponse\`.
 
 **Contract Information**
 
@@ -227,9 +229,11 @@ ${ms.args && ms.args.length ? '\n**Input**\n\n' : ''}${printProps(ms.args)}
 
 **Response**
 
-An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose sender will eventually receive the following event data:' : ''}
+An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose sender will eventually receive the following event data:' : '.'}
 
 ${printProps(getEventProps(events, ms.events))}
+
+See [MutisigOperation](/colonyjs/api-multisigoperation/) for more information.
 
 **Contract Information**
 
@@ -324,7 +328,7 @@ function getEventName(p) {
 
 function getNestedEventDescription(event) {
   const args = printArgs(event.args).toLowerCase().replace(/\s/g, '').replace(/\W/g, '-');
-  return `Contains the data defined in [${event.name}](#events${event.name.toLowerCase()}addlistener${args}------)`;
+  return `Contains the data defined in [${event.name}](#events${event.name.toLowerCase()})`;
 }
 
 function formatDescription(str) {

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -130,15 +130,15 @@ function printCallers(callers) {
 ### \`${caller.name}.call(${printArgs(caller.args, false)})\`
 
 ${caller.description}
-${caller.args && caller.args.length ? '\n#### Arguments\n\n' : ''}${printProps('Argument', caller.args)}
+${caller.args && caller.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', caller.args)}
 
-#### Return Values
+**Response**
 
 A promise which resolves to an object containing the following properties:
 
 ${printProps('Return Value', caller.returns)}
 
-#### Contract Information
+**Contract Information**
 
 ${printContractData(caller.contractData)}
 `,
@@ -159,9 +159,13 @@ function printSenders(senders, events) {
 ### \`${sender.name}.send(${printArgs(sender.args, true)})\`
 
 ${sender.description}
-${sender.args && sender.args.length ? '\n#### Arguments\n\n' : ''}${printProps('Argument', sender.args)}
+${sender.args && sender.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', sender.args)}
 
-#### Response
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
+**Response**
 
 An instance of a \`ContractResponse\`${
   // XXX If this gets even more complicated, find another way!
@@ -176,7 +180,7 @@ An instance of a \`ContractResponse\`${
 
 ${printProps('Event Data', getEventProps(events, sender.events))}
 
-#### Contract Information
+**Contract Information**
 
 ${printContractData(sender.contractData)}
 `,
@@ -194,7 +198,7 @@ function printEvents(events) {
 ### \`events.${event.name}.addListener((${printArgs(event.args)}) => { /* ... */ })\`
 
 ${event.description}
-${event.args && event.args.length ? '\n#### Arguments\n\n' : ''}${printProps('Argument', event.args)}
+${event.args && event.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', event.args)}
 
 `).join('');
 }
@@ -212,15 +216,15 @@ function printMultiSig(multisig, events) {
 ### \`${ms.name}.startOperation(${printArgs(ms.args, false)})\`
 
 ${ms.description}
-${ms.args && ms.args.length ? '\n#### Arguments\n\n' : ''}${printProps('Argument', ms.args)}
+${ms.args && ms.args.length ? '\n**Input**\n\n' : ''}${printProps('Argument', ms.args)}
 
-#### Response
+**Response**
 
 An instance of a \`MultiSigOperation\`${ms.events && ms.events.length ? ' whose sender will eventually receive the following event data:' : ''}
 
 ${printProps('Event Data', getEventProps(events, ms.events))}
 
-#### Contract Information
+**Contract Information**
 
 ${printContractData(ms.contractData)}
 `,
@@ -240,7 +244,7 @@ function printContractData(data) {
 
 function printProps(title, props) {
   if (props && props.length) {
-    return `|${title}|Type|Description|
+    return `|Name|Type|Description|
 |---|---|---|
 ${props
       .map(param => `|${param.name}|${param.type}|${param.description}|`)


### PR DESCRIPTION
## Description

This pull request makes the following fixes and improvements to the documentation:

- [x] Add missing `token` param to payout methods in "Task Lifecycle"
- [x] Add the `options` object to the "Senders" section in each API page
- [x] Update commit in "Local Setup" to use the `temp-ethdenver`branch
- [x] Add step in "Local Setup" for adding `.gitignore` after installing packages
- [x] Add `RECOVERY` role with explanation to "Managing Permissions"
- [x] Improve examples for each page in the "Topics" section (#362)
- [x] Add "Reputation" page to "Topics" and `getReputation` to API (#367)
- [x] Make it more clear that the colony address must be the token owner (#377)

## Related Issues

Closes #362
Closes #367
Closes #377