### PR TITLE
Supply optional `network` property to HTTP loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## NEXT
+
+**Bug fixes**
+
+* Supply an optional `network` property to HTTP loaders (`@colony/colony-js-contract-loader-http`)
+
 ## v1.13.2
 
 **New Features**

--- a/packages/colony-js-contract-loader-http/src/flowtypes.js
+++ b/packages/colony-js-contract-loader-http/src/flowtypes.js
@@ -5,4 +5,5 @@ import type { Transform } from '@colony/colony-js-contract-loader';
 export type ConstructorArgs = {
   endpoint: string,
   transform: Transform,
+  network?: string,
 };

--- a/packages/colony-js-contract-loader-http/src/loaders/HttpLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/HttpLoader.js
@@ -19,8 +19,8 @@ export default class HttpLoader extends ContractLoader
 
   _endpoint: string;
 
-  constructor({ endpoint, transform }: ConstructorArgs = {}) {
-    super({ transform });
+  constructor({ endpoint, transform, network }: ConstructorArgs = {}) {
+    super({ transform, network });
     assert(
       typeof endpoint === 'string' && endpoint,
       'An `endpoint` option must be provided',
@@ -78,7 +78,11 @@ export default class HttpLoader extends ContractLoader
 
     let contractDef;
     try {
-      contractDef = this._transform(json, query, requiredProps);
+      contractDef = this._transform(
+        json,
+        { ...query, ...(this._network ? { network: this._network } : {}) },
+        requiredProps,
+      );
     } catch (error) {
       throwError('transform contract definition', error);
     }

--- a/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
+++ b/packages/colony-js-contract-loader-http/src/loaders/TrufflepigLoader.js
@@ -14,8 +14,8 @@ const DEFAULT_ENDPOINT = `${DEFAULT_HOST}/contracts?name=%%NAME%%&address=%%ADDR
 export default class TrufflepigLoader extends HttpLoader {
   _host: string;
 
-  constructor({ endpoint = DEFAULT_ENDPOINT }: ConstructorArgs = {}) {
-    super({ transform: truffleTransform, endpoint });
+  constructor({ endpoint = DEFAULT_ENDPOINT, network }: ConstructorArgs = {}) {
+    super({ transform: truffleTransform, endpoint, network });
     const [host] = this._endpoint.split('/contracts');
     this._host = host;
   }


### PR DESCRIPTION
## Description

Supply an optional `network` property to HTTP loaders, so that the `TrufflepigLoader` can select the appropriate contract.

**Changes** 🏗

* Supply an optional `network` property to HTTP loaders
