### PR TITLE
Fix task role change parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+**Bug Fixes**
+
+* Fix parameters in `makeExecuteTaskRoleChange` (`@colony/colony-js-client`)
+
 ## v1.13.1
 
 **Bug fixes**

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -2777,7 +2777,7 @@ export default class ColonyClient extends ContractClient {
       this.addMultisigSender(name, {
         input: [['taskId', 'number'], ['address', 'address']],
         getRequiredSignees: async (args: InputArgs) => {
-          const { taskId, user } = args;
+          const { taskId, address } = args;
 
           // The manager's sig is required for all role change operations
           const { address: manager } = await this.getTaskRole.call({
@@ -2786,7 +2786,7 @@ export default class ColonyClient extends ContractClient {
           });
 
           const requiredSignees = await getRequiredSignees(args);
-          const signees = [manager, user].concat(requiredSignees);
+          const signees = [manager, address].concat(requiredSignees);
 
           return filterRequiredSignees(signees);
         },


### PR DESCRIPTION
## Description

This pull request fixes `setTaskEvaluatorRole` and `setTaskWorkerRole`.

**Changes** 🏗

* Update `makeExecuteTaskRoleChange` to use `address` rather than `user` param