### PR TITLE
Add verbse option to ContractClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## next
 
+**New Features**
+
+* Add `verbose` option to `ContractClient` (`@colony/colony-js-contract-client`)
+* Add `verbose` option to `getColonyClient` method (`@colony/colony-js-client`)
+* Add `verbose` option to `getNetworkClient` method (`@colony/colony-js-client`)
+
 **Bug Fixes**
 
 * Fix parameters in `makeExecuteTaskRoleChange` (`@colony/colony-js-client`)

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -1918,12 +1918,13 @@ export default class ColonyClient extends ContractClient {
     query,
     tokenClient,
     tokenLockingClient,
+    verbose,
   }: {
     networkClient?: ColonyNetworkClient,
     tokenClient?: TokenClient,
     tokenLockingClient?: TokenLockingClient,
   } & ContractClientConstructorArgs) {
-    super({ adapter, query });
+    super({ adapter, query, verbose });
 
     if (!(networkClient instanceof ColonyNetworkClient))
       throw new Error(
@@ -1980,6 +1981,7 @@ export default class ColonyClient extends ContractClient {
     const tokenClient = new this.constructor.TokenClient({
       adapter: this.adapter,
       query: { contractAddress: tokenAddress },
+      verbose: this.verbose,
     });
     await tokenClient.init();
     return tokenClient;

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -1021,6 +1021,7 @@ export default class ColonyNetworkClient extends ContractClient {
       networkClient: this,
       query: { contractAddress },
       tokenLockingClient,
+      verbose: this.verbose,
     });
     await colonyClient.init();
     return colonyClient;
@@ -1048,6 +1049,7 @@ export default class ColonyNetworkClient extends ContractClient {
       networkClient: this,
       query: { contractAddress, contractName: 'IMetaColony' },
       tokenLockingClient,
+      verbose: this.verbose,
     });
     await metaColonyClient.init();
     return metaColonyClient;
@@ -1073,6 +1075,7 @@ export default class ColonyNetworkClient extends ContractClient {
       adapter: this.adapter,
       networkClient: this,
       query: { contractAddress },
+      verbose: this.verbose,
     });
     await tokenLockingClient.init();
     return tokenLockingClient;

--- a/packages/colony-js-client/src/getColonyClient.js
+++ b/packages/colony-js-client/src/getColonyClient.js
@@ -12,11 +12,13 @@ const getColonyClient = async (
   network: string,
   wallet: WalletObjectType,
   infuraProjectId?: string,
+  verbose?: boolean,
 ) => {
   const networkClient = await getNetworkClient(
     network,
     wallet,
     infuraProjectId,
+    verbose,
   );
   return networkClient.getColonyClientByAddress(address);
 };

--- a/packages/colony-js-client/src/getNetworkClient.js
+++ b/packages/colony-js-client/src/getNetworkClient.js
@@ -48,6 +48,7 @@ const getNetworkClient = async (
   network: string,
   wallet: WalletObjectType,
   infuraProjectId?: string,
+  verbose?: boolean,
 ) => {
   let loader;
   let provider;
@@ -82,7 +83,11 @@ const getNetworkClient = async (
   });
 
   // Initialize network client using ethers adapter and default query
-  const networkClient = new ColonyNetworkClient({ adapter, query: {} });
+  const networkClient = new ColonyNetworkClient({
+    adapter,
+    query: {},
+    verbose,
+  });
   await networkClient.init();
 
   return networkClient;

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -274,7 +274,7 @@ export default class ContractClient {
 
     // Allow initialising of clients where some events may be missing in the
     // ABI, due to changing of events on the contract and then log the error
-    // if the client is initialized in verbose mode.
+    // as a warning if the client is initialized in verbose mode.
     try {
       const event = new ContractEvent({
         eventName,
@@ -291,7 +291,7 @@ export default class ContractClient {
       });
     } catch (error) {
       if (this.verbose) {
-        console.info(error);
+        console.warn(`WARNING: ${error.message}`);
       }
     }
   }

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -41,6 +41,9 @@ export default class ContractClient {
   // Mapping of event topics to ContractEvents
   eventSignatures = {};
 
+  // Show additional logs
+  verbose: ?boolean;
+
   // Static getters used in lieu of named exports; this package only has
   // one export.
   static get Caller(): typeof ContractMethodCaller {
@@ -68,9 +71,10 @@ export default class ContractClient {
     return {};
   }
 
-  constructor({ adapter, query }: ContractClientConstructorArgs) {
+  constructor({ adapter, query, verbose }: ContractClientConstructorArgs) {
     this.adapter = adapter;
     this._query = Object.assign({}, this.constructor.defaultQuery, query);
+    this.verbose = verbose;
   }
 
   get contract() {
@@ -269,7 +273,8 @@ export default class ContractClient {
     }
 
     // Allow initialising of clients where some events may be missing in the
-    // ABI, due to changing of events on the contract.
+    // ABI, due to changing of events on the contract and then log the error
+    // if the client is initialized in verbose mode.
     try {
       const event = new ContractEvent({
         eventName,
@@ -285,7 +290,9 @@ export default class ContractClient {
         [event.interface.topics[0]]: event,
       });
     } catch (error) {
-      console.info(error);
+      if (this.verbose) {
+        console.info(error);
+      }
     }
   }
 }

--- a/packages/colony-js-contract-client/src/classes/ContractEvent.js
+++ b/packages/colony-js-contract-client/src/classes/ContractEvent.js
@@ -47,7 +47,7 @@ export default class ContractEvent<ParamTypes: Object> {
     this.argsDef = argsDef;
 
     if (!this.interface)
-      throw new Error(`No such event "${eventName}" on this contract`);
+      throw new Error(`No such event "${eventName}" in loaded ABI`);
 
     this._wrappedHandlers = new Map();
     this.assertValid = makeAssert(`Validation failed for event ${eventName}`);

--- a/packages/colony-js-contract-client/src/flowtypes/methods.js
+++ b/packages/colony-js-contract-client/src/flowtypes/methods.js
@@ -40,6 +40,7 @@ export type ContractResponse<EventData> = {
 export type ContractClientConstructorArgs = {
   adapter: IAdapter,
   query: ?Query,
+  verbose: ?boolean,
 };
 
 export type ValidateEmpty = (


### PR DESCRIPTION
## Description

This pull request adds a `verbose` parameter to `ContractClient`. This provides the option to view additional logs such as `No such event "x" on this contract`.

**New stuff** ✨

* Add `verbose` option to `ContractClient`
* Add `verbose` option to `getColonyClient` method
* Add `verbose` option to `getNetworkClient` method

**Changes** 🏗

* Only log `No such event "x" on this contract` if `verbose` is `true`

Closes #430
