### PR TITLE
Update docs and token client params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
 * Remove `rinkeby` deployments from network loader, as they are no longer supported (`@colony/colony-js-contract-loader-network`)
 * Remove unused network support from `getNetworkClient` (`@colony/colony-js-client`)
 
+* Updated caller methods in `TokenClient` (`@colony/colony-js-client`)
+  * Updated `approve`
+    * Changed `user` input parameter to `address`
+  * Updated `burn`
+    * Changed `user` input parameter to `address`
+  * Updated `mint`
+    * Changed `user` input parameter to `address`
+* Updated sender methods in `TokenClient` (`@colony/colony-js-client`)
+  * Updated `getAllowance`
+    * Changed `user` input parameter to `address`
+
 ## v1.12.1
 
 **Bug Fixes**

--- a/docs/_API_TokenClient.md
+++ b/docs/_API_TokenClient.md
@@ -21,7 +21,7 @@ Get the token allowance of an address. The allowance is the amount of tokens tha
 ```js
 await tokenClient.getAllowance.call({
   sourceAddress,
-  user,
+  address,
 });
 ```
 
@@ -31,7 +31,7 @@ await tokenClient.getAllowance.call({
 |Name|Type|Description|
 |---|---|---|
 |sourceAddress|address|The address that approved the allowance (the token `owner`).|
-|user|address|The address that was approved for the allowance (the token `spender`).|
+|address|address|The address that was approved for the allowance (the token `spender`).|
 
 **Response**
 
@@ -177,7 +177,7 @@ Approve a token allowance. This function can only be called by the token `owner`
 
 ```js
 await tokenClient.approve.send({
-  user,
+  address,
   amount,
 }, options);
 ```
@@ -187,7 +187,7 @@ await tokenClient.approve.send({
 
 |Name|Type|Description|
 |---|---|---|
-|user|address|The address that will be approved for the allowance (the token `spender`).|
+|address|address|The address that will be approved for the allowance (the token `spender`).|
 |amount|big number|The amount of tokens that will be approved (the amount `allowed`).|
 
 **Options**
@@ -218,11 +218,11 @@ Contract: [base.sol](https://github.com/dapphub/dappsys-monolithic/blob/de9114c5
 
 ### `burn`
 
-Burn tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
+Burn tokens. This function can only be called by the token owner or an address with authority.
 
 ```js
 await tokenClient.burn.send({
-  user,
+  address,
   amount,
 }, options);
 ```
@@ -232,7 +232,7 @@ await tokenClient.burn.send({
 
 |Name|Type|Description|
 |---|---|---|
-|user|address|The address from which the tokens will be burned.|
+|address|address|The address from which the tokens will be burned.|
 |amount|big number|The amount of tokens that will be burned.|
 
 **Options**
@@ -304,11 +304,11 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/8e513958601
 
 ### `mint`
 
-Mint new tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
+Mint new tokens. This function can only be called by the token owner or an address with authority.
 
 ```js
 await tokenClient.mint.send({
-  user,
+  address,
   amount,
 }, options);
 ```
@@ -318,7 +318,7 @@ await tokenClient.mint.send({
 
 |Name|Type|Description|
 |---|---|---|
-|user|address|The address that will receive the minted tokens.|
+|address|address|The address that will receive the minted tokens.|
 |amount|big number|The amount of tokens that will be minted.|
 
 **Options**
@@ -348,7 +348,7 @@ Contract: [Token.sol](https://github.com/JoinColony/colonyToken/blob/8e513958601
 
 ### `setAuthority`
 
-Assign an account the `ADMIN` authority role within a colony.
+Assign an account the token authority role within a colony.
 
 ```js
 await tokenClient.setAuthority.send({
@@ -361,7 +361,7 @@ await tokenClient.setAuthority.send({
 
 |Name|Type|Description|
 |---|---|---|
-|authority|address|The address that will be assigned the `ADMIN` authority role.|
+|authority|address|The address that will be assigned the token authority role.|
 
 **Options**
 

--- a/docs/_Intro_GetStarted.md
+++ b/docs/_Intro_GetStarted.md
@@ -61,19 +61,17 @@ const { BN } = require('web3-utils');
 
   // Step 5: Get Colony Client
 
-  // Step 6: Set Token Owner
+  // Step 6: Mint Tokens
 
-  // Step 7: Mint Tokens
+  // Step 7: Claim Colony Funds
 
-  // Step 8: Claim Colony Funds
+  // Step 8: Add Payment
 
-  // Step 9: Add Payment
+  // Step 9: Move Funds
 
-  // Step 10: Move Funds
+  // Step 10: Finalize Payment
 
-  // Step 11: Finalize Payment
-
-  // Step 12: Claim Payment
+  // Step 11: Claim Payment
 
 })()
   .then(() => process.exit())
@@ -81,7 +79,7 @@ const { BN } = require('web3-utils');
 
 ```
 
-*Note: If you change the input values and encounter a bug, it is not necessary to call every method again. For example, if you provide an invalid `amount` when calling `mintTokens`, you will already have a token, a colony, and your colony will be set as the token owner, so you can comment out steps 3, 4, and 6 and use your colony address when calling `getColonyClientByAddress`.*
+*Note: If you change the input values and encounter a bug, it is not necessary to call every method again. For example, if you provide an invalid `amount` when minting tokens in step 6, you will already have a token and a colony, so you can comment out steps 3 and 4 and use your colony address when calling `getColonyClientByAddress`.*
 
 ### Step 1: Open Wallet
 
@@ -164,7 +162,7 @@ console.log('Colony Address:', colonyAddress);
 
 ### Step 5: Get Colony Client
 
-Great! You used an instance of the network client to create a token and a colony but now you need to call methods specific to your colony, which will require an instance of the colony client.
+In the previous step, you will use an instance of the network client to create a token and a colony but now you need to call methods specific to your colony, which will require the colony client.
 
 Add the following code below `// Step 5: Get Colony Client`:
 
@@ -177,33 +175,17 @@ const colonyClient = await networkClient.getColonyClientByAddress(colonyAddress)
 
 *Note: Just a friendly reminder. If you jumped ahead and started running the examples, you do not need to call `createToken` and `createColony` every time you run the script. You can use the token and colony you already created and update this method to use your colony address.*
 
-### Step 6: Set Token Owner
+### Step 6: Mint Tokens
 
-In order for you and permissioned colony members to call token methods such as `mint` and `burn` from within your colony, you will need to set the colony address as the token owner.
+In order to fund payments within your colony, you will first need to mint some tokens. If you did not change the input when calling `createToken`, which specified `18` decimals for your token, then the following `amount` will be equivalent to `1` token .
 
-Add the following code below `// Step 6: Set Token Owner`:
-
-```js
-
-// Set the colony contract as the token owner
-await colonyClient.tokenClient.setOwner.send({
-  owner: colonyAddress,
-});
-
-console.log('Token owner set!');
-
-```
-
-### Step 7: Mint Tokens
-
-In order to fund payments within your colony, you will first need to mint some tokens. If you did not change the input when calling `createToken`, which specified `18` decimals for your token, then the following `amount` will be equivalent to `1` token in the smallest unit of your token.
-
-Add the following code below `// Step 7: Mint Tokens`:
+Add the following code below `// Step 6: Mint Tokens`:
 
 ```js
 
 // Mint tokens
-await colonyClient.mintTokens.send({
+await colonyClient.tokenClient.mint.send({
+  address: colonyAddress,
   amount: new BN('1000000000000000000'),
 });
 
@@ -211,11 +193,11 @@ console.log('Tokens minted!');
 
 ```
 
-### Step 8: Claim Colony Funds
+### Step 7: Claim Colony Funds
 
 Great! You've minted your first token but before you can use it within your colony, you will need to claim it. Claiming colony funds will add any tokens owned by the colony contract to the funding pot associated with the root domain of the colony, which will also secure the availability of those funds.
 
-Add the following code below `// Step 8: Claim Colony Funds`:
+Add the following code below `// Step 7: Claim Colony Funds`:
 
 ```js
 
@@ -228,13 +210,13 @@ console.log('Colony funds claimed!');
 
 ```
 
-### Step 9: Add Payment
+### Step 8: Add Payment
 
 Now that you have funds available in the root domain of your colony, you can fund domains, tasks, and payments within your colony. The goal within this example is to make a payment, so the next step will be adding a payment to your colony.
 
-You will use your wallet address as the recipient, which you can justify as your reward for all the hard work you put in to setting up your colony. You will also use the address of the token you assigned as the native token for your colony and the id of the root domain so that you will earn reputation at the root level of your colony.
+You will use your wallet address as the recipient, which you can justify as your reward for all the hard work you put in to setting up your colony. You will also use the address of the token you assigned as the native token for your colony.
 
-Add the following code below `// Step 9: Add Payment`:
+Add the following code below `// Step 8: Add Payment`:
 
 ```js
 
@@ -243,7 +225,6 @@ const addPaymentResponse = await colonyClient.addPayment.send({
   recipient: wallet.address,
   token: tokenAddress,
   amount: new BN('1000000000000000000'),
-  domainId: 1,
 });
 
 // Set payment id and pot id
@@ -254,11 +235,11 @@ console.log('Payment Data:', { paymentId, potId });
 
 ```
 
-### Step 10: Move Funds
+### Step 9: Move Funds
 
 Next, you will need to fund your payment by moving funds from the funding pot for the colony to the funding pot for the payment. Each payment within a colony has its own funding pot in order to ensure funds are secured for that payment.
 
-Add the following code below `// Step 10: Move Funds`:
+Add the following code below `// Step 9: Move Funds`:
 
 ```js
 
@@ -274,11 +255,11 @@ console.log('Funds moved to payment pot!');
 
 ```
 
-### Step 11: Finalize Payment
+### Step 10: Finalize Payment
 
 Now that your payment has been funded, you can finalize it. A payment can only be finalized if the payment amount is available in the funding pot associated with the payment. There are additional methods available to update your payment, but once a payment is finalized, you will no longer be able to update it and the recipient will be able to claim the payment.
 
-Add the following code below `// Step 11: Finalize Payment`:
+Add the following code below `// Step 10: Finalize Payment`:
 
 ```js
 
@@ -289,11 +270,11 @@ console.log('Payment finalized!');
 
 ```
 
-### Step 12: Claim Payment
+### Step 11: Claim Payment
 
 Wahoo! All your hard work has paid off. It's time to claim your payment! Claiming your payment will transfer the payment amount to your wallet and reward you with reputation within your colony.
 
-Add the following code below `// Step 12: Claim Payment`:
+Add the following code below `// Step 11: Claim Payment`:
 
 ```js
 

--- a/docs/_Intro_GetStarted.md
+++ b/docs/_Intro_GetStarted.md
@@ -214,7 +214,7 @@ console.log('Colony funds claimed!');
 
 Now that you have funds available in the root domain of your colony, you can fund domains, tasks, and payments within your colony. The goal within this example is to make a payment, so the next step will be adding a payment to your colony.
 
-You will use your wallet address as the recipient, which you can justify as your reward for all the hard work you put in to setting up your colony. You will also use the address of the token you assigned as the native token for your colony.
+You will use your wallet address as the recipient, which you can justify as your reward for all the hard work you put in to setting up your colony. You will also use the address of the token you assigned as the native token for your colony and the id of the root domain so that you will earn reputation at the root level of your colony.
 
 Add the following code below `// Step 8: Add Payment`:
 
@@ -225,6 +225,7 @@ const addPaymentResponse = await colonyClient.addPayment.send({
   recipient: wallet.address,
   token: tokenAddress,
   amount: new BN('1000000000000000000'),
+  domainId: 1,
 });
 
 // Set payment id and pot id

--- a/docs/_Topics_RegisteringENSLabels.md
+++ b/docs/_Topics_RegisteringENSLabels.md
@@ -13,7 +13,7 @@ You can register a colony label using an instance of [ColonyClient](/colonyjs/ap
 ```js
 
 // Register a colony label
-const register = await colonyClient.registerColonyLabel.send({
+await colonyClient.registerColonyLabel.send({
   colonyName: 'mycolony',
 });
 
@@ -24,7 +24,7 @@ You can also set an OrbitDBPath when you register a colony label:
 ```js
 
 // Register a colony label
-const register = await colonyClient.registerColonyLabel.send({
+await colonyClient.registerColonyLabel.send({
   colonyName: 'mycolony',
   orbitDBPath: 'Qm...'
 });
@@ -40,7 +40,7 @@ You can register a user label using an instance of [ColonyNetworkClient](/colony
 ```js
 
 // Register a user label
-const register = await colonyClient.registerUserLabel.send({
+await networkClient.registerUserLabel.send({
   username: 'colonyuser',
 });
 
@@ -51,7 +51,7 @@ You can also set an OrbitDBPath when you register a user label:
 ```js
 
 // Register a user label
-const register = await colonyClient.registerUserLabel.send({
+await networkClient.registerUserLabel.send({
   username: 'colonyuser',
   orbitDBPath: 'Qm...'
 });

--- a/docs/_Topics_TokensAndFunding.md
+++ b/docs/_Topics_TokensAndFunding.md
@@ -55,18 +55,19 @@ await colonyClient.mintTokens.send({
 
 *Note: You must be assigned the `ROOT` role to call this method.*
 
-Alternatively, if the colony contract is not the `owner` of the token contract, you can mint tokens using an instance of [TokenClient](/colonyjs/api-tokenclient):
+Alternatively, if the colony contract is not the `owner` of the token contract or assigned the token authority role, you can mint tokens using an instance of [TokenClient](/colonyjs/api-tokenclient):
 
 ```js
 
 // Mint tokens
 await colonyClient.tokenClient.mint.send({
+  address: '0x0...',
   amount: new BN('10000000000000000000'),
 });
 
 ```
 
-*Note: You must be the `owner` of the token contract to call this method.*
+*Note: You must be the `owner` of the token contract or assigned the token authority role to call this method. The `address` is the address that will receive the minted tokens, ie the colony address.*
 
 ### Get Token Info
 

--- a/packages/colony-js-client/src/TokenClient/index.js
+++ b/packages/colony-js-client/src/TokenClient/index.js
@@ -48,7 +48,7 @@ export default class TokenClient extends ContractClient {
   */
   approve: TokenClient.Sender<
     {
-      user: Address, // The address that will be approved for the allowance (the token `spender`).
+      address: Address, // The address that will be approved for the allowance (the token `spender`).
       amount: BigNumber, // The amount of tokens that will be approved (the amount `allowed`).
     },
     {
@@ -64,11 +64,11 @@ export default class TokenClient extends ContractClient {
   >;
 
   /*
-  Burn tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
+  Burn tokens. This function can only be called by the token owner or an address with authority.
   */
   burn: TokenClient.Sender<
     {
-      user: Address, // The address from which the tokens will be burned.
+      address: Address, // The address from which the tokens will be burned.
       amount: BigNumber, // The amount of tokens that will be burned.
     },
     {
@@ -108,7 +108,7 @@ export default class TokenClient extends ContractClient {
   getAllowance: TokenClient.Caller<
     {
       sourceAddress: Address, // The address that approved the allowance (the token `owner`).
-      user: Address, // The address that was approved for the allowance (the token `spender`).
+      address: Address, // The address that was approved for the allowance (the token `spender`).
     },
     {
       amount: BigNumber, // The amount of tokens that were approved (the amount `allowed`).
@@ -199,11 +199,11 @@ export default class TokenClient extends ContractClient {
   >;
 
   /*
-  Mint new tokens. This is a `DSToken` function that can only be called by the token `owner`. When a colony contract address is assigned as the token `owner`, this function can only be called by the user assigned the `FOUNDER` authority role.
+  Mint new tokens. This function can only be called by the token owner or an address with authority.
   */
   mint: TokenClient.Sender<
     {
-      user: Address, // The address that will receive the minted tokens.
+      address: Address, // The address that will receive the minted tokens.
       amount: BigNumber, // The amount of tokens that will be minted.
     },
     {
@@ -219,11 +219,11 @@ export default class TokenClient extends ContractClient {
   >;
 
   /*
-  Assign an account the `ADMIN` authority role within a colony.
+  Assign an account the token authority role within a colony.
   */
   setAuthority: TokenClient.Sender<
     {
-      authority: Address, // The address that will be assigned the `ADMIN` authority role.
+      authority: Address, // The address that will be assigned the token authority role.
     },
     {
       LogSetAuthority: LogSetAuthority,
@@ -320,7 +320,7 @@ export default class TokenClient extends ContractClient {
     const amount = ['amount', 'bigNumber'];
     const sourceAddress = ['sourceAddress', 'address'];
     const destinationAddress = ['destinationAddress', 'address'];
-    const user = ['user', 'address'];
+    const address = ['address', 'address'];
 
     // Events
     this.addEvent('Transfer', [
@@ -351,7 +351,7 @@ export default class TokenClient extends ContractClient {
     });
     this.addCaller('getAllowance', {
       functionName: 'allowance',
-      input: [sourceAddress, user],
+      input: [sourceAddress, address],
       output: [amount],
     });
     this.addCaller('isLocked', {
@@ -368,13 +368,13 @@ export default class TokenClient extends ContractClient {
       input: [sourceAddress, destinationAddress, amount],
     });
     this.addSender('approve', {
-      input: [user, amount],
+      input: [address, amount],
     });
     this.addSender('mint', {
-      input: [user, amount],
+      input: [address, amount],
     });
     this.addSender('burn', {
-      input: [user, amount],
+      input: [address, amount],
     });
     this.addSender('setOwner', {
       input: [['owner', 'address']],

--- a/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
+++ b/packages/colony-js-client/src/lib/EthersWrappedWallet/index.js
@@ -51,11 +51,11 @@ export default class EthersWrappedWallet {
       chainId: chainId || this.provider.chainId,
       data,
       // If no gas limit is provided, we need to get the estimate and multiply
-      // it by 1.1 (an amount that will prevent the transaction from failing)
+      // it by 1.2 (an amount that will prevent the transaction from failing)
       gasLimit: gasLimit
         ? new BigNumber(gasLimit)
         : (await this.estimateGas(tx))
-            .mul(new BigNumber('11'))
+            .mul(new BigNumber('12'))
             .div(new BigNumber('10')),
       gasPrice: gasPrice ? new BigNumber(gasPrice) : await this.getGasPrice(),
       nonce: nonce || (await this.getTransactionCount()),


### PR DESCRIPTION
## Description

This pull request removes the "Set Token Owner" step from "Get Started" documentation. Developers should use `TokenAuthority` but to keep the steps to a minimum, we can instruct them to mint tokens using the `TokenClient` since they are the owner of the token.

This pull request also updates the `user` param in `TokenClient` to `address` and makes some minor changes to the descriptions in the `TokenClient` documentation.

The last change is increasing the `gasLimit` estimate from `1.1` to `1.2`. This has been intermittently causing `Error: gas required exceeds allowance or always failing transaction`.

**Changes** 🏗

* Update "Get Started" documentation
* Update `TokenClient` params and method descriptions
* Increase `gasLimit` calculation to `1.2` in EthersWrappedWallet