### PR TITLE
Update docs, register ENS, and get reputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## next
 
-**New Feature**
+**New Features**
 
 * Add `getColonyClient` method (`@colony/colony-js-client`)
+* Add `mainnet` option to `getNetworkClient` (`@colony/colony-js-client`)
+* Add `mainnet` support to network loader (`@colony/colony-js-contract-loader-network`)
+* Add version 2 deployment to network loader (`@colony/colony-js-contract-loader-network`)
 
 **Bug Fixes**
 
@@ -13,14 +16,9 @@
 * Patch `lookupRegisteredENSDomain` for testnets. Domains were previously being returned ending in `.eth` on networks where the deployed ENS uses the `.test` TLD (`@colony/colony-js-client`)
 * Fix `getLogs` method to correctly format topic filters (`@colony/colony-js-contract-client`)
 
-**New Features**
-
-* Added `mainnet` option to `getNetworkClient` (`@colony/colony-js-client`)
-* Added `mainnet` support to network loader (`@colony/colony-js-contract-loader-network`)
-* Added version 2 deployment to network loader (`@colony/colony-js-contract-loader-network`)
-
 **Maintenance**
 
+* Update `getReputation` method for use with `mainnet` and `goerli` (`@colony/colony-js-client`)
 * Add `ColonyRoleSet` event, which replaces the existing role set events as the output of any methods which previously used them. The existing events remain in the client for the purpose of parsing logs which were created by previous versions of the contract (`@colony/colony-js-client`)
 * Improve thrown error for `DomainAuth` sender methods when the current address does not have permission (`@colony/colony-js-client`)
 * Remove `rinkeby` deployments from network loader, as they are no longer supported (`@colony/colony-js-contract-loader-network`)

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -2001,7 +2001,7 @@ await colonyClient.registerColonyLabel.send({
 |Name|Type|Description|
 |---|---|---|
 |colonyName|string|The ENS label that will be registered for the colony.|
-|orbitDBPath|string|The path of the OrbitDB database associated with the colony.|
+|orbitDBPath|string (optional)|The path of the OrbitDB database associated with the colony.|
 
 **Options**
 

--- a/docs/_API_ColonyClient.md
+++ b/docs/_API_ColonyClient.md
@@ -257,7 +257,7 @@ await colonyClient.getFundingPotBalance.call({
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the funding pot.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Response**
 
@@ -322,7 +322,7 @@ await colonyClient.getFundingPotPayout.call({
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the funding pot.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Response**
 
@@ -357,7 +357,7 @@ await colonyClient.getNonRewardPotsTotal.call({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Response**
 
@@ -555,7 +555,7 @@ A promise which resolves to an object containing the following properties:
 |colonyWideReputation|big number|The total reputation score throughout the colony.|
 |totalTokens|big number|The total amount of tokens at the time the reward payout was created.|
 |amount|big number|The total amount of tokens allocated for the reward payout.|
-|tokenAddress|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|tokenAddress|any address|The address of the token contract (an empty address if Ether).|
 |blockTimestamp|date|The timestamp at the time the reward payout was created.|
 
 **Contract Information**
@@ -657,7 +657,7 @@ await colonyClient.getTaskPayout.call({
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The task role (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Response**
 
@@ -864,7 +864,7 @@ await colonyClient.hasColonyRole.call({
 |---|---|---|
 |address|address|The address that will be checked for the role.|
 |domainId|number|The ID of the domain that the role is assigned.|
-|role|undefined|The role that will be checked (`RECOVERY`, `ROOT`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `ADMINISTRATION`, `FUNDING`).|
+|role|colony role|The role that will be checked (`RECOVERY`, `ROOT`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `ADMINISTRATION`, `FUNDING`).|
 
 **Response**
 
@@ -1142,7 +1142,7 @@ await colonyClient.addPayment.send({
 |Name|Type|Description|
 |---|---|---|
 |recipient|address|The address that will receive the payment.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens (or Ether) for the payment.|
 |domainId|number|The ID of the domain.|
 |skillId|number|The ID of the skill.|
@@ -1324,7 +1324,7 @@ await colonyClient.claimColonyFunds.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Options**
 
@@ -1336,7 +1336,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |fee|big number|The fee deducted from the claim and added to the colony rewards pot.|
 |payoutRemainder|big number|The remaining funds (after the fee) moved to the top-level domain pot.|
 |ColonyFundsClaimed|object|Contains the data defined in [ColonyFundsClaimed](#eventscolonyfundsclaimed)|
@@ -1370,7 +1370,7 @@ await colonyClient.claimPayment.send({
 |Name|Type|Description|
 |---|---|---|
 |paymentId|number|The ID of the payment.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Options**
 
@@ -1383,7 +1383,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the pot that was modified.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was claimed.|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
@@ -1481,7 +1481,7 @@ await colonyClient.claimTaskPayout.send({
 |---|---|---|
 |taskId|number|The ID of the task.|
 |role|task role|The task role that is claiming the payout (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Options**
 
@@ -1494,7 +1494,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the pot that was modified.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was claimed.|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
@@ -1802,7 +1802,7 @@ await colonyClient.makePayment.send({
 |Name|Type|Description|
 |---|---|---|
 |recipient|address|The address that will receive the payment.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens (or Ether) for the payment.|
 |domainId|number|The ID of the domain.|
 |skillId|number|The ID of the skill.|
@@ -1822,7 +1822,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |fromPot|number|The ID of the pot from which the funds were moved.|
 |toPot|number|The ID of the pot to which the funds were moved.|
 |amount|big number|The amount of funds that were moved between pots.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |from|address|The address of the account that sent tokens.|
 |to|address|The address of the account that received tokens.|
 |value|big number|The amount of tokens that were transferred.|
@@ -1954,7 +1954,7 @@ await colonyClient.moveFundsBetweenPots.send({
 |fromPot|number|The ID of the pot from which funds will be moved.|
 |toPot|number|The ID of the pot to which funds will be moved.|
 |amount|big number|The amount of funds that will be moved between pots.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Options**
 
@@ -1969,7 +1969,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |fromPot|number|The ID of the pot from which the funds were moved.|
 |toPot|number|The ID of the pot to which the funds were moved.|
 |amount|big number|The amount of funds that were moved between pots.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |ColonyFundsMovedBetweenFundingPots|object|Contains the data defined in [ColonyFundsMovedBetweenFundingPots](#eventscolonyfundsmovedbetweenfundingpots)|
 
 See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
@@ -2186,7 +2186,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2234,7 +2234,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2270,7 +2270,7 @@ await colonyClient.setAllTaskPayouts.send({
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |managerAmount|big number|The payout amount in tokens (or Ether) for the task `MANAGER` role.|
 |evaluatorAmount|big number|The payout amount in tokens (or Ether) for the task `EVALUATOR` role.|
 |workerAmount|big number|The payout amount in tokens (or Ether) for the task `WORKER` role.|
@@ -2287,7 +2287,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
 
@@ -2336,7 +2336,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2381,7 +2381,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2429,7 +2429,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2762,7 +2762,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 |ColonyRoleSet|object|Contains the data defined in [ColonyRoleSet](#eventscolonyroleset)|
 
@@ -2838,7 +2838,7 @@ await colonyClient.startNextRewardPayout.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |key|string|The key of the element that the proof is for.|
 |value|string|The value of the element that the proof is for.|
 |branchMask|number|The branchmask of the proof.|
@@ -2854,7 +2854,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |lockCount|number|The total lock count for the token.|
 |payoutId|number|The ID of the payout cycle that started.|
 |TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlocked)|
@@ -3315,7 +3315,7 @@ await colonyClient.setTaskEvaluatorPayout.startOperation({
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
 **Response**
@@ -3326,7 +3326,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
 
@@ -3402,7 +3402,7 @@ await colonyClient.setTaskManagerPayout.startOperation({
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
 **Response**
@@ -3413,7 +3413,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
 
@@ -3530,7 +3530,7 @@ await colonyClient.setTaskWorkerPayout.startOperation({
 |Name|Type|Description|
 |---|---|---|
 |taskId|number|The ID of the task.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The payout amount in tokens (or Ether).|
 
 **Response**
@@ -3541,7 +3541,7 @@ An instance of a `MultiSigOperation` whose sender will eventually receive the fo
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
 |TaskPayoutSet|object|Contains the data defined in [TaskPayoutSet](#eventstaskpayoutset)|
 
@@ -3780,7 +3780,7 @@ colonyClient.events.ColonyFundsClaimed.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |fee|big number|The fee deducted from the claim and added to the colony rewards pot.|
 |payoutRemainder|big number|The remaining funds (after the fee) moved to the top-level domain pot.|
 
@@ -3822,7 +3822,7 @@ colonyClient.events.ColonyFundsMovedBetweenFundingPots.removeListener(eventHandl
 |fromPot|number|The ID of the pot from which the funds were moved.|
 |toPot|number|The ID of the pot to which the funds were moved.|
 |amount|big number|The amount of funds that were moved between pots.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 
 ### `ColonyInitialised`
@@ -3858,7 +3858,7 @@ colonyClient.events.ColonyInitialised.removeListener(eventHandler);
 |Name|Type|Description|
 |---|---|---|
 |colonyNetwork|address|The address of the Colony Network.|
-|token|address (0x0 included)|The address of the token contract.|
+|token|any address|The address of the token contract.|
 
 
 ### `ColonyLabelRegistered`
@@ -3967,7 +3967,7 @@ colonyClient.events.ColonyRoleSet.removeListener(eventHandler);
 |---|---|---|
 |address|address|The address for which the role was set.|
 |domainId|number|The domain in which the role was set.|
-|role|undefined|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
+|role|colony role|The role which was set, one of: `ADMINISTRATION`, `ARBITRATION`, `ARCHITECTURE`, `ARCHITECTURE_SUBDOMAIN`, `FUNDING`, `RECOVERY` or `ROOT`.|
 |setTo|boolean|Whether the role was assigned (`true`) on unassigned (`false`).|
 
 
@@ -4251,7 +4251,7 @@ colonyClient.events.PayoutClaimed.removeListener(eventHandler);
 |Name|Type|Description|
 |---|---|---|
 |potId|number|The ID of the pot that was modified.|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was claimed.|
 
 
@@ -4715,7 +4715,7 @@ colonyClient.events.TaskPayoutSet.removeListener(eventHandler);
 |---|---|---|
 |taskId|number|The ID of the task that was modified.|
 |role|task role|The role of the task that was modified (`MANAGER`, `EVALUATOR`, or `WORKER`).|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The task payout amount that was set.|
 
 
@@ -4863,7 +4863,7 @@ colonyClient.events.TokenLocked.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |lockCount|number|The total lock count for the token.|
 
 

--- a/docs/_API_ColonyNetworkClient.md
+++ b/docs/_API_ColonyNetworkClient.md
@@ -1401,51 +1401,6 @@ Contract: [ColonyNetworkMining.sol](https://github.com/JoinColony/colonyNetwork/
 Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/glider/contracts/IColonyNetwork.sol)
   
 
-### `registerColonyLabel`
-
-Register an ENS label for a colony.
-
-```js
-await colonyNetworkClient.registerColonyLabel.send({
-  colonyName,
-  orbitDBPath,
-}, options);
-```
-
-
-**Input**
-
-|Name|Type|Description|
-|---|---|---|
-|colonyName|string|The ENS label that will be registered for the colony.|
-|orbitDBPath|string|The path of the OrbitDB database associated with the colony.|
-
-**Options**
-
-See [Sender](/colonyjs/api-contractclient/#sender) for more information about options.
-
-**Response**
-
-An instance of a `ContractResponse` which will eventually receive the following event data:
-
-|Name|Type|Description|
-|---|---|---|
-|colony|address|The address of the colony that registered a label.|
-|label|string|The ENS label that was registered for the colony.|
-|ColonyLabelRegistered|object|Contains the data defined in [ColonyLabelRegistered](#eventscolonylabelregistered)|
-
-See [Sender](/colonyjs/api-contractclient/#sendinput-options) for more information about `ContractResponse`.
-
-**Contract Information**
-
-
-  
-  
-Contract: [ColonyNetworkENS.sol](https://github.com/JoinColony/colonyNetwork/tree/glider/contracts/ColonyNetworkENS.sol)
-  
-Interface: [IColonyNetwork.sol](https://github.com/JoinColony/colonyNetwork/tree/glider/contracts/IColonyNetwork.sol)
-  
-
 ### `registerUserLabel`
 
 Register an ENS label for a user.
@@ -1463,7 +1418,7 @@ await colonyNetworkClient.registerUserLabel.send({
 |Name|Type|Description|
 |---|---|---|
 |username|string|The ENS label that will be registered for the user.|
-|orbitDBPath|string|The path of the OrbitDB database associated with the user.|
+|orbitDBPath|string (optional)|The path of the OrbitDB database associated with the user.|
 
 **Options**
 

--- a/docs/_API_TokenLockingClient.md
+++ b/docs/_API_TokenLockingClient.md
@@ -29,7 +29,7 @@ await tokenLockingClient.getTotalLockCount.call({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Response**
 
@@ -65,7 +65,7 @@ await tokenLockingClient.getUserLock.call({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |user|address|The address of the user.|
 
 **Response**
@@ -106,7 +106,7 @@ await tokenLockingClient.deposit.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
 
 **Options**
@@ -119,7 +119,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract receiving the deposit.|
+|token|any address|The address of the token contract receiving the deposit.|
 |user|address|The address of the user that deposited tokens.|
 |amount|big number|The amount of tokens that were deposited.|
 |timestamp|date|The timestamp when the tokens were deposited.|
@@ -152,7 +152,7 @@ await tokenLockingClient.lockToken.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 
 **Options**
 
@@ -164,7 +164,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract that was locked.|
+|token|any address|The address of the token contract that was locked.|
 |lockCount|big number|The address of the token contract that was assigned.|
 |TokenLocked|object|Contains the data defined in [TokenLocked](#eventstokenlocked)|
 
@@ -196,7 +196,7 @@ await tokenLockingClient.incrementLockCounterTo.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |lockId|number|The ID of the lock count that will be set.|
 
 **Options**
@@ -238,7 +238,7 @@ await tokenLockingClient.unlockTokenForUser.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |user|address|The address of the user.|
 |lockId|number|The ID of the lock count that will be set.|
 
@@ -252,7 +252,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract that was unlocked.|
+|token|any address|The address of the token contract that was unlocked.|
 |user|address|The address of the user that the tokens were unlocked for.|
 |lockId|number|The ID of the lock that the was set for the user.|
 |UserTokenUnlocked|object|Contains the data defined in [UserTokenUnlocked](#eventsusertokenunlocked)|
@@ -285,7 +285,7 @@ await tokenLockingClient.withdraw.send({
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract (an empty address if Ether).|
+|token|any address|The address of the token contract (an empty address if Ether).|
 |amount|big number|The amount of tokens that will be deposited.|
 
 **Options**
@@ -298,7 +298,7 @@ An instance of a `ContractResponse` which will eventually receive the following 
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract from which tokens were withdrawn.|
+|token|any address|The address of the token contract from which tokens were withdrawn.|
 |user|address|The address of the user that withdrew tokens.|
 |amount|big number|The amount of tokens that were withdrawn.|
 |UserTokenWithdrawn|object|Contains the data defined in [UserTokenWithdrawn](#eventsusertokenwithdrawn)|
@@ -352,7 +352,7 @@ tokenLockingClient.events.TokenLocked.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract that was locked.|
+|token|any address|The address of the token contract that was locked.|
 |lockCount|big number|The address of the token contract that was assigned.|
 
 
@@ -390,7 +390,7 @@ tokenLockingClient.events.UserTokenDeposited.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract receiving the deposit.|
+|token|any address|The address of the token contract receiving the deposit.|
 |user|address|The address of the user that deposited tokens.|
 |amount|big number|The amount of tokens that were deposited.|
 |timestamp|date|The timestamp when the tokens were deposited.|
@@ -429,7 +429,7 @@ tokenLockingClient.events.UserTokenUnlocked.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract that was unlocked.|
+|token|any address|The address of the token contract that was unlocked.|
 |user|address|The address of the user that the tokens were unlocked for.|
 |lockId|number|The ID of the lock that the was set for the user.|
 
@@ -467,6 +467,6 @@ tokenLockingClient.events.UserTokenWithdrawn.removeListener(eventHandler);
 
 |Name|Type|Description|
 |---|---|---|
-|token|address (0x0 included)|The address of the token contract from which tokens were withdrawn.|
+|token|any address|The address of the token contract from which tokens were withdrawn.|
 |user|address|The address of the user that withdrew tokens.|
 |amount|big number|The amount of tokens that were withdrawn.|

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -24,6 +24,13 @@ const networkClient = getNetworkClient('goerli', wallet);
 
 ```
 
+```js
+
+// Get the network client using the main network
+const networkClient = getNetworkClient('mainnet', wallet);
+
+```
+
 
 If you are using this method with the `local` option, you will need to have [trufflepig](https://github.com/JoinColony/trufflepig) installed and running. We recommend using [purser](/purser/docs-overview) to get a wallet instance but you can also use [ethers](https://github.com/ethers-io/ethers.js/).
 

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -38,6 +38,15 @@ const networkClient = getNetworkClient('mainnet', wallet);
 
 ```
 
+If you would like to use a specific Infura Project ID, you can pass it in as a third parameter.
+
+```js
+
+// Get the network client using the main network using a Infura Project ID
+const networkClient = getNetworkClient('mainnet', wallet, infuraProjectId);
+
+```
+
 If you are using this method with the `local` option, you will need to have [trufflepig](https://github.com/JoinColony/trufflepig) installed and running. We recommend using [purser](/purser/docs-overview) to get a wallet instance but you can also use [ethers](https://github.com/ethers-io/ethers.js/).
 
 Alternatively, you can create an instance of [ColonyNetworkClient](/colonyjs/api-colonynetworkclient) by instantiating its class using an adapter and then initializing it using the `init` method:
@@ -81,6 +90,20 @@ const colonyClient = getColonyClient(colonyAddress, 'goerli', wallet);
 
 // Get the colony client using the main network
 const colonyClient = getColonyClient(colonyAddress, 'mainnet', wallet);
+
+```
+
+If you would like to use a specific Infura Project ID, you can pass it in as a fourth parameter.
+
+```js
+
+// Get the network client using the main network using a specific Infura Project ID
+const networkClient = getColonyClient(
+  colonyAddress,
+  'mainnet',
+  wallet,
+  infuraProjectId,
+);
 
 ```
 

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -31,7 +31,6 @@ const networkClient = getNetworkClient('mainnet', wallet);
 
 ```
 
-
 If you are using this method with the `local` option, you will need to have [trufflepig](https://github.com/JoinColony/trufflepig) installed and running. We recommend using [purser](/purser/docs-overview) to get a wallet instance but you can also use [ethers](https://github.com/ethers-io/ethers.js/).
 
 Alternatively, you can create an instance of [ColonyNetworkClient](/colonyjs/api-colonynetworkclient) by instantiating its class using an adapter and then initializing it using the `init` method:
@@ -48,7 +47,32 @@ See [Adapters](/colonyjs/components-adapters) for more information about adapter
 
 ## Colony Client
 
-Ask the [ColonyNetworkClient](/colonyjs/api-colonynetworkclient) for an instance of [ColonyClient](/colonyjs/api-colonyclient):
+Use `getColonyClient` to get an instance of [ColonyClient](/colonyjs/api-colonyclient):
+
+```js
+
+// Get the colony client using the local network
+const colonyClient = getColonyClient(colonyAddress, 'local', wallet);
+
+```
+
+```js
+
+// Get the colony client using the goerli network
+const colonyClient = getColonyClient(colonyAddress, 'goerli', wallet);
+
+```
+
+```js
+
+// Get the colony client using the main network
+const colonyClient = getColonyClient(colonyAddress, 'mainnet', wallet);
+
+```
+
+If you are using this method with the `local` option, you will need to have [trufflepig](https://github.com/JoinColony/trufflepig) installed and running. We recommend using [purser](/purser/docs-overview) to get a wallet instance but you can also use [ethers](https://github.com/ethers-io/ethers.js/).
+
+Alternatively, you can get an instance of [ColonyClient](/colonyjs/api-colonyclient) from the [ColonyNetworkClient](/colonyjs/api-colonynetworkclient):
 
 ```js
 
@@ -56,7 +80,7 @@ const colonyClient = await networkClient.getColonyClient(colonyId);
 
 ```
 
-Alternatively, you can create an instance of [ColonyClient](/colonyjs/api-colonyclient) by instantiating the [ColonyClient](/colonyjs/api-colonyclient) class using an adapter and query and then initializing it using the `init` method:
+And like [ColonyNetworkClient](/colonyjs/api-colonynetworkclient), you can create an instance of [ColonyClient](/colonyjs/api-colonyclient) by instantiating the [ColonyClient](/colonyjs/api-colonyclient) class using an adapter and query and then initializing it using the `init` method:
 
 ```js
 

--- a/docs/_Components_Clients.md
+++ b/docs/_Components_Clients.md
@@ -12,6 +12,13 @@ Use `getNetworkClient` to get an instance of [ColonyNetworkClient](/colonyjs/api
 
 ```js
 
+// Import the getNetworkClient method
+const { getNetworkClient } = require('@colony/colony-js-client');
+
+```
+
+```js
+
 // Get the network client using the local network
 const networkClient = getNetworkClient('local', wallet);
 
@@ -48,6 +55,13 @@ See [Adapters](/colonyjs/components-adapters) for more information about adapter
 ## Colony Client
 
 Use `getColonyClient` to get an instance of [ColonyClient](/colonyjs/api-colonyclient):
+
+```js
+
+// Import the getColonyClient method
+const { getColonyClient } = require('@colony/colony-js-client');
+
+```
 
 ```js
 

--- a/docs/_Topics_RegisteringENSLabels.md
+++ b/docs/_Topics_RegisteringENSLabels.md
@@ -1,0 +1,61 @@
+---
+title: Registering ENS Labels
+section: Topics
+order: 9
+---
+
+Register a custom ENS label for your colony and wallet address.
+
+## Register Colony Label
+
+You can register a colony label using an instance of [ColonyClient](/colonyjs/api-colonyclient):
+
+```js
+
+// Register a colony label
+const register = await colonyClient.registerColonyLabel.send({
+  colonyName: 'mycolony',
+});
+
+```
+
+You can also set an OrbitDBPath when you register a colony label:
+
+```js
+
+// Register a colony label
+const register = await colonyClient.registerColonyLabel.send({
+  colonyName: 'mycolony',
+  orbitDBPath: 'Qm...'
+});
+
+```
+
+*Note: The `orbitDBPath` will link your colony with your colony profile within our dApp. Updating the `orbitDBPath` is currently not possible but it will be in a future version of colonyNetwork, therefore, if you register a colony label outside of the dApp without setting an `orbitDBPath`, you will not be able to update the `orbitDBPath` until a future release of colonyNetwork.*
+
+## Register User Label
+
+You can register a user label using an instance of [ColonyNetworkClient](/colonyjs/api-colonynetworkclient):
+
+```js
+
+// Register a user label
+const register = await colonyClient.registerUserLabel.send({
+  username: 'colonyuser',
+});
+
+```
+
+You can also set an OrbitDBPath when you register a user label:
+
+```js
+
+// Register a user label
+const register = await colonyClient.registerUserLabel.send({
+  username: 'colonyuser',
+  orbitDBPath: 'Qm...'
+});
+
+```
+
+*Note: The `orbitDBPath` will link your wallet with your user profile within our dApp. Updating the `orbitDBPath` is currently not possible but it will be in a future version of colonyNetwork, therefore, if you register a user label outside of the dApp without setting an `orbitDBPath`, you will not be able to update the `orbitDBPath` until a future release of colonyNetwork.*

--- a/docs/_Topics_ReputationAndRewards.md
+++ b/docs/_Topics_ReputationAndRewards.md
@@ -19,7 +19,7 @@ To get the reputation score for a given address within a particular domain or sk
 // Get reputation using colony client
 await colonyClient.getReputation.send({
   skillId: 1,
-  user: '0x0...',
+  address: '0x0...',
 });
 
 ```
@@ -30,9 +30,9 @@ await colonyClient.getReputation.send({
 await networkClient.getReputation.send({
   colonyAddress: '0x0...',
   skillId: 1,
-  user: '0x0...',
+  address: '0x0...',
 });
 
 ```
 
-*Note: Currently this method is only supported on rinkeby.*
+*Note: Currently this method is only supported on goerli and mainnet.*

--- a/docs/_Topics_ReputationAndRewards.md
+++ b/docs/_Topics_ReputationAndRewards.md
@@ -35,4 +35,4 @@ await networkClient.getReputation.send({
 
 ```
 
-*Note: Currently this method is only supported on goerli and mainnet.*
+*Note: This method will not work when connected to a local test network. This method will only work when connected to goerli or mainnet.*

--- a/docs/_Topics_UsingIPFS.md
+++ b/docs/_Topics_UsingIPFS.md
@@ -1,7 +1,7 @@
 ---
 title: Using IPFS
 section: Topics
-order: 10
+order: 11
 ---
 
 A natural way to use the `specificationHash` and `deliverableHash` properties within a task is to point to a file hosted on IPFS. This leaves open the format for the task specification (the description of the work to be done) and the task deliverable (the work done) and provides the opportunity to use text files, PDFs, or other forms of media.

--- a/docs/_Topics_UsingMultisignature.md
+++ b/docs/_Topics_UsingMultisignature.md
@@ -1,7 +1,7 @@
 ---
 title: Using Multisignature
 section: Topics
-order: 9
+order: 10
 ---
 
 Important changes to a task within a colony must be approved by multiple "task roles". Most of the methods that modify a task require multiple signatures before the modification will take affect and the transaction will be executed. We achieve this process with something known as "multisgnature".

--- a/packages/colony-js-client/scripts/docgen.js
+++ b/packages/colony-js-client/scripts/docgen.js
@@ -35,11 +35,11 @@ const CONTRACT_CLIENTS = [
 
 const TYPES = {
   Address: 'address',
-  AnyAddress: 'address (0x0 included)',
+  AnyAddress: 'any address',
   Array: 'array',
-  AuthorityRole: 'authority role',
   BigNumber: 'big number',
   BooleanTypeAnnotation: 'boolean',
+  ColonyRole: 'colony role',
   Date: 'date',
   HexString: 'hex string',
   IPFSHash: 'IPFS hash',

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -2827,26 +2827,43 @@ export default class ColonyClient extends ContractClient {
     });
   }
 
+  /*
+  Get the reputation of an address within this colony for the given `skillId`.
+  */
   async getReputation({
-    skillId = 1,
-    user,
+    skillId,
+    address,
   }: {
     skillId: number,
-    user: Address,
+    address: Address,
   } = {}) {
     assert(Number.isFinite(skillId), 'skillId must be a number');
-    assert(isValidAddress(user), 'user must be an address');
+    assert(isValidAddress(address), 'address must be an address');
 
-    if (this.network !== 'rinkeby')
-      throw new Error(
-        'Reputation is currently only supported for contracts on Rinkeby',
-      );
+    // Throw error if private network
+    if (typeof this.network === 'undefined') {
+      throw new Error('This method is not supported on a private network');
+    }
 
+    // Throw error if not goerli or mainnet
+    if (
+      this.network !== 'goerli' &&
+      this.network !== 'mainnet' &&
+      this.network !== 'homestead'
+    ) {
+      throw new Error('This method is only supported on goerli or mainnet');
+    }
+
+    // Get the current reputation root hash
+    const { rootHash } = await this.networkClient.getReputationRootHash.call();
+
+    // Fetch current reputation
     const response = await fetch(
-      `https://colony.io/reputation/${this.network}/${
+      `https://colony.io/reputation/${this.network}/${rootHash}/${
         this.contract.address
-      }]/${skillId}/${user}`,
+      }/${skillId}/${address}`,
     );
+
     return response.json();
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1208,7 +1208,7 @@ export default class ColonyClient extends ContractClient {
   registerColonyLabel: ColonyClient.Sender<
     {
       colonyName: string, // The ENS label that will be registered for the colony.
-      orbitDBPath: string, // The path of the OrbitDB database associated with the colony.
+      orbitDBPath: ?string, // The path of the OrbitDB database associated with the colony.
     },
     {
       ColonyLabelRegistered: ColonyLabelRegistered,
@@ -2625,6 +2625,9 @@ export default class ColonyClient extends ContractClient {
     });
     this.addSender('registerColonyLabel', {
       input: [['colonyName', 'string'], ['orbitDBPath', 'string']],
+      defaultValues: {
+        orbitDBPath: '',
+      },
     });
     this.addSender('removeAdminRole', {
       input: [['user', 'address']],

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -1326,31 +1326,45 @@ export default class ColonyNetworkClient extends ContractClient {
   }
 
   /*
-  Get the reputation of a user within a colony for the given `skillId`.
+  Get the reputation of an address within a colony for the given `skillId`.
   */
   async getReputation({
     colonyAddress,
-    skillId = 1,
-    user,
+    skillId,
+    address,
   }: {
-    skillId: number,
     colonyAddress: Address,
-    user: Address,
-  }) {
-    assert(Number.isFinite(skillId), 'skillId must be a number');
-    assert(isValidAddress(user), 'user must be an address');
+    skillId: number,
+    address: Address,
+  } = {}) {
     assert(isValidAddress(colonyAddress), 'colonyAddress must be an address');
+    assert(Number.isFinite(skillId), 'skillId must be a number');
+    assert(isValidAddress(address), 'address must be an address');
 
-    if (this.network !== 'rinkeby')
-      throw new Error(
-        'Reputation is currently only supported for contracts on Rinkeby',
-      );
+    // Throw error if private network
+    if (typeof this.network === 'undefined') {
+      throw new Error('This method is not supported on a private network');
+    }
 
+    // Throw error if not goerli or mainnet
+    if (
+      this.network !== 'goerli' &&
+      this.network !== 'mainnet' &&
+      this.network !== 'homestead'
+    ) {
+      throw new Error('This method is only supported on goerli or mainnet');
+    }
+
+    // Get the current reputation root hash
+    const { rootHash } = await this.getReputationRootHash.call();
+
+    // Fetch current reputation
     const response = await fetch(
       `https://colony.io/reputation/${
         this.network
-      }/${colonyAddress}]/${skillId}/${user}`,
+      }/${rootHash}/${colonyAddress}/${skillId}/${address}`,
     );
+
     return response.json();
   }
 }

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -761,31 +761,12 @@ export default class ColonyNetworkClient extends ContractClient {
   >;
 
   /*
-  Register an ENS label for a colony.
-  */
-  registerColonyLabel: ColonyNetworkClient.Sender<
-    {
-      colonyName: string, // The ENS label that will be registered for the colony.
-      orbitDBPath: string, // The path of the OrbitDB database associated with the colony.
-    },
-    {
-      ColonyLabelRegistered: ColonyLabelRegistered,
-    },
-    ColonyNetworkClient,
-    {
-      contract: 'ColonyNetworkENS.sol',
-      interface: 'IColonyNetwork.sol',
-      version: 'glider',
-    },
-  >;
-
-  /*
   Register an ENS label for a user.
   */
   registerUserLabel: ColonyNetworkClient.Sender<
     {
       username: string, // The ENS label that will be registered for the user.
-      orbitDBPath: string, // The path of the OrbitDB database associated with the user.
+      orbitDBPath: ?string, // The path of the OrbitDB database associated with the user.
     },
     {
       UserLabelRegistered: UserLabelRegistered,
@@ -1300,11 +1281,11 @@ export default class ColonyNetworkClient extends ContractClient {
       input: [['skillId', 'number']],
     });
     this.addSender('initialiseReputationMining', {});
-    this.addSender('registerColonyLabel', {
-      input: [['colonyName', 'string'], ['orbitDBPath', 'string']],
-    });
     this.addSender('registerUserLabel', {
       input: [['username', 'string'], ['orbitDBPath', 'string']],
+      defaultValues: {
+        orbitDBPath: '',
+      },
     });
     this.addSender('setMiningResolver', {
       input: [['miningResolverAddress', 'address']],


### PR DESCRIPTION
## Description

This pull request updates documentation in preparation for the next release.

**New stuff** ✨

* Add `mainnet` option to "Components > Clients" documentation.
* Add `getColonyClient` to "Components > Clients" documentation.
* Add examples to "Components > Clients" documentation using specifc Infura Project ID.

**Changes** 🏗

* Update `getReputation` method for use on `goerli` and `mainnet`.
* Update `regsterColonyLabel` and `regsterUserLabel` so that the `orbitDBPath` is optional. The default value will be an empty string if the `orbitDBPath` is not provided.
* Change `AnyAddress` type description. `0x0` is actually invalid and the full empty address is too long to include. I think `any address` will cause less confusion as a type description with details that are already included in the parameter description such as "(empty address if ether)".

**Removed** ⚰️ 

* Removed `registerColonyLabel` method in `ColonyNetworkClient`. This method must be called by a colony and should not have been here.

## Checklist

- [x] Update "Components > Clients" documentation
- [x] Add documentation explaining how to register ENS labels
- [x] Update register label methods to make `orbitDBPath` optional
- [x] Update `getReputation` method and supporting documentation