### PR TITLE
Use pending block tag to tell bad Infura response

### DIFF
--- a/packages/colony-js-client/src/lib/InfuraProvider/index.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/index.js
@@ -3,6 +3,8 @@
 import { providers } from 'ethers';
 import promiseRetry from 'promise-retry';
 
+import type { PerformParams } from './types';
+
 export const defaultInfuraProjectId = '7d0d81d0919f4f05b9ab6634be01ee73';
 
 // Custom provider for use with Infura which retries query requests if the
@@ -44,55 +46,72 @@ export default class InfuraProvider extends providers.JsonRpcProvider {
     this._verbose = verbose;
   }
 
-  async perform(method: string, params: *) {
-    if (method === 'call') {
-      // Perform eth_call as usual.
-      const latestResult = await super.perform(method, params);
+  async perform(method: string, params: PerformParams) {
+    // Perform as usual.
+    const latestResult = await super.perform(method, params);
 
-      if (latestResult === '0x') {
-        // If we got 0x then see if the pending block gives us any different.
-        const pendingResult = await super.send('eth_call', [
+    // If we got 0x then see if the pending block gives us any different.
+    if (latestResult === '0x') {
+      let pendingResult = latestResult;
+
+      if (method === 'call' || method === 'estimateGas') {
+        // We retry a call for estimate too, since if that succeeds then the
+        // estimate should have also, and estimate doesn't allow specifying a
+        // block.
+        pendingResult = await super.send('eth_call', [
           // eslint-disable-next-line no-underscore-dangle
           super.constructor._hexlifyTransaction(params.transaction),
           'pending',
         ]);
-
-        // If results differ, retry a few times until latest is not null.
-        if (latestResult !== pendingResult) {
-          if (this._verbose) {
-            console.warn(
-              // eslint-disable-next-line max-len
-              'Infura returned invalid "0x" for "latest" block, got valid for "pending"',
-              { latest: latestResult, pending: pendingResult },
-            );
-          }
-
-          // Set the number of retries. The time between retries will increase with
-          // a default exponential factor of 2.
-          const retries = 7;
-          return promiseRetry({ retries }, (retry, number) => {
-            if (this._verbose) {
-              console.warn(`Retry ${number} at "latest" block`);
-            }
-            return new Promise((resolve, reject) => {
-              super
-                .perform(method, params)
-                .then(retryResult => {
-                  if (number < retries && retryResult === '0x') {
-                    retry();
-                  } else {
-                    resolve(retryResult);
-                  }
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            });
-          });
-        }
+      } else if (
+        (method === 'getCode' || method === 'getStorageAt') &&
+        (!params.blockTag || params.blockTag === 'latest')
+      ) {
+        // Don't retry if a non-latest blockTag was specified.
+        pendingResult = await super.perform(method, {
+          ...params,
+          blockTag: 'pending',
+        });
       }
-      return latestResult;
+
+      // If results differ, retry a few times until latest is not null.
+      if (latestResult !== pendingResult) {
+        if (this._verbose) {
+          console.warn(
+            // eslint-disable-next-line max-len
+            'Infura returned invalid "0x" for "latest" block, got valid for "pending"',
+            { latest: latestResult, pending: pendingResult },
+          );
+        }
+        return this._retry(method, params);
+      }
     }
-    return super.perform(method, params);
+
+    return latestResult;
+  }
+
+  _retry(method: string, params: PerformParams) {
+    // Set the number of retries. The time between retries will increase with
+    // a default exponential factor of 2.
+    const retries = 7;
+    return promiseRetry({ retries }, (retry, number) => {
+      if (this._verbose) {
+        console.warn(`Retry ${number} at "latest" block`);
+      }
+      return new Promise((resolve, reject) => {
+        super
+          .perform(method, params)
+          .then(retryResult => {
+            if (number < retries && retryResult === '0x') {
+              retry();
+            } else {
+              resolve(retryResult);
+            }
+          })
+          .catch(error => {
+            reject(error);
+          });
+      });
+    });
   }
 }

--- a/packages/colony-js-client/src/lib/InfuraProvider/index.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/index.js
@@ -80,7 +80,7 @@ export default class InfuraProvider extends providers.JsonRpcProvider {
           console.warn(
             // eslint-disable-next-line max-len
             'Infura returned invalid "0x" for "latest" block, got valid for "pending"',
-            { latest: latestResult, pending: pendingResult },
+            { latest: latestResult, pending: pendingResult, method, params },
           );
         }
         return this._retry(method, params);

--- a/packages/colony-js-client/src/lib/InfuraProvider/types.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/types.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+export type PerformParams = {
+  data?: string,
+  from?: string,
+  to?: string,
+  transaction?: Object,
+  blockTag?: string | boolean,
+};

--- a/packages/colony-js-client/src/lib/InfuraProvider/types.js
+++ b/packages/colony-js-client/src/lib/InfuraProvider/types.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-export type Params = {
-  data: string,
-  from: string,
-  to: string,
-};


### PR DESCRIPTION
## Description

We've worked out that where a particular `eth_call` request gets `0x` back when it shouldn't, an equivalent call with the block tag of `pending` (default is `latest`) will give us the correct result.

Now we are using this to determine if the initial `0x` response is invalid, and then waiting for the call with `latest` block tag to succeed. This is to make sure that the transactions we're using for the state are confirmed.

**Changes** 🏗

* `InfuraProvider` uses `eth_call` with block tag of `pending` to determine if a `0x` response was invalid, before retrying. This prevents retries in situations where they are not needed.

## TODO

- [ ] Some more testing before approving please!

Resolves #437 
