### PR TITLE
Fix DomainAuth sender to account for defaultValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+**Bug Fixes**
+
+* Fix `DomainAuth` sender to account for `defaultValues` (`@colony/colony-js-client`)
+
 ## v1.12.1
 
 **Bug Fixes**

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -91,11 +91,17 @@ export default class DomainAuth<
       throw new Error('Client not compatible with DomainAuth sender');
     }
 
+    // combine with default values
+    const inputValuesWithDefaults = {
+      ...(this.defaultValues || {}),
+      ...inputValues,
+    };
+
     // get proof input values
-    const proofs = await this.getPermissionProofs(inputValues);
+    const proofs = await this.getPermissionProofs(inputValuesWithDefaults);
 
     return super.estimate({
-      ...inputValues,
+      ...inputValuesWithDefaults,
       ...proofs,
     });
   }
@@ -112,12 +118,18 @@ export default class DomainAuth<
       throw new Error('Client not compatible with DomainAuth sender');
     }
 
+    // combine with default values
+    const inputValuesWithDefaults = {
+      ...(this.defaultValues || {}),
+      ...inputValues,
+    };
+
     // get proof input values
-    const proofs = await this.getPermissionProofs(inputValues);
+    const proofs = await this.getPermissionProofs(inputValuesWithDefaults);
 
     return super.send(
       {
-        ...inputValues,
+        ...inputValuesWithDefaults,
         ...proofs,
       },
       options,


### PR DESCRIPTION
## Description

The `DomainAuth` sender was not accounting for the sender's `defaultValues` when generating the permission proof.

**Changes** 🏗

* Include `defaultValues` when generating the permission proof in `DomainAuth` sender

Resolves #414 
