### PR TITLE
Add createTokenAuthority sender to TokenClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This release implements a lot of changes and additions in preparation for the up
 
 Also, please note that colonyJS is currently using `ethers` version `3.0.27`.
 
+**New Features**
+
+* Added `createTokenAuthority`method (`@colony/colony-js-client`)
+
 **Types**
 
 * Added `[number]` param type (`@colony/colony-js-contract-client`)

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -402,6 +402,39 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3
   
   
 
+### `createTokenAuthority.send({ allowedToTransfer, colonyAddress, tokenAddress }, options)`
+
+Deploy a TokenAuthority contract which can then be use to control the transfer of a token.
+
+**Input**
+
+|Name|Type|Description|
+|---|---|---|
+|allowedToTransfer|undefined|Additional addresses which are allowed to transfer the token while locked.|
+|colonyAddress|address|The address of the colony which should be allowed control of the token.|
+|tokenAddress|address|The address of the token for which this contract will operate.|
+
+**Options**
+
+See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
+
+**Response**
+
+An instance of a `ContractResponse` which will receive a receipt with a `contractAddress` property.
+
+
+
+See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
+
+**Contract Information**
+
+
+  
+  
+Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts/Token.sol)
+  
+  
+
   
   
 ## Events

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -169,7 +169,7 @@ See [Sender](/colonyjs/api-contractclient/#sender) for more information about op
 
 An instance of a \`ContractResponse\`${
   // XXX If this gets even more complicated, find another way!
-  sender.name === 'createToken'
+  sender.name === 'createToken' || sender.name === 'createTokenAuthority'
     ? ' which will receive a receipt with a \`contractAddress\` property.'
     : (
         sender.events && sender.events.length

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -2,6 +2,7 @@
 
 import BigNumber from 'bn.js';
 import ContractClient from '@colony/colony-js-contract-client';
+import CreateTokenAuthority from './senders/CreateTokenAuthority';
 import GetTokenInfo from './callers/GetTokenInfo';
 
 type Address = string;
@@ -261,6 +262,24 @@ export default class TokenClient extends ContractClient {
       version: '5acd5e2526ffdd9b9577b340f9c8dcf3c22df5ce',
     },
   >;
+  /*
+  Deploy a TokenAuthority contract which can then be use to control the transfer of a token.
+  */
+  createTokenAuthority: TokenClient.Sender<
+    {
+      allowedToTransfer: Address[], // Additional addresses which are allowed to transfer the token while locked.
+      colonyAddress: Address, // The address of the colony which should be allowed control of the token.
+      tokenAddress: Address, // The address of the token for which this contract will operate.
+    },
+    {},
+    TokenClient,
+    {
+      contract: 'Token.sol',
+      // eslint-disable-next-line max-len
+      contractPath: 'https://github.com/JoinColony/colonyToken/blob/7cc7d6b5bf3e94e6d97cd65583e3da38a994753f/contracts',
+      version: '8d3a50719cd51459db153006b5bd56c031e9d169',
+    },
+  >;
 
   static get defaultQuery() {
     return {
@@ -308,6 +327,7 @@ export default class TokenClient extends ContractClient {
     });
 
     // Senders
+    this.createTokenAuthority = new CreateTokenAuthority({ client: this });
     this.addSender('transfer', {
       input: [destinationAddress, amount],
     });

--- a/packages/colony-js-client/src/TokenClient/senders/CreateTokenAuthority.js
+++ b/packages/colony-js-client/src/TokenClient/senders/CreateTokenAuthority.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import ContractClient from '@colony/colony-js-contract-client';
+
+export default class CreateToken<
+  InputValues: *,
+  OutputValues: *,
+  Client: *,
+  ContractData: *,
+> extends ContractClient.Sender<
+  InputValues,
+  OutputValues,
+  Client,
+  ContractData,
+> {
+  constructor({
+    name = 'createTokenAuthority',
+    input = [
+      ['tokenAddress', 'address'],
+      ['colonyAddress', 'address'],
+      ['allowedToTransfer', '[address]'],
+    ],
+    ...props
+  }: *) {
+    super({ name, input, ...props });
+  }
+
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const transaction = await this._getContractDeployTransaction(args);
+    return this.client.adapter.provider.estimateGas(transaction);
+  }
+
+  async _sendTransaction(args: *, options: *) {
+    const transaction = await this._getContractDeployTransaction(args);
+    return this.client.adapter.wallet.sendTransaction(transaction, options);
+  }
+
+  async _getContractDeployTransaction(args: *) {
+    return this.client.adapter.getContractDeployTransaction(
+      { contractName: 'TokenAuthority' },
+      args,
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a `createTokenAuthority` sender to the `TokenClient`, which allows for deploying a `TokenAuthority` contract. The `contractAddress` you get back can then be used with the `setAuthority` method.

In the end, we don't need support for the `canCall` function, since we can check this by just attempting to call the function (or `estimateGas`) ourselves. If it errors, then we weren't allowed!

Closes #390 
