### PR TITLE
Fix LookupRegisteredENSDomain caller for empty response

### DIFF
--- a/packages/colony-js-client/src/ColonyNetworkClient/callers/LookupRegisteredENSDomain.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/callers/LookupRegisteredENSDomain.js
@@ -12,12 +12,7 @@ export default class LookupRegisteredENSDomain extends ContractClient.Caller<
     const { domain } = super.convertOutputValues(result);
 
     // if we're on a known testnet, patch the returned ENS domain to use .test
-    // eslint-disable-next-line no-underscore-dangle
-    const { address: contractAddress } = this.client._contract;
-    if (
-      contractAddress.toLowerCase() ===
-      '0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B'.toLowerCase()
-    ) {
+    if (domain && domain.length && this.client.network === 'goerli') {
       const [name, scope] = domain.split('.');
       const patchedDomain = `${name}.${scope}.joincolony.test`;
       return { domain: patchedDomain };


### PR DESCRIPTION
## Description

The `LookupRegisteredENSDomain` caller did not contain a check for whether the returned value was undefined (in the case of a name which is not registered), causing the `convertOutputValues` method to throw.

**Changes** 🏗

* `LookupRegisteredENSDomain` `convertOutputValues` now only attempts to transform the returned value if it is set
