### PR TITLE
DomainAuth sender

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/packages/colonyDapp/.*
 <PROJECT_ROOT>/node_modules/oboe/test/json/incomplete.json
+<PROJECT_ROOT>/lib/colonyNetwork/node_modules/oboe/test/json/incomplete.json
 
 [include]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,26 +127,13 @@ Also, please note that colonyJS is currently using `ethers` version `3.0.27`.
     * See `claimPayment` and `claimTaskPayout` for more information.
   * Removed `createTask`
     * `addTask` has replaced `createTask` for consistency.
-    * `addTask` added a `permissionDomainId` input parameter.
-    * `addTask` added a `childSkillIndex` input parameter.
   * Removed `removeAdminRole` (See `setAdminRole`)
-  * Updated `addDomain`
-    * Added `permissionDomainId` input parameter.
-    * Added `childSkillIndex` input parameter.
   * Updated `addGlobalSkill`
     * Removed `parentSkillId` as an input parameter. Global skills no longer exist within a skills tree and always use `0` for the `parentSkillId`.
   * Updated `bootstrapColony`
     * Changed `users` input parameter to `addresses`.
   * Updated `makePayment`
-    * Added `permissionDomainId` input parameter.
-    * Added `childSkillIndex` input parameter.
-    * Added `callerPermissionDomainId` input parameter.
-    * Added `callerChildSkillIndex` input parameter.
     * Changed `worker` input parameter to `recipient`.
-  * Updated `moveFundsBetweenPots`
-    * Added `permissionDomainId` input parameter.
-    * Added `fromChildSkillIndex` input parameter.
-    * Added `toChildSkillIndex` input parameter.
   * Updated `removeRecoveryRole`
     * Changed `user` input parameter to `address`.
   * Updated `setRecoveryRole`
@@ -162,8 +149,6 @@ Also, please note that colonyJS is currently using `ethers` version `3.0.27`.
     * Changed `user` input parameter to `address`.
   * Updated `setTaskManagerRole`
     * Changed `user` input parameter to `address`.
-    * Added `permissionDomainId` input parameter.
-    * Added `childSkillIndex` input parameter.
   * Updated `setTaskWorkerRole`
     * Changed `user` input parameter to `address`.
   * Updated `startNextRewardPayout`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,8 @@ Also, please note that colonyJS is currently using `ethers` version `3.0.27`.
 * Updated events in `ColonyNetworkClient` (`@colony/colony-js-client`)
   * Added `ColonyVersionAdded`
 
+* Updated `TokenClient` to reflect `colonyToken` contract (`@colony/colony-js-client`)
+
 ## v1.11.2
 
 **Bug Fixes**

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -815,7 +815,7 @@ Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e25
 Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IMetaColony.sol)
   
 
-### `addDomain.send({ permissionDomainId, childSkillIndex, parentDomainId }, options)`
+### `addDomain.send({ parentDomainId }, options)`
 
 Add a domain to the colony.
 
@@ -823,8 +823,6 @@ Add a domain to the colony.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |parentDomainId|number|The ID of the parent domain.|
 
 **Options**
