### PR TITLE
Fix input name for `makeExecuteTaskRoleChange`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**
 
 * Fix `DomainAuth` sender to account for `defaultValues` (`@colony/colony-js-client`)
+* Fix `makeExecuteTaskRoleChange` input to use `address` (`@colony/colony-js-client`)
 
 ## v1.12.1
 

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -2758,7 +2758,7 @@ export default class ColonyClient extends ContractClient {
       getRequiredSignees: (args: InputArgs) => Promise<any>,
     ) =>
       this.addMultisigSender(name, {
-        input: [['taskId', 'number'], ['user', 'address']],
+        input: [['taskId', 'number'], ['address', 'address']],
         getRequiredSignees: async (args: InputArgs) => {
           const { taskId, user } = args;
 


### PR DESCRIPTION
## Description

This pull request changes the input value `user` to `address` in `makeExecuteTaskRoleChange`. This is already reflected in the type declaration and the documentation examples.

**Changes** 🏗

* Update `makeExecuteTaskRoleChange`