### PR TITLE
Correct Token contractName and params

### DIFF
--- a/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateToken.js
@@ -15,7 +15,7 @@ export default class CreateToken<
 > {
   constructor({
     name = 'createToken',
-    input = [['symbol', 'bytes32String']],
+    input = [['name', 'string'], ['symbol', 'string'], ['decimals', 'number']],
     ...props
   }: *) {
     super({ name, input, ...props });
@@ -34,7 +34,7 @@ export default class CreateToken<
 
   async _getContractDeployTransaction(args: *) {
     return this.client.adapter.getContractDeployTransaction(
-      { contractName: 'DSToken' },
+      { contractName: 'Token' },
       args,
     );
   }

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -91,7 +91,9 @@ describe('ColonyNetworkClient', () => {
 
     sandbox.spyOn(networkClient.createToken, '_send');
 
+    const name = 'Test Token';
     const symbol = 'TST';
+    const decimals = 18;
 
     const options = { gasLimit: 400000 };
 
@@ -101,15 +103,17 @@ describe('ColonyNetworkClient', () => {
       },
     } = await networkClient.createToken.send(
       {
+        name,
         symbol,
+        decimals,
       },
       options,
     );
 
     expect(contractAddress).toBe(receipt.contractAddress);
     expect(adapter.getContractDeployTransaction).toHaveBeenCalledWith(
-      expect.objectContaining({ contractName: 'DSToken' }),
-      [`0x${symbol.padStart(64, '0')}`],
+      expect.objectContaining({ contractName: 'Token' }),
+      [name, symbol, decimals],
     );
     expect(wallet.sendTransaction).toHaveBeenCalledWith(
       deployTransaction,


### PR DESCRIPTION
## Description

This PR corrects the `contractName` to use in the `CreateToken` sender (now `Token` rather than `DSToken`), and adds all constructor parameters (`name` and `decimals`, in addition to `symbol` which was already there, but of the wrong type). A changelog entry already exists which covers this.