@@ -959,7 +957,7 @@ Contract: [ColonyPayment.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `addTask.send({ permissionDomainId, childSkillIndex, specificationHash, domainId, skillId, dueDate }, options)`
+### `addTask.send({ specificationHash, domainId, skillId, dueDate }, options)`
 
 Add a new task within the colony.
 
@@ -967,8 +965,6 @@ Add a new task within the colony.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |specificationHash|IPFS hash|The specification hash of the task (an IPFS hash).|
 |domainId|number (optional)|The ID of the domain (default value of `1`).|
 |skillId|number (optional)|The ID of the skill (default value of `null`).|
@@ -1363,7 +1359,7 @@ Contract: [ContractRecovery.sol](https://github.com/JoinColony/colonyNetwork/tre
 Interface: [IRecovery.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IRecovery.sol)
   
 
-### `finalizePayment.send({ permissionDomainId, childSkillIndex, paymentId }, options)`
+### `finalizePayment.send({ paymentId }, options)`
 
 Finalize a payment. Once a payment is finalized, no further changes to the payment can be made and the address that is assigned the payment can claim the payment.
 
@@ -1371,8 +1367,6 @@ Finalize a payment. Once a payment is finalized, no further changes to the payme
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |paymentId|number|The ID of the payment.|
 
 **Options**
@@ -1467,7 +1461,7 @@ Contract: [ColonyTask.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `makePayment.send({ permissionDomainId, childSkillIndex, callerPermissionDomainId, callerChildSkillIndex, recipient, token, amount, domainId, skillId }, options)`
+### `makePayment.send({ recipient, token, amount, domainId, skillId }, options)`
 
 Make a payment in one transaction. This function is not included in the core contracts but instead it comes from the `OneTxPayment` extension contract. The `OneTxPayment` extension contract and the sender must both be assigned the colony `ADMINISTRATION` role.
 
@@ -1475,10 +1469,6 @@ Make a payment in one transaction. This function is not included in the core con
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
-|callerPermissionDomainId|number|The ID of the domain in which the caller has permission.|
-|callerChildSkillIndex|number|The index that the `domainId` is relative to the `callerPermissionDomainId`.|
 |recipient|address|The address that will receive the payment.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens (or Ether) for the payment.|
@@ -1597,7 +1587,7 @@ Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e25
 Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IMetaColony.sol)
   
 
-### `moveFundsBetweenPots.send({ permissionDomainId, fromChildSkillIndex, toChildSkillIndex, fromPot, toPot, amount, token }, options)`
+### `moveFundsBetweenPots.send({ fromPot, toPot, amount, token }, options)`
 
 Move funds from one pot to another.
 
@@ -1605,9 +1595,6 @@ Move funds from one pot to another.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain that grants the address permission to call the method.|
-|fromChildSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
-|toChildSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |fromPot|number|The ID of the pot from which funds will be moved.|
 |toPot|number|The ID of the pot to which funds will be moved.|
 |amount|big number|The amount of funds that will be moved between pots.|
@@ -1818,7 +1805,7 @@ Contract: [OldRoles.sol](https://github.com/JoinColony/colonyNetwork/blob/5acd5e
   
   
 
-### `setAdministrationRole.send({ permissionDomainId, childSkillIndex, address, domainId, setTo }, options)`
+### `setAdministrationRole.send({ address, domainId, setTo }, options)`
 
 Assign the colony `ADMINISTRATION` role to an address. The address calling the method must have permission within the domain that permission is being granted or a parent domain to the domain that permission is being granted. The address calling the method must already be assigned either the colony `ROOT` or `ARCHITECTURE` role within the domain or parent domain.
 
@@ -1826,8 +1813,6 @@ Assign the colony `ADMINISTRATION` role to an address. The address calling the m
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain that grants the address permission to call the method.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |address|address|The address that will be assigned or unassigned the colony `ADMINISTRATION` role.|
 |domainId|number|The ID of the domain that the colony `ADMINISTRATION` role will be assigned or unassigned.|
 |setTo|boolean|A boolean indicating whether the address will be assigned or unassigned the colony `ADMINISTRATION` role.|
@@ -1900,7 +1885,7 @@ Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `setArchitectureRole.send({ permissionDomainId, childSkillIndex, address, domainId, setTo }, options)`
+### `setArchitectureRole.send({ address, domainId, setTo }, options)`
 
 Assign the colony `ARCHITECTURE` role to an address. The address calling the method must have permission within the domain that permission is being granted or a parent domain to the domain that permission is being granted. The address calling the method must already be assigned either the colony `ROOT` or `ARCHITECTURE` role within the domain or parent domain.
 
@@ -1908,8 +1893,6 @@ Assign the colony `ARCHITECTURE` role to an address. The address calling the met
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain that grants the address permission to call the method.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |address|address|The address that will be assigned or unassigned the colony `ARCHITECTURE` role.|
 |domainId|number|The ID of the domain that the colony `ARCHITECTURE` role will be assigned or unassigned.|
 |setTo|boolean|A boolean indicating whether the address will be assigned or unassigned the colony `ARCHITECTURE` role.|
@@ -1978,7 +1961,7 @@ Contract: [OldRoles.sol](https://github.com/JoinColony/colonyNetwork/blob/5acd5e
   
   
 
-### `setFundingRole.send({ permissionDomainId, childSkillIndex, address, domainId, setTo }, options)`
+### `setFundingRole.send({ address, domainId, setTo }, options)`
 
 Assign the colony `FUNDING` role to an address. The address calling the method must have permission within the domain that permission is being granted or a parent domain to the domain that permission is being granted. The address calling the method must already be assigned either the colony `ROOT` or `ARCHITECTURE` role within the domain or parent domain.
 
@@ -1986,8 +1969,6 @@ Assign the colony `FUNDING` role to an address. The address calling the method m
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain that grants the address permission to call the method.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |address|address|The address that will be assigned or unassigned the colony `FUNDING` role.|
 |domainId|number|The ID of the domain that the colony `FUNDING` role will be assigned or unassigned.|
 |setTo|boolean|A boolean indicating whether the address will be assigned or unassigned the colony `FUNDING` role.|
@@ -2050,7 +2031,7 @@ Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e25
 Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IMetaColony.sol)
   
 
-### `setPaymentDomain.send({ permissionDomainId, childSkillIndex, paymentId, domainId }, options)`
+### `setPaymentDomain.send({ paymentId, domainId }, options)`
 
 Set the payment domain.
 
@@ -2058,8 +2039,6 @@ Set the payment domain.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |paymentId|number|The ID of the payment.|
 |domainId|address|The ID of the domain.|
 
@@ -2085,7 +2064,7 @@ Contract: [ColonyPayment.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `setPaymentPayout.send({ permissionDomainId, childSkillIndex, paymentId, token, amount }, options)`
+### `setPaymentPayout.send({ paymentId, token, amount }, options)`
 
 Set the payment payout.
 
@@ -2093,8 +2072,6 @@ Set the payment payout.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |paymentId|number|The ID of the payment.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of the payment.|
@@ -2121,7 +2098,7 @@ Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `setPaymentRecipient.send({ permissionDomainId, childSkillIndex, paymentId, recipient }, options)`
+### `setPaymentRecipient.send({ paymentId, recipient }, options)`
 
 Set the payment recipient.
 
@@ -2129,8 +2106,6 @@ Set the payment recipient.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |paymentId|number|The ID of the payment.|
 |recipient|address|The address that will receive the payment.|
 
@@ -2156,7 +2131,7 @@ Contract: [ColonyPayment.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `setPaymentSkill.send({ permissionDomainId, childSkillIndex, paymentId, skillId }, options)`
+### `setPaymentSkill.send({ paymentId, skillId }, options)`
 
 Set the payment skill.
 
@@ -2164,8 +2139,6 @@ Set the payment skill.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |paymentId|number|The ID of the payment.|
 |skillId|address|The ID of the skill.|
 
@@ -2823,7 +2796,7 @@ Contract: [ColonyFunding.sol](https://github.com/JoinColony/colonyNetwork/tree/5
 Interface: [IColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IColony.sol)
   
 
-### `setTaskManagerRole.startOperation({ taskId, address, permissionDomainId, childSkillIndex })`
+### `setTaskManagerRole.startOperation({ taskId, address })`
 
 Assign the task `MANAGER` role to an address. This function can only be called before the task is finalized. The address currently assigned the task `MANAGER` role and the address being assigned the task `MANAGER` role must both sign the transaction before it can be executed.
 
@@ -2833,8 +2806,6 @@ Assign the task `MANAGER` role to an address. This function can only be called b
 |---|---|---|
 |taskId|number|The ID of the task.|
 |address|address|The address that will be assigned the task `MANAGER` role.|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 
 **Response**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -918,7 +918,7 @@ Contract: [Colony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e25
 Interface: [IMetaColony.sol](https://github.com/JoinColony/colonyNetwork/tree/5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce/contracts/IMetaColony.sol)
   
 
-### `addPayment.send({ permissionDomainId, childSkillIndex, recipient, token, amount, domainId, skillId }, options)`
+### `addPayment.send({ recipient, token, amount, domainId, skillId }, options)`
 
 Add a payment to the colony.
 
@@ -926,8 +926,6 @@ Add a payment to the colony.
 
 |Name|Type|Description|
 |---|---|---|
-|permissionDomainId|number|The ID of the domain in which the sender has permission.|
-|childSkillIndex|number|The index that the `domainId` is relative to the `permissionDomainId`.|
 |recipient|address|The address that will receive the payment.|
 |token|address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens (or Ether) for the payment.|

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -43,7 +43,7 @@ A promise which resolves to an object containing the following properties:
 
   Function: `allowance`
   
-Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/erc20.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 
@@ -70,7 +70,7 @@ A promise which resolves to an object containing the following properties:
 
   Function: `balanceOf`
   
-Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/erc20.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 
@@ -116,7 +116,7 @@ A promise which resolves to an object containing the following properties:
 
   Function: `totalSupply`
   
-Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/erc20.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 
@@ -157,7 +157,7 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
 
   
   
-Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/erc20.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 
@@ -193,7 +193,7 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
 
   
   
-Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/token.sol)
+Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts/Token.sol)
   
   
 
@@ -229,7 +229,7 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
 
   
   
-Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/token.sol)
+Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts/Token.sol)
   
   
 
@@ -264,37 +264,6 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
   
   
 Contract: [auth.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/auth.sol)
-  
-  
-
-### `setName.send({ name }, options)`
-
-Set the `name` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
-
-**Input**
-
-|Name|Type|Description|
-|---|---|---|
-|name|string|The name of the token that will be set.|
-
-**Options**
-
-See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
-
-**Response**
-
-An instance of a `ContractResponse`.
-
-
-
-See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
-
-**Contract Information**
-
-
-  
-  
-Contract: [token.sol](https://github.com/dapphub/dappsys-monolithic/tree/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/token.sol)
   
   
 
@@ -360,7 +329,7 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
 
   
   
-Contract: [erc20.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/erc20.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 
@@ -398,7 +367,7 @@ See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more informati
 
   
   
-Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts/Token.sol)
+Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361/base.sol)
   
   
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1984,7 +1984,7 @@ export default class ColonyClient extends ContractClient {
         {
           address: async () => {
             const { address } = await this.getExtensionAddress.call({
-              contractName: 'OneTx',
+              contractName: 'OneTxPayment',
             });
             return address;
           },

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -21,8 +21,7 @@ import AddPayment from './senders/AddPayment';
 import AddTask from './senders/AddTask';
 import MakePayment from './senders/MakePayment';
 import RemoveExtension from './senders/RemoveExtension';
-// eslint-disable-next-line no-unused-vars
-import DomainAuth from './senders/DomainAuth';
+import DomainAuth, { getDomainIdFromPot } from './senders/DomainAuth';
 import SetAdminRole from './senders/SetAdminRole';
 import SetFounderRole from './senders/SetFounderRole';
 import addRecoveryMethods from '../addRecoveryMethods';
@@ -257,8 +256,6 @@ export default class ColonyClient extends ContractClient {
   */
   addDomain: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       parentDomainId: number, // The ID of the parent domain.
     },
     {
@@ -328,8 +325,6 @@ export default class ColonyClient extends ContractClient {
   */
   addTask: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       specificationHash: IPFSHash, // The specification hash of the task (an IPFS hash).
       domainId: ?number, // The ID of the domain (default value of `1`).
       skillId: ?number, // The ID of the skill (default value of `null`).
@@ -540,8 +535,6 @@ export default class ColonyClient extends ContractClient {
   */
   finalizePayment: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       paymentId: number, // The ID of the payment.
     },
     {},
@@ -1065,10 +1058,6 @@ export default class ColonyClient extends ContractClient {
   */
   makePayment: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
-      callerPermissionDomainId: number, // The ID of the domain in which the caller has permission.
-      callerChildSkillIndex: number, // The index that the `domainId` is relative to the `callerPermissionDomainId`.
       recipient: Address, // The address that will receive the payment.
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The amount of tokens (or Ether) for the payment.
@@ -1130,9 +1119,6 @@ export default class ColonyClient extends ContractClient {
   */
   moveFundsBetweenPots: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain that grants the address permission to call the method.
-      fromChildSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
-      toChildSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       fromPot: number, // The ID of the pot from which funds will be moved.
       toPot: number, // The ID of the pot to which funds will be moved.
       amount: BigNumber, // The amount of funds that will be moved between pots.
@@ -1274,8 +1260,6 @@ export default class ColonyClient extends ContractClient {
   */
   setAdministrationRole: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain that grants the address permission to call the method.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       address: Address, // The address that will be assigned or unassigned the colony `ADMINISTRATION` role.
       domainId: number, // The ID of the domain that the colony `ADMINISTRATION` role will be assigned or unassigned.
       setTo: boolean, // A boolean indicating whether the address will be assigned or unassigned the colony `ADMINISTRATION` role.
@@ -1316,8 +1300,6 @@ export default class ColonyClient extends ContractClient {
   */
   setArchitectureRole: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain that grants the address permission to call the method.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       address: Address, // The address that will be assigned or unassigned the colony `ARCHITECTURE` role.
       domainId: number, // The ID of the domain that the colony `ARCHITECTURE` role will be assigned or unassigned.
       setTo: boolean, // A boolean indicating whether the address will be assigned or unassigned the colony `ARCHITECTURE` role.
@@ -1358,8 +1340,6 @@ export default class ColonyClient extends ContractClient {
   */
   setFundingRole: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain that grants the address permission to call the method.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       address: Address, // The address that will be assigned or unassigned the colony `FUNDING` role.
       domainId: number, // The ID of the domain that the colony `FUNDING` role will be assigned or unassigned.
       setTo: boolean, // A boolean indicating whether the address will be assigned or unassigned the colony `FUNDING` role.
@@ -1394,8 +1374,6 @@ export default class ColonyClient extends ContractClient {
   */
   setPaymentDomain: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       paymentId: number, // The ID of the payment.
       domainId: Address, // The ID of the domain.
     },
@@ -1412,8 +1390,6 @@ export default class ColonyClient extends ContractClient {
   */
   setPaymentPayout: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       paymentId: number, // The ID of the payment.
       token: Address, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The amount of the payment.
@@ -1431,8 +1407,6 @@ export default class ColonyClient extends ContractClient {
   */
   setPaymentRecipient: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       paymentId: number, // The ID of the payment.
       recipient: Address, // The address that will receive the payment.
     },
@@ -1449,8 +1423,6 @@ export default class ColonyClient extends ContractClient {
   */
   setPaymentSkill: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       paymentId: number, // The ID of the payment.
       skillId: Address, // The ID of the skill.
     },
@@ -1645,8 +1617,6 @@ export default class ColonyClient extends ContractClient {
     {
       taskId: number, // The ID of the task.
       address: Address, // The address that will be assigned the task `MANAGER` role.
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
     },
     {
       TaskRoleUserSet: TaskRoleUserSet,
@@ -1954,8 +1924,8 @@ export default class ColonyClient extends ContractClient {
       },
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING,
-          domainIdInputValueName: 'domainId',
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
           permissionDomainIdInputValueName: 'permissionDomainId',
           childSkillIndexInputValueName: 'childSkillIndex',
         },
@@ -1978,14 +1948,24 @@ export default class ColonyClient extends ContractClient {
         skillId: 0,
         dueDate: new Date(0),
       },
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
     });
     this.makePayment = new MakePayment({
       client: this,
       name: 'makePayment',
       functionName: 'makePayment',
       input: [
+        // permission proof for OneTX contract
         ['permissionDomainId', 'number'],
         ['childSkillIndex', 'number'],
+        // permission proof for caller
         ['callerPermissionDomainId', 'number'],
         ['callerChildSkillIndex', 'number'],
         ['recipient', 'address'],
@@ -1998,6 +1978,21 @@ export default class ColonyClient extends ContractClient {
         domainId: DEFAULT_DOMAIN_ID,
         skillId: 0,
       },
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          // TODO: these need to be proof for the OneTx extension contract
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          permissionDomainIdInputValueName: 'callerPermissionDomainId',
+          childSkillIndexInputValueName: 'callerChildSkillIndex',
+        },
+      ],
     });
     this.removeExtension = new RemoveExtension({
       client: this,
@@ -2016,6 +2011,197 @@ export default class ColonyClient extends ContractClient {
       name: 'setFounderRole',
       functionName: 'setFounderRole',
       input: [['address', 'address']],
+    });
+    this.addDomain = new DomainAuth({
+      client: this,
+      name: 'addDomain',
+      functionName: 'addDomain',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['parentDomainId', 'number'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'parentDomainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.finalizePayment = new DomainAuth({
+      client: this,
+      name: 'finalizePayment',
+      functionName: 'finalizePayment',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['paymentId', 'number'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: () => Promise.resolve(1), // TODO: fetch this from the task
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.moveFundsBetweenPots = new DomainAuth({
+      client: this,
+      name: 'moveFundsBetweenPots',
+      functionName: 'moveFundsBetweenPots',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['fromChildSkillIndex', 'number'],
+        ['toChildSkillIndex', 'number'],
+        ['fromPot', 'number'],
+        ['toPot', 'number'],
+        ['amount', 'bigNumber'],
+        ['token', 'tokenAddress'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: ({ fromPot }) => getDomainIdFromPot(fromPot, this),
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'fromChildSkillIndex',
+        },
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: ({ toPot }) => getDomainIdFromPot(toPot, this),
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'toChildSkillIndex',
+        },
+      ],
+    });
+    this.setAdministrationRole = new DomainAuth({
+      client: this,
+      name: 'setAdministrationRole',
+      functionName: 'setAdministrationRole',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['address', 'address'],
+        ['domainId', 'number'],
+        ['setTo', 'boolean'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.setArchitectureRole = new DomainAuth({
+      client: this,
+      name: 'setArchitectureRole',
+      functionName: 'setArchitectureRole',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['address', 'address'],
+        ['domainId', 'number'],
+        ['setTo', 'boolean'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.setFundingRole = new DomainAuth({
+      client: this,
+      name: 'setFundingRole',
+      functionName: 'setFundingRole',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['address', 'address'],
+        ['domainId', 'number'],
+        ['setTo', 'boolean'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: 'domainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.setPaymentPayout = new DomainAuth({
+      client: this,
+      name: 'setPaymentPayout',
+      functionName: 'setPaymentPayout',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['paymentId', 'number'],
+        ['token', 'address'],
+        ['amount', 'bigNumber'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: async ({ paymentId }) => {
+            const { domainId } = await this.getPayment.call({ paymentId });
+            return domainId;
+          },
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.setPaymentRecipient = new DomainAuth({
+      client: this,
+      name: 'setPaymentRecipient',
+      functionName: 'setPaymentRecipient',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['paymentId', 'number'],
+        ['recipient', 'address'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: async ({ paymentId }) => {
+            const { domainId } = await this.getPayment.call({ paymentId });
+            return domainId;
+          },
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
+    });
+    this.setPaymentSkill = new DomainAuth({
+      client: this,
+      name: 'setPaymentSkill',
+      functionName: 'setPaymentSkill',
+      input: [
+        ['permissionDomainId', 'number'],
+        ['childSkillIndex', 'number'],
+        ['paymentId', 'number'],
+        ['skillId', 'number'],
+      ],
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
+          domainId: async ({ paymentId }) => {
+            const { domainId } = await this.getPayment.call({ paymentId });
+            return domainId;
+          },
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
     });
 
     // Task callers
@@ -2285,13 +2471,6 @@ export default class ColonyClient extends ContractClient {
     /* eslint-enable max-len */
 
     // Senders
-    this.addSender('addDomain', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['parentDomainId', 'number'],
-      ],
-    });
     this.addSender('bootstrapColony', {
       input: [['addresses', '[address]'], ['amounts', '[bigNumber]']],
     });
@@ -2324,13 +2503,6 @@ export default class ColonyClient extends ContractClient {
     this.addSender('deprecateGlobalSkill', {
       input: [['skillId', 'number']],
     });
-    this.addSender('finalizePayment', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-      ],
-    });
     this.addSender('finalizeRewardPayout', {
       input: [['payoutId', 'number']],
     });
@@ -2339,17 +2511,6 @@ export default class ColonyClient extends ContractClient {
     });
     this.addSender('mintTokens', {
       input: [['amount', 'bigNumber']],
-    });
-    this.addSender('moveFundsBetweenPots', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['fromChildSkillIndex', 'number'],
-        ['toChildSkillIndex', 'number'],
-        ['fromPot', 'number'],
-        ['toPot', 'number'],
-        ['amount', 'bigNumber'],
-        ['token', 'tokenAddress'],
-      ],
     });
     this.addSender('registerColonyLabel', {
       input: [['colonyName', 'string'], ['orbitDBPath', 'string']],
@@ -2365,15 +2526,6 @@ export default class ColonyClient extends ContractClient {
         ['salt', 'string'],
       ],
     });
-    this.addSender('setAdministrationRole', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['address', 'address'],
-        ['domainId', 'number'],
-        ['setTo', 'boolean'],
-      ],
-    });
     this.addSender('setAllTaskPayouts', {
       input: [
         ['taskId', 'number'],
@@ -2381,65 +2533,6 @@ export default class ColonyClient extends ContractClient {
         ['managerAmount', 'bigNumber'],
         ['evaluatorAmount', 'bigNumber'],
         ['workerAmount', 'bigNumber'],
-      ],
-    });
-    this.addSender('setArchitectureRole', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['address', 'address'],
-        ['domainId', 'number'],
-        ['setTo', 'boolean'],
-      ],
-    });
-    this.addSender('setFundingRole', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['address', 'address'],
-        ['domainId', 'number'],
-        ['setTo', 'boolean'],
-      ],
-    });
-    this.addSender('setPaymentAmount', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-        ['amount', 'bigNumber'],
-      ],
-    });
-    this.addSender('setPaymentDomain', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-        ['domainId', 'number'],
-      ],
-    });
-    this.addSender('setPaymentPayout', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-        ['token', 'address'],
-        ['amount', 'bigNumber'],
-      ],
-    });
-    this.addSender('setPaymentRecipient', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-        ['recipient', 'address'],
-      ],
-    });
-    this.addSender('setPaymentSkill', {
-      input: [
-        ['permissionDomainId', 'number'],
-        ['childSkillIndex', 'number'],
-        ['paymentId', 'number'],
-        ['skillId', 'number'],
       ],
     });
     this.addSender('setRewardInverse', {

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -21,12 +21,15 @@ import AddPayment from './senders/AddPayment';
 import AddTask from './senders/AddTask';
 import MakePayment from './senders/MakePayment';
 import RemoveExtension from './senders/RemoveExtension';
+// eslint-disable-next-line no-unused-vars
+import DomainAuth from './senders/DomainAuth';
 import SetAdminRole from './senders/SetAdminRole';
 import SetFounderRole from './senders/SetFounderRole';
 import addRecoveryMethods from '../addRecoveryMethods';
 
 import {
   COLONY_ROLE_ARCHITECTURE,
+  COLONY_ROLE_FUNDING,
   COLONY_ROLES,
   DEFAULT_DOMAIN_ID,
   FUNDING_POT_TYPES,
@@ -303,8 +306,6 @@ export default class ColonyClient extends ContractClient {
   */
   addPayment: ColonyClient.Sender<
     {
-      permissionDomainId: number, // The ID of the domain in which the sender has permission.
-      childSkillIndex: number, // The index that the `domainId` is relative to the `permissionDomainId`.
       recipient: Address, // The address that will receive the payment.
       token: TokenAddress, // The address of the token contract (an empty address if Ether).
       amount: BigNumber, // The amount of tokens (or Ether) for the payment.
@@ -1951,6 +1952,14 @@ export default class ColonyClient extends ContractClient {
         domainId: DEFAULT_DOMAIN_ID,
         skillId: 0,
       },
+      permissions: [
+        {
+          role: COLONY_ROLE_FUNDING,
+          domainIdInputValueName: 'domainId',
+          permissionDomainIdInputValueName: 'permissionDomainId',
+          childSkillIndexInputValueName: 'childSkillIndex',
+        },
+      ],
     });
     this.addTask = new AddTask({
       client: this,

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -27,6 +27,8 @@ import SetFounderRole from './senders/SetFounderRole';
 import addRecoveryMethods from '../addRecoveryMethods';
 
 import {
+  COLONY_ROLE_ADMINISTRATION,
+  COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
   COLONY_ROLE_ARCHITECTURE,
   COLONY_ROLE_FUNDING,
   COLONY_ROLES,
@@ -1924,10 +1926,10 @@ export default class ColonyClient extends ContractClient {
       },
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });
@@ -1950,10 +1952,10 @@ export default class ColonyClient extends ContractClient {
       },
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });
@@ -1980,17 +1982,22 @@ export default class ColonyClient extends ContractClient {
       },
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          // TODO: these need to be proof for the OneTx extension contract
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          address: async () => {
+            const { address } = await this.getExtensionAddress.call({
+              contractName: 'OneTx',
+            });
+            return address;
+          },
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION, // TODO: also need to have COLONY_ROLE_FUNDING
         },
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'callerPermissionDomainId',
-          childSkillIndexInputValueName: 'callerChildSkillIndex',
+          childSkillIndexNames: ['callerChildSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'callerPermissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION, // TODO: also need to have COLONY_ROLE_FUNDING
         },
       ],
     });
@@ -2023,10 +2030,10 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'parentDomainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['parentDomainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ARCHITECTURE,
         },
       ],
     });
@@ -2041,10 +2048,13 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: () => Promise.resolve(1), // TODO: fetch this from the task
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: async ({ paymentId }) => {
+            const { domainId } = await this.getPayment.call({ paymentId });
+            return [domainId];
+          },
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });
@@ -2063,16 +2073,13 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: ({ fromPot }) => getDomainIdFromPot(fromPot, this),
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'fromChildSkillIndex',
-        },
-        {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: ({ toPot }) => getDomainIdFromPot(toPot, this),
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'toChildSkillIndex',
+          childSkillIndexNames: ['fromChildSkillIndex', 'toChildSkillIndex'],
+          domainIds: async ({ fromPot, toPot }) => [
+            await getDomainIdFromPot(fromPot, this),
+            await getDomainIdFromPot(toPot, this),
+          ],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_FUNDING,
         },
       ],
     });
