### PR TITLE
Support Goerli Infura provider in getNetworkClient

### DIFF
--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -37,7 +37,7 @@ const getInfuraProvider = (network: string, infuraProjectId?: string) => {
 
   return new providers.JsonRpcProvider(
     `https://${host}/v3/${infuraProjectId || defaultInfuraProjectId}`,
-    network,
+    network === 'goerli' ? undefined : network,
   );
 };
 

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -8,10 +8,47 @@ import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
 import ColonyNetworkClient from './ColonyNetworkClient/index';
 import EthersWrappedWallet from './lib/EthersWrappedWallet/index';
 
+export const defaultInfuraProjectId = '7d0d81d0919f4f05b9ab6634be01ee73';
+
+// Adapted from Ethers 4.0 to include support for Goerli
+const getInfuraProvider = (network: string, infuraProjectId?: string) => {
+  let host;
+  switch (network) {
+    case 'homestead':
+      host = 'mainnet.infura.io';
+      break;
+    case 'ropsten':
+      host = 'ropsten.infura.io';
+      break;
+    case 'rinkeby':
+      host = 'rinkeby.infura.io';
+      break;
+    case 'goerli':
+      host = 'goerli.infura.io';
+      break;
+    case 'kovan':
+      host = 'kovan.infura.io';
+      break;
+    default:
+      throw new Error(
+        `Could not get provider, unsupported network: ${network}`,
+      );
+  }
+
+  return new providers.JsonRpcProvider(
+    `https://${host}/v3/${infuraProjectId || defaultInfuraProjectId}`,
+    network,
+  );
+};
+
 // This method provides a simple way of getting an initialized network client
 // that uses NetworkLoader for the remote network and TrufflePigLoader for a
 // local testrpc network (TrufflePig must be installed and running).
-const getNetworkClient = async (network: string, wallet: any) => {
+const getNetworkClient = async (
+  network: string,
+  wallet: any,
+  infuraProjectId?: string,
+) => {
   let loader;
   let provider;
 
@@ -27,7 +64,7 @@ const getNetworkClient = async (network: string, wallet: any) => {
     provider = new providers.JsonRpcProvider();
   } else {
     loader = new NetworkLoader({ network });
-    provider = providers.getDefaultProvider(network);
+    provider = getInfuraProvider(network, infuraProjectId);
   }
 
   // Use EthersWrappedWallet if purser wallet

--- a/packages/colony-js-contract-loader-network/src/NetworkLoader.js
+++ b/packages/colony-js-contract-loader-network/src/NetworkLoader.js
@@ -12,11 +12,11 @@ const NETWORKS = {
   GOERLI: 'goerli',
 };
 
-const DEFAULT_NETWORK = NETWORKS.RINKEBY;
+const DEFAULT_NETWORK = NETWORKS.GOERLI;
 
 type Network = $Values<typeof NETWORKS>;
 
-const LATEST_VERSION = 3;
+const LATEST_VERSION = 1;
 
 const CONTRACTS_MANIFEST = {
   // static: [],

--- a/packages/colony-js-contract-loader-network/src/__tests__/NetworkLoader.test.js
+++ b/packages/colony-js-contract-loader-network/src/__tests__/NetworkLoader.test.js
@@ -2,11 +2,11 @@
 /* eslint-disable max-len */
 
 import NetworkLoader from '../NetworkLoader';
-import EtherRouter from '../../contracts/versioned/rinkeby-v3/EtherRouter.json';
+import EtherRouter from '../../contracts/versioned/goerli-v1/EtherRouter.json';
 
 describe('colony-contract-loader-network - NetworkLoader', () => {
-  const loader = new NetworkLoader({ network: 'rinkeby' });
-  const contractAddress = '0x7da82c7ab4771ff031b66538d2fb9b0b047f6cf9';
+  const loader = new NetworkLoader({ network: 'goerli' });
+  const contractAddress = '0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B';
 
   // XXX static contracts are disabled for the moment
   // test('It should load a static contract that is defined', async () => {
@@ -32,7 +32,7 @@ describe('colony-contract-loader-network - NetworkLoader', () => {
     const contract = await loader.load({
       contractName: 'IColony',
       contractAddress,
-      version: '3',
+      version: '1',
     });
     expect(contract).toHaveProperty('abi', expect.any(Array));
     expect(contract).toHaveProperty('address', contractAddress);
@@ -46,7 +46,7 @@ describe('colony-contract-loader-network - NetworkLoader', () => {
     expect(contract).toHaveProperty('abi', expect.any(Array));
     expect(contract).toHaveProperty(
       'address',
-      EtherRouter.networks.rinkeby.address,
+      EtherRouter.networks.goerli.address,
     );
   });
 
@@ -60,7 +60,7 @@ describe('colony-contract-loader-network - NetworkLoader', () => {
       expect(false).toBe(true); // should be unreachable
     } catch (error) {
       expect(error.toString()).toMatch(
-        'Contract IColonyNetwork with version 3 not found in main',
+        'Contract IColonyNetwork with version 1 not found in main',
       );
     }
   });
@@ -71,7 +71,7 @@ describe('colony-contract-loader-network - NetworkLoader', () => {
       expect(false).toBe(true); // should be unreachable
     } catch (error) {
       expect(error.toString()).toMatch(
-        'Contract CryptoKitty with version 3 not found in rinkeby',
+        'Contract CryptoKitty with version 1 not found in goerli',
       );
     }
   });
@@ -86,7 +86,7 @@ describe('colony-contract-loader-network - NetworkLoader', () => {
       expect(false).toBe(true); // should be unreachable
     } catch (error) {
       expect(error.toString()).toMatch(
-        'Contract IColony with version 420 not found in rinkeby',
+        'Contract IColony with version 420 not found in goerli',
       );
     }
   });


### PR DESCRIPTION
## Description

Does what it says! Since we're stuck on Ethers v3 for now, this borrows some `InfuraProvider` logic from v4 so that we can support connecting to the Goerli testnet.