### PR TITLE
Add custom Infura provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## NEXT
+
+**Bug fixes**
+
+* Add custom Infura provider which retries queries when bad responses are recieved, which happens occasionally (`@colony/colony-js-client`)
+
 ## v1.13.3
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug fixes**
 
-* Add custom Infura provider which retries queries when bad responses are recieved, which happens occasionally (`@colony/colony-js-client`)
+* Add custom Infura provider which retries queries when bad responses are received, which happens occasionally (`@colony/colony-js-client`)
 
 ## v1.13.3
 

--- a/packages/colony-js-client/package.json
+++ b/packages/colony-js-client/package.json
@@ -66,6 +66,7 @@
         "ethereumjs-tx": "^1.3.7",
         "ethers": "3.0.27",
         "isomorphic-fetch": "^2.2.1",
+        "promise-retry": "^1.1.1",
         "web3-utils": "^1.0.0-beta.55"
     },
     "devDependencies": {

--- a/packages/colony-js-client/src/lib/InfuraProvider/index.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/index.js
@@ -1,0 +1,94 @@
+/* @flow */
+
+import { providers } from 'ethers';
+import promiseRetry from 'promise-retry';
+
+import type { Params } from './types';
+
+export const defaultInfuraProjectId = '7d0d81d0919f4f05b9ab6634be01ee73';
+
+// Custom provider for use with Infura which retries query requests if the
+// result is unexpected data.
+// Related issue: https://github.com/INFURA/infura/issues/157
+export default class InfuraProvider extends providers.JsonRpcProvider {
+  constructor(
+    networkName: string,
+    infuraProjectId?: string,
+    verbose?: boolean,
+  ) {
+    let host;
+    switch (networkName) {
+      case 'homestead':
+      case 'mainnet':
+        host = 'mainnet.infura.io';
+        break;
+      case 'goerli':
+        host = 'goerli.infura.io';
+        break;
+      default:
+        throw new Error(
+          `Could not get provider, unsupported network: ${networkName}`,
+        );
+    }
+
+    const url = `https://${host}/v3/${infuraProjectId ||
+      defaultInfuraProjectId}`;
+    const network =
+      networkName === 'goerli'
+        ? {
+            chainId: 5,
+            ensAddress: '0x112234455c3a32fd11230c42e7bccd4a84e02010',
+            name: 'goerli',
+          }
+        : networkName;
+
+    super(url, network);
+    this._verbose = verbose;
+  }
+
+  async perform(method: string, params: Params) {
+    const result = await super.perform(method, params);
+    if (
+      (method === 'call' ||
+        method === 'estimateGas' ||
+        method.startsWith('get')) &&
+      result === '0x'
+    ) {
+      // Set the number of retries. The time between retries will increase with
+      // a default exponential factor of 2.
+      const retries = 7;
+
+      // Retry if the result is '0x'. '0x' is an acceptable response if the
+      // method does not exist on the contract, therefore, the promise must
+      // eventually resolve with `0x` after the given number of retries.
+      return promiseRetry({ retries }, (retry, number) => {
+        if (this._verbose) {
+          console.warn(
+            // eslint-disable-next-line max-len
+            `Possibly invalid response for method "${method}"; retry ${number}.`,
+            {
+              method,
+              params,
+              result,
+            },
+          );
+        }
+        return new Promise((resolve, reject) => {
+          super
+            .perform(method, params)
+            .then(retryResult => {
+              if (number < retries && retryResult === '0x') {
+                retry();
+              } else {
+                resolve(retryResult);
+              }
+            })
+            .catch(error => {
+              reject(error);
+            });
+        });
+      });
+    }
+    return result;
+  }
+}

--- a/packages/colony-js-client/src/lib/InfuraProvider/types.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/types.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+export type Params = {
+  data: string,
+  from: string,
+  to: string,
+};


### PR DESCRIPTION
## Description

This provider retries queries when a bad (`0x`) response is received. We should test this and ideally reproduce the error and see that this sorts it before merging.

**Changes** 🏗

* Use `InfuraProvider` in place of `getInfuraProvider`
