### PR TITLE
Fix custom senders to correctly estimate

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/senders/AddExtension.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/AddExtension.js
@@ -14,14 +14,28 @@ export default class AddExtension extends ContractClient.Sender<
   ColonyClient,
   *,
 > {
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const factoryContract = await this._getContract(args);
+    return factoryContract.callEstimate('deployExtension', [
+      this.client.contract.address,
+    ]);
+  }
+
   async _sendTransaction(args: *, options: *) {
-    const factoryContract = await this.client.adapter.getContract({
-      contractName: `${args[0]}Factory`,
-    });
+    const factoryContract = await this._getContract(args);
     return factoryContract.callTransaction(
       'deployExtension',
       [this.client.contract.address],
       options,
     );
+  }
+
+  async _getContract(args: *) {
+    const factoryContract = await this.client.adapter.getContract({
+      contractName: `${args[0]}Factory`,
+    });
+    if (!factoryContract) throw new Error('No such extension');
+    return factoryContract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
@@ -3,7 +3,18 @@
 import DomainAuth from './DomainAuth';
 
 export default class MakePayment extends DomainAuth<*, *, *> {
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const contract = await this._getContract();
+    return contract.callEstimate('makePayment', args);
+  }
+
   async _sendTransaction(args: *, options: *) {
+    const contract = await this._getContract();
+    return contract.callTransaction('makePayment', args, options);
+  }
+
+  async _getContract() {
     const factoryContract = await this.client.adapter.getContract({
       contractName: 'OneTxPaymentFactory',
     });
@@ -11,10 +22,12 @@ export default class MakePayment extends DomainAuth<*, *, *> {
       'deployedExtensions',
       [this.client.contract.address],
     );
+    if (!contractAddress)
+      throw new Error('OneTxPayment not deployed for this Colony');
     const contract = await this.client.adapter.getContract({
       contractAddress,
       contractName: 'OneTxPayment',
     });
-    return contract.callTransaction('makePayment', args, options);
+    return contract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/RemoveExtension.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/RemoveExtension.js
@@ -14,14 +14,28 @@ export default class RemoveExtension extends ContractClient.Sender<
   ColonyClient,
   *,
 > {
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const factoryContract = await this._getContract(args);
+    return factoryContract.callEstimate('removeExtension', [
+      this.client.contract.address,
+    ]);
+  }
+
   async _sendTransaction(args: *, options: *) {
-    const factoryContract = await this.client.adapter.getContract({
-      contractName: `${args[0]}Factory`,
-    });
+    const factoryContract = await this._getContract(args);
     return factoryContract.callTransaction(
       'removeExtension',
       [this.client.contract.address],
       options,
     );
+  }
+
+  async _getContract(args: *) {
+    const factoryContract = await this.client.adapter.getContract({
+      contractName: `${args[0]}Factory`,
+    });
+    if (!factoryContract) throw new Error('No such extension');
+    return factoryContract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/SetAdminRole.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/SetAdminRole.js
@@ -17,7 +17,18 @@ export default class SetAdminRole extends ContractClient.Sender<
   ColonyClient,
   *,
 > {
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const contract = await this._getContract();
+    return contract.callEstimate('setAdminRole', args);
+  }
+
   async _sendTransaction(args: *, options: *) {
+    const contract = await this._getContract();
+    return contract.callTransaction('setAdminRole', args, options);
+  }
+
+  async _getContract() {
     const factoryContract = await this.client.adapter.getContract({
       contractName: 'OldRolesFactory',
     });
@@ -25,10 +36,12 @@ export default class SetAdminRole extends ContractClient.Sender<
       'deployedExtensions',
       [this.client.contract.address],
     );
+    if (!contractAddress)
+      throw new Error('OldRoles not deployed for this Colony');
     const contract = await this.client.adapter.getContract({
       contractAddress,
       contractName: 'OldRoles',
     });
-    return contract.callTransaction('setAdminRole', args, options);
+    return contract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/SetFounderRole.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/SetFounderRole.js
@@ -16,7 +16,18 @@ export default class SetFounderRole extends ContractClient.Sender<
   ColonyClient,
   *,
 > {
+  async estimate(inputValues: *) {
+    const args = this.getValidatedArgs(inputValues);
+    const contract = await this._getContract();
+    return contract.callEstimate('setFounderRole', args);
+  }
+
   async _sendTransaction(args: *, options: *) {
+    const contract = await this._getContract();
+    return contract.callTransaction('setFounderRole', args, options);
+  }
+
+  async _getContract() {
     const factoryContract = await this.client.adapter.getContract({
       contractName: 'OldRolesFactory',
     });
@@ -24,10 +35,12 @@ export default class SetFounderRole extends ContractClient.Sender<
       'deployedExtensions',
       [this.client.contract.address],
     );
+    if (!contractAddress)
+      throw new Error('OldRoles not deployed for this Colony');
     const contract = await this.client.adapter.getContract({
       contractAddress,
       contractName: 'OldRoles',
     });
-    return contract.callTransaction('setFounderRole', args, options);
+    return contract;
   }
 }


### PR DESCRIPTION
## Description

Custom senders in ColonyClient which interact with contracts other than the Colony contract were not correctly estimating gas, as they did not have their own appropriate estimate methods.
