### PR TITLE
Convert Ethers BNs to bn.js in paramTypes

### DIFF
--- a/packages/colony-js-contract-client/src/__tests__/paramTypes.js
+++ b/packages/colony-js-contract-client/src/__tests__/paramTypes.js
@@ -61,7 +61,7 @@ describe('Parameter types', () => {
     expect(validateValueType(bn, 'bigNumber')).toBe(true);
 
     // Cleaning
-    expect(convertOutputValue(bn, 'bigNumber')).toBe(bn);
+    expect(convertOutputValue(bn, 'bigNumber')).toEqual(bn);
 
     expect(convertOutputValue(null, 'bigNumber')).toBe(null);
 

--- a/packages/colony-js-contract-client/src/modules/paramTypes.js
+++ b/packages/colony-js-contract-client/src/modules/paramTypes.js
@@ -46,7 +46,10 @@ const PARAM_TYPE_MAP: {
     },
     convertOutput(value) {
       if (!Array.isArray(value)) return [];
-      return value.map(element => (isBigNumber(element) ? element : null));
+      return value.map(
+        element =>
+          isBigNumber(element) ? new BigNumber(element.toString()) : null,
+      );
     },
     convertInput: passThrough,
   },
@@ -72,7 +75,7 @@ const PARAM_TYPE_MAP: {
     validate: isBigNumber,
     convertOutput(value: any) {
       if (isBigNumber(value)) {
-        return value;
+        return new BigNumber(value.toString());
       } else if (Number.isFinite(value)) {
         return new BigNumber(value);
       }


### PR DESCRIPTION
## Description

* Convert Ethers BNs to bn.js BNs in applicable paramType `convertOutput` functions

## TODO

- [ ] Should we proxy provider methods such as `getBalance` in the adapter so that we can convert BNs?

Closes #381
