### PR TITLE
Fix EthersAdapter getTransactionReceipt

### DIFF
--- a/packages/colony-js-adapter-ethers/src/EthersAdapter.js
+++ b/packages/colony-js-adapter-ethers/src/EthersAdapter.js
@@ -93,8 +93,11 @@ export default class EthersAdapter implements IAdapter {
         throw error;
     }
 
-    // Wait until the transaction has been mined, then get the receipt.
-    await this.waitForTransaction(transactionHash, timeoutMs);
+    // If we didn't get the receipt, wait for the transaction and try again.
+    if (!receipt) {
+      await this.waitForTransaction(transactionHash, timeoutMs);
+    }
+
     receipt = this._getTransactionReceipt(transactionHash);
     return receipt;
   }


### PR DESCRIPTION
## Description

When the receipt for a transaction is fetched, the `getTransactionReceipt` function was then still attempting to wait for the transaction to be mined, which would never happen (since it had already happened).

**Changes** 🏗

* Only wait for transaction if receipt was not already fetched