@@ -2089,10 +2096,10 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2109,10 +2116,10 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2129,10 +2136,10 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: 'domainId',
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: ['domainId'],
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2149,13 +2156,13 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: async ({ paymentId }) => {
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: async ({ paymentId }) => {
             const { domainId } = await this.getPayment.call({ paymentId });
-            return domainId;
+            return [domainId];
           },
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });
@@ -2171,13 +2178,13 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: async ({ paymentId }) => {
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: async ({ paymentId }) => {
             const { domainId } = await this.getPayment.call({ paymentId });
-            return domainId;
+            return [domainId];
           },
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });
@@ -2193,13 +2200,13 @@ export default class ColonyClient extends ContractClient {
       ],
       permissions: [
         {
-          role: COLONY_ROLE_FUNDING, // TODO: what does this need to be
-          domainId: async ({ paymentId }) => {
+          childSkillIndexNames: ['childSkillIndex'],
+          domainIds: async ({ paymentId }) => {
             const { domainId } = await this.getPayment.call({ paymentId });
-            return domainId;
+            return [domainId];
           },
-          permissionDomainIdInputValueName: 'permissionDomainId',
-          childSkillIndexInputValueName: 'childSkillIndex',
+          permissionDomainIdName: 'permissionDomainId',
+          role: COLONY_ROLE_ADMINISTRATION,
         },
       ],
     });

--- a/packages/colony-js-client/src/ColonyClient/senders/AddPayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/AddPayment.js
@@ -1,38 +1,13 @@
 /* @flow */
 
-import ContractClient from '@colony/colony-js-contract-client';
-
-import type BigNumber from 'bn.js';
-import type ColonyClient from '../index';
-
-type Address = string;
-type TokenAddress = string;
-
-type InputValues = {
-  permissionDomainId: number,
-  childSkillIndex: number,
-  recipient: Address,
-  token: TokenAddress,
-  amount: BigNumber,
-  domainId: number,
-  skillId: number,
-};
-
-type OutputValues = {
-  id: number,
-};
+import DomainAuth from './DomainAuth';
 
 // XXX This is a good use-case for some kind of async validation step,
 // but since the underlying method functionality is due to change very soon,
 // we're opting to not make big changes to the Sender behaviour, and simply
 // extend the `send` method to perform this async validation.
-export default class AddPayment extends ContractClient.Sender<
-  InputValues,
-  OutputValues,
-  ColonyClient,
-  *,
-> {
-  async send(inputValues: InputValues, options: *) {
+export default class AddPayment extends DomainAuth<*, *, *> {
+  async send(inputValues: *, options: *) {
     // Validate that the domain exists before attempting to create a task
     if (Object.hasOwnProperty.call(inputValues, 'domainId')) {
       const { count } = await this.client.getDomainCount.call();

--- a/packages/colony-js-client/src/ColonyClient/senders/AddTask.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/AddTask.js
@@ -1,32 +1,13 @@
 /* @flow */
 
-import ContractClient from '@colony/colony-js-contract-client';
-import type ColonyClient from '../index';
-
-type InputValues = {
-  permissionDomainId: number,
-  childSkillIndex: number,
-  specificationHash: string,
-  domainId: number,
-  skillId: number,
-  dueDate: Date,
-};
-
-type OutputValues = {
-  id: number,
-};
+import DomainAuth from './DomainAuth';
 
 // XXX This is a good use-case for some kind of async validation step,
 // but since the underlying method functionality is due to change very soon,
 // we're opting to not make big changes to the Sender behaviour, and simply
 // extend the `send` method to perform this async validation.
-export default class AddTask extends ContractClient.Sender<
-  InputValues,
-  OutputValues,
-  ColonyClient,
-  *,
-> {
-  async send(inputValues: InputValues, options: *) {
+export default class AddTask extends DomainAuth<*, *, *> {
+  async send(inputValues: *, options: *) {
     // Validate that the domain exists before attempting to create a task
     if (Object.hasOwnProperty.call(inputValues, 'domainId')) {
       const { count } = await this.client.getDomainCount.call();

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -23,9 +23,9 @@ type PermissionType = {|
 |};
 
 export default class DomainAuth<
-  InputValues: { [inputValueName: string]: any },
-  OutputValues: { [outputValueName: string]: any },
-  ContractData: { [dataValueName: string]: any },
+  InputValues: *,
+  OutputValues: *,
+  ContractData: *,
 > extends ContractClient.Sender<
   InputValues,
   OutputValues,
@@ -35,13 +35,20 @@ export default class DomainAuth<
   _permissions: PermissionType[];
 
   constructor({
+    client,
+    defaultGasLimit,
     permissions,
+    validateEmpty,
     ...rest
   }: ContractMethodSenderArgs<ColonyClient> & {
     permissions: PermissionType[],
   }) {
-    // $FlowFixMe why does it think things are missing?
-    super(rest);
+    super({
+      client,
+      defaultGasLimit,
+      validateEmpty,
+      ...rest,
+    });
     this._permissions = permissions;
   }
 
@@ -60,7 +67,6 @@ export default class DomainAuth<
     // get proof input values
     const proofs = await this.getPermissionProofs(inputValues);
 
-    // $FlowFixMe needs to be InputValues plus extra values from permissions
     return super.send(
       {
         ...inputValues,
@@ -75,7 +81,7 @@ export default class DomainAuth<
    * childSkillIndex as proof of permission, under the specified input value
    * keys. Return an object of input values.
    */
-  async getPermissionProofs(inputValues: InputValues) {
+  async getPermissionProofs(inputValues: InputValues): Promise<Object> {
     const proofs = await Promise.all(
       this._permissions.map(
         async ({
@@ -176,9 +182,8 @@ export default class DomainAuth<
       domainId: 1,
       role,
     });
-    if (hasRootPermission) return 1;
 
-    return -1;
+    return hasRootPermission ? 1 : -1;
   }
 
   /**

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -1,0 +1,231 @@
+/* @flow */
+/* eslint-disable no-underscore-dangle */
+
+import ContractClient from '@colony/colony-js-contract-client';
+// eslint-disable-next-line max-len
+import type { ContractMethodSenderArgs } from '@colony/colony-js-contract-client';
+
+import { COLONY_ROLES } from '../../constants';
+
+import type { ColonyClient } from '../../index';
+
+type ColonyRole = $Keys<typeof COLONY_ROLES>;
+
+type PermissionType = {|
+  // the role required
+  role: ColonyRole,
+  // the name of the input value containing the domainId in which the role is required
+  domainIdInputValueName: string,
+  // the name of the output value to set as the permisisonDomainId
+  permissionDomainIdInputValueName: string,
+  // the name of the output value to set as the childSkillIndex
+  childSkillIndexInputValueName: string,
+|};
+
+export default class DomainAuth<
+  InputValues: { [inputValueName: string]: any },
+  OutputValues: { [outputValueName: string]: any },
+  ContractData: { [dataValueName: string]: any },
+> extends ContractClient.Sender<
+  InputValues,
+  OutputValues,
+  ColonyClient,
+  ContractData,
+> {
+  _permissions: PermissionType[];
+
+  constructor({
+    permissions,
+    ...rest
+  }: ContractMethodSenderArgs<ColonyClient> & {
+    permissions: PermissionType[],
+  }) {
+    // $FlowFixMe why does it think things are missing?
+    super(rest);
+    this._permissions = permissions;
+  }
+
+  async send(inputValues: InputValues, options: *) {
+    // if for some reason we don't have the required methods, then throw
+    if (
+      !(
+        this.client.networkClient &&
+        this.client.networkClient.getParentSkillId &&
+        this.client.hasColonyRole
+      )
+    ) {
+      throw new Error('Client not compatible with DomainAuth sender');
+    }
+
+    // get proof input values
+    const proofs = await this.getPermissionProofs(inputValues);
+
+    // $FlowFixMe needs to be InputValues plus extra values from permissions
+    return super.send(
+      {
+        ...inputValues,
+        ...proofs,
+      },
+      options,
+    );
+  }
+
+  /**
+   * For each required permission, get the permissionDomainId and
+   * childSkillIndex as proof of permission, under the specified input value
+   * keys. Return an object of input values.
+   */
+  async getPermissionProofs(inputValues: InputValues) {
+    const proofs = await Promise.all(
+      this._permissions.map(
+        async ({
+          role,
+          domainIdInputValueName,
+          permissionDomainIdInputValueName,
+          childSkillIndexInputValueName,
+        }) => {
+          const [
+            permissionDomainId,
+            childSkillIndex,
+          ] = await this.getPermissionProof(
+            inputValues[domainIdInputValueName],
+            role,
+          );
+          return {
+            [permissionDomainIdInputValueName]: permissionDomainId,
+            [childSkillIndexInputValueName]: childSkillIndex,
+          };
+        },
+      ),
+    );
+    return proofs.reduce((acc, proof) => ({ ...acc, ...proof }));
+  }
+
+  /**
+   * For a given domainId and role, if we have permission for that role in that
+   * domain, get the permissionDomainId and childSkillIndex as proof of that
+   * fact.
+   */
+  async getPermissionProof(domainId: number, role: ColonyRole) {
+    // check for permission in that domain
+    const permissionDomainId = await this.hasPermission(domainId, role);
+
+    if (permissionDomainId < 0) {
+      // don't continue if tx will fail
+      throw new Error('Current wallet address does not have permission');
+    } else if (permissionDomainId === domainId) {
+      // if we have permission in immediate domain we know index will be zero
+      return [permissionDomainId, 0]; // TODO: is this correct?
+    }
+
+    // get the permission and child domain skills
+    const {
+      skillId: permissionDomainSkillId,
+    } = await this.client.getDomain.call({
+      domainId: permissionDomainId,
+    });
+    const { skillId: childDomainSkillId } = await this.client.getDomain.call({
+      domainId,
+    });
+
+    // get all the child skills of the permission domain skill
+    const {
+      children: permissionDomainSkillChildren,
+    } = await this.client.networkClient.getSkill.call({
+      skillId: permissionDomainSkillId,
+    });
+
+    // find the index of the child domain skill in the permission domain skill children
+    const childSkillIndex = permissionDomainSkillChildren.findIndex(
+      childSkillId => childSkillId === childDomainSkillId,
+    );
+
+    // this should never happen, but if we can't find the index then throw
+    if (childSkillIndex < 0) {
+      throw new Error(
+        'Unable to find child domain skill in permission domain skill children',
+      );
+    }
+
+    return [permissionDomainId, childSkillIndex];
+  }
+
+  /**
+   * For colonies which are limited to one level of domain, determine whether
+   * the current wallet address has permission for a role in a given domain.
+   * Returns the domainId in which we have permission.
+   */
+  async hasPermission(domainId: number, role: ColonyRole): Promise<number> {
+    const address = await this.client.adapter.wallet.getAddress();
+
+    // if we have permission in the specified domain, return that
+    const {
+      hasColonyRole: hasDomainPermission,
+    } = await this.client.hasColonyRole.call({
+      address,
+      domainId,
+      role,
+    });
+    if (hasDomainPermission) return domainId;
+
+    // if we have permission in root domain, return that
+    const {
+      hasColonyRole: hasRootPermission,
+    } = await this.client.hasColonyRole.call({
+      address,
+      domainId: 1,
+      role,
+    });
+    if (hasRootPermission) return 1;
+
+    return -1;
+  }
+
+  /**
+   * For colonies with multiple levels of domains, determine whether the
+   * current wallet address has permission for a role in a given domain.
+   * Returns the domainId in which we have permission.
+   *
+   * NOTE: this is not currently used
+   * TODO: it's broken
+   */
+  async hasPermissionMultiLevel(
+    domainId: number,
+    role: ColonyRole,
+  ): Promise<number> {
+    const address = await this.client.adapter.wallet.getAddress();
+
+    // check for permission in that domain
+    let { hasColonyRole: hasPermission } = await this.client.hasColonyRole.call(
+      {
+        address,
+        domainId,
+        role,
+      },
+    );
+
+    // keep searching up the domain tree until we have permission
+    let currentDomainId = domainId;
+    while (!hasPermission && currentDomainId !== 1) {
+      // get the parent domain
+      // TODO: this is getting the parent skill
+      ({
+        parentSkillId: currentDomainId,
+        // eslint-disable-next-line no-await-in-loop
+      } = await this.client.networkClient.getParentSkillId.call({
+        skillId: currentDomainId,
+        parentSkillIndex: 0,
+      }));
+
+      // check for permission in that
+      // eslint-disable-next-line no-await-in-loop
+      ({ hasColonyRole: hasPermission } = await this.client.hasColonyRole.call({
+        address,
+        domainId: currentDomainId,
+        role,
+      }));
+    }
+
+    return hasPermission ? currentDomainId : -1;
+  }
+}

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
@@ -1,27 +1,8 @@
 /* @flow */
 
-import ContractClient from '@colony/colony-js-contract-client';
+import DomainAuth from './DomainAuth';
 
-import type BigNumber from 'bn.js';
-import type ColonyClient from '../index';
-
-type Address = string;
-type TokenAddress = string;
-
-type InputValues = {
-  worker: Address,
-  token: TokenAddress,
-  amount: BigNumber,
-  domainId: number,
-  skillId: number,
-};
-
-export default class OneTxPayment extends ContractClient.Sender<
-  InputValues,
-  *,
-  ColonyClient,
-  *,
-> {
+export default class MakePayment extends DomainAuth<*, *, *> {
   async _sendTransaction(args: *, options: *) {
     const factoryContract = await this.client.adapter.getContract({
       contractName: 'OneTxPaymentFactory',

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -55,7 +55,7 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: 'erc20.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
@@ -74,10 +74,10 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: 'token.sol',
+      contract: 'Token.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
-      version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts',
+      version: '8d3a50719cd51459db153006b5bd56c031e9d169',
     },
   >;
   /*
@@ -94,7 +94,7 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       function: 'allowance',
-      contract: 'erc20.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
@@ -113,7 +113,7 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       function: 'balanceOf',
-      contract: 'erc20.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
@@ -134,7 +134,7 @@ export default class TokenClient extends ContractClient {
       contract: 'Token.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts',
-      version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
+      version: '8d3a50719cd51459db153006b5bd56c031e9d169',
     },
   >;
   /*
@@ -148,7 +148,7 @@ export default class TokenClient extends ContractClient {
     TokenClient,
     {
       function: 'totalSupply',
-      contract: 'erc20.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
@@ -167,10 +167,10 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: 'token.sol',
+      contract: 'Token.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
-      version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts',
+      version: '8d3a50719cd51459db153006b5bd56c031e9d169',
     },
   >;
   /*
@@ -189,22 +189,6 @@ export default class TokenClient extends ContractClient {
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
-    },
-  >;
-  /*
-  Set the `name` of a token contract. This function can only be called by the current `owner` of the contract. In order to call token contract methods from within a colony, the token `owner` must be the address of the colony contract.
-  */
-  setName: TokenClient.Sender<
-    {
-      name: string, // The name of the token that will be set.
-    },
-    {},
-    TokenClient,
-    {
-      contract: 'token.sol',
-      // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/dapphub/dappsys-monolithic/tree/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
-      version: '9ddf14118cd0436a19a7278282e4b8a607e14b54',
     },
   >;
   /*
@@ -236,7 +220,7 @@ export default class TokenClient extends ContractClient {
     {},
     TokenClient,
     {
-      contract: 'erc20.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
       contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
@@ -256,10 +240,10 @@ export default class TokenClient extends ContractClient {
     },
     TokenClient,
     {
-      contract: 'Token.sol',
+      contract: 'base.sol',
       // eslint-disable-next-line max-len
-      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts',
-      version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
+      contractPath: 'https://github.com/dapphub/dappsys-monolithic/blob/de9114c5fa1b881bf16b1414e7ed90cd3cb2e361',
+      version: '8d3a50719cd51459db153006b5bd56c031e9d169',
     },
   >;
   /*
@@ -342,9 +326,6 @@ export default class TokenClient extends ContractClient {
     });
     this.addSender('burn', {
       input: [user, amount],
-    });
-    this.addSender('setName', {
-      input: [['name', 'bytes32String']],
     });
     this.addSender('setOwner', {
       input: [['owner', 'address']],

--- a/packages/colony-js-contract-client/src/index.js
+++ b/packages/colony-js-contract-client/src/index.js
@@ -6,6 +6,7 @@ export { addParamType } from './modules/paramTypes';
 
 export type {
   ContractClientConstructorArgs,
+  ContractMethodSenderArgs,
   ContractResponse,
   MultisigOperationConstructorArgs,
   SendOptions,

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -57,7 +57,11 @@ const PARAM_TYPE_MAP: {
     },
     convertOutput(value) {
       if (!Array.isArray(value)) return [];
-      return value.map(element => (Number.isFinite(element) ? element : null));
+      return value.map(element => {
+        // convert BN (ethers or bn.js)
+        const number = isBigNumber(element) ? element.toNumber() : element;
+        return Number.isFinite(number) ? number : null;
+      });
     },
     convertInput: passThrough,
   },


### PR DESCRIPTION
## Description

This PR adds the `DomainAuth` sender, which is used for methods which require a permission "proof" to be sent as arguments. This is the `_permissionDomainId` and `_childSkillIndex` seen in many colonyNetwork functions.

The `DomainAuth` sender works out what these values should be without any additional input from the user. Based on the `domainId` in which the user is trying to do something, and the `role` which they need in that domain, it will search the domain and all its parents until it finds a domain in which the user has permission - or if it fails to find it, the user does not have permission and the sender throws.

## TODO

- [x] Set the correct `role` for all senders in the `ColonyClient`
- [x] Refactor to allow for the case where there are multiple domains under a shared permission domain (`moveFundsBetweenPots`)

Closes #386 
