### PR TITLE
Add `eth_call` support and revert reason strings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
      // XXX waiting on https://github.com/gajus/eslint-plugin-flowtype/pull/308
     "$PropertyType": false,
     "$Values": false,
+    "$Shape": false,
     "$Keys": false
   },
   "overrides": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## NEXT
 
+**Features**
+
+* Add support for `eth_call` for Senders in order to simulate sending the transaction and receive a result or parsed revert error (`@colony/colony-js-client`, `@colony/colony-js-contract-client`, `@colony/colony-js-adapter`, `@colony/colony-js-adapter-ethers`)
+* Add `reason` property to transaction receipts (`@colony/colony-js-contract-client`)
+
 **Bug fixes**
 
 * Add custom Infura provider which retries queries when bad responses are received, which happens occasionally (`@colony/colony-js-client`)

--- a/packages/colony-js-adapter-ethers/src/EthersContract.js
+++ b/packages/colony-js-adapter-ethers/src/EthersContract.js
@@ -57,7 +57,7 @@ class EthersContract extends ethers.Contract implements IContract {
    * Given a function name, an array of arguments and optional transaction
    * options, apply the arguments and return the sent transaction
    */
-  async callTransaction(
+  async sendTransaction(
     functionName: string,
     args: Array<any>,
     options: TransactionOptions,

--- a/packages/colony-js-adapter/index.js
+++ b/packages/colony-js-adapter/index.js
@@ -15,7 +15,7 @@ export type {
   LogFilter,
 } from './interface/Provider';
 export type { Signature } from './interface/Signature';
-export type { Transaction } from './interface/Transaction';
+export type { Transaction, TransactionRequest } from './interface/Transaction';
 export type { TransactionReceipt } from './interface/TransactionReceipt';
 export type { TransactionOptions } from './interface/TransactionOptions';
 export type { Wallet as IWallet } from './interface/Wallet';

--- a/packages/colony-js-adapter/interface/Adapter.js
+++ b/packages/colony-js-adapter/interface/Adapter.js
@@ -5,7 +5,7 @@ import type { Query } from '@colony/colony-js-contract-loader';
 import type { Contract } from './Contract';
 import type { Provider } from './Provider';
 import type { Signature } from './Signature';
-import type { Transaction } from './Transaction';
+import type { Transaction, TransactionRequest } from './Transaction';
 import type { TransactionReceipt } from './TransactionReceipt';
 import type { Wallet } from './Wallet';
 
@@ -15,6 +15,7 @@ export interface Adapter {
   wallet: Wallet;
   ecRecover(digest: Array<number>, signature: Signature): string;
   getContract(query: Query): Promise<Contract>;
+  callTransaction(transaction: TransactionRequest): Promise<string>;
   getContractDeployTransaction(
     query: Query,
     contractParams: Array<any>,

--- a/packages/colony-js-adapter/interface/Contract.js
+++ b/packages/colony-js-adapter/interface/Contract.js
@@ -30,7 +30,7 @@ export interface Contract {
   ): void;
   callConstant(functionName: string, args: Array<any>): Promise<any>;
   callEstimate(functionName: string, args: Array<any>): Promise<BigNumber>;
-  callTransaction(
+  sendTransaction(
     functionName: string,
     args: Array<any>,
     options: TransactionOptions,

--- a/packages/colony-js-adapter/interface/Provider.js
+++ b/packages/colony-js-adapter/interface/Provider.js
@@ -18,6 +18,7 @@ export type Log = { data: string, topics: string[] };
 export interface Provider {
   name: string;
   chainId: string;
+  call(transaction: $Shape<Transaction>): Promise<string>;
   estimateGas(transaction: Transaction): Promise<number>;
   getAddress(): string | Promise<string>;
   getBalance(addressOrName: string, blockTag?: string): Promise<BigNumber>;

--- a/packages/colony-js-adapter/interface/Transaction.js
+++ b/packages/colony-js-adapter/interface/Transaction.js
@@ -26,6 +26,15 @@ export type Transaction = {
   raw: string,
 };
 
+export type TransactionRequest = {
+  data?: $PropertyType<Transaction, 'data'>,
+  from?: $PropertyType<Transaction, 'from'>,
+  gasLimit?: $PropertyType<Transaction, 'gasLimit'>,
+  gasPrice?: $PropertyType<Transaction, 'gasPrice'>,
+  to?: $PropertyType<Transaction, 'to'>,
+  value?: $PropertyType<Transaction, 'value'>,
+}
+
 export type SignedTransaction = Transaction & {
   r: string,
   s: string,

--- a/packages/colony-js-adapter/interface/TransactionReceipt.js
+++ b/packages/colony-js-adapter/interface/TransactionReceipt.js
@@ -11,6 +11,7 @@ export type TransactionReceipt = {
   hash: string,
   logs: Array<*>,
   logsBloom: string,
+  reason?: string,
   root: string,
   status: number, // 0 => failure, 1 => success
   transactionHash: string,

--- a/packages/colony-js-client/src/ColonyClient/senders/AddExtension.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/AddExtension.js
@@ -24,7 +24,7 @@ export default class AddExtension extends ContractClient.Sender<
 
   async _sendTransaction(args: *, options: *) {
     const factoryContract = await this._getContract(args);
-    return factoryContract.callTransaction(
+    return factoryContract.sendTransaction(
       'deployExtension',
       [this.client.contract.address],
       options,

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
@@ -37,7 +37,7 @@ export default class MakePayment extends DomainAuth<*, *, *> {
 
   async _sendTransaction(args: *, options: *) {
     const contract = await this._getContract();
-    return contract.callTransaction('makePayment', args, options);
+    return contract.sendTransaction('makePayment', args, options);
   }
 
   async _getContract() {
@@ -50,10 +50,9 @@ export default class MakePayment extends DomainAuth<*, *, *> {
     );
     if (!contractAddress)
       throw new Error('OneTxPayment not deployed for this Colony');
-    const contract = await this.client.adapter.getContract({
+    return this.client.adapter.getContract({
       contractAddress,
       contractName: 'OneTxPayment',
     });
-    return contract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/RemoveExtension.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/RemoveExtension.js
@@ -24,7 +24,7 @@ export default class RemoveExtension extends ContractClient.Sender<
 
   async _sendTransaction(args: *, options: *) {
     const factoryContract = await this._getContract(args);
-    return factoryContract.callTransaction(
+    return factoryContract.sendTransaction(
       'removeExtension',
       [this.client.contract.address],
       options,

--- a/packages/colony-js-client/src/ColonyClient/senders/SetAdminRole.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/SetAdminRole.js
@@ -25,7 +25,7 @@ export default class SetAdminRole extends ContractClient.Sender<
 
   async _sendTransaction(args: *, options: *) {
     const contract = await this._getContract();
-    return contract.callTransaction('setAdminRole', args, options);
+    return contract.sendTransaction('setAdminRole', args, options);
   }
 
   async _getContract() {
@@ -38,10 +38,9 @@ export default class SetAdminRole extends ContractClient.Sender<
     );
     if (!contractAddress)
       throw new Error('OldRoles not deployed for this Colony');
-    const contract = await this.client.adapter.getContract({
+    return this.client.adapter.getContract({
       contractAddress,
       contractName: 'OldRoles',
     });
-    return contract;
   }
 }

--- a/packages/colony-js-client/src/ColonyClient/senders/SetFounderRole.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/SetFounderRole.js
@@ -24,7 +24,7 @@ export default class SetFounderRole extends ContractClient.Sender<
 
   async _sendTransaction(args: *, options: *) {
     const contract = await this._getContract();
-    return contract.callTransaction('setFounderRole', args, options);
+    return contract.sendTransaction('setFounderRole', args, options);
   }
 
   async _getContract() {
@@ -37,10 +37,9 @@ export default class SetFounderRole extends ContractClient.Sender<
     );
     if (!contractAddress)
       throw new Error('OldRoles not deployed for this Colony');
-    const contract = await this.client.adapter.getContract({
+    return this.client.adapter.getContract({
       contractAddress,
       contractName: 'OldRoles',
     });
-    return contract;
   }
 }

--- a/packages/colony-js-contract-client/package.json
+++ b/packages/colony-js-contract-client/package.json
@@ -54,6 +54,7 @@
         "@colony/colony-js-adapter": "^1.12.0",
         "@colony/colony-js-contract-loader": "^1.12.0",
         "@colony/colony-js-utils": "^1.12.0",
+        "ethers": "3.0.27",
         "assert": "^2.0.0",
         "babel-runtime": "^6.26.0",
         "bn.js": "^4.11.8",

--- a/packages/colony-js-contract-client/src/__tests__/ContractClient.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractClient.js
@@ -29,7 +29,7 @@ describe('ContractClient', () => {
 
     callEstimate = sandbox.fn(async () => gasEstimate);
 
-    callTransaction = sandbox.fn(async () => transaction);
+    sendTransaction = sandbox.fn(async () => transaction);
 
     createTransactionData = sandbox.fn(async () => txData);
 
@@ -39,11 +39,18 @@ describe('ContractClient', () => {
           topics: ['0xabc'],
         },
       },
+      functions: {
+        myFunction: sandbox.fn(),
+      },
     };
   })();
   const query = { contractName: 'MyContract' };
   const adapter = {
     getContract: sandbox.fn(() => contract),
+    callTransaction: sandbox.fn(),
+    wallet: {
+      getAddress: sandbox.fn(() => 'mock-wallet-address'),
+    },
   };
   const options = {
     myOption: 123,
@@ -217,8 +224,8 @@ describe('ContractClient', () => {
     const result = await client.send(fnName, args, txOpts);
 
     expect(result).toEqual(transaction);
-    expect(client.contract.callTransaction).toHaveBeenCalledTimes(1);
-    expect(client.contract.callTransaction).toHaveBeenCalledWith(
+    expect(client.contract.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(client.contract.sendTransaction).toHaveBeenCalledWith(
       fnName,
       args,
       txOpts,

--- a/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
+++ b/packages/colony-js-contract-client/src/__tests__/ContractMethodSender.js
@@ -28,6 +28,9 @@ describe('ContractMethodSender', () => {
           parse: sandbox.fn().mockReturnValue({ id: 1, '0': 1, length: 1 }),
         },
       },
+      functions: {
+        myFunction: sandbox.fn(() => ({ data: 'mock-tx-data' })),
+      },
     },
   };
   const functionName = 'myFunction';
@@ -86,6 +89,10 @@ describe('ContractMethodSender', () => {
     provider: {
       name: 'mainnet',
     },
+    wallet: {
+      getAddress: sandbox.fn(() => 'mock-wallet-address'),
+    },
+    callTransaction: sandbox.fn(),
   };
   const client = new ContractClient({ contract, adapter });
   client._contract = contract;

--- a/packages/colony-js-contract-client/src/classes/ContractClient.js
+++ b/packages/colony-js-contract-client/src/classes/ContractClient.js
@@ -11,6 +11,7 @@ import type {
   LogFilter,
   TransactionOptions,
   TransactionReceipt,
+  TransactionRequest,
 } from '@colony/colony-js-adapter';
 
 import ContractEvent from './ContractEvent';
@@ -110,6 +111,10 @@ export default class ContractClient {
     return this.contract.callConstant(functionName, args);
   }
 
+  async callTransaction(transaction: TransactionRequest) {
+    return this.adapter.callTransaction(transaction);
+  }
+
   /**
    * Low-level method to estimate the gas cost of sending a transaction to
    * call a contract function with an array of arguments that have been
@@ -129,7 +134,7 @@ export default class ContractClient {
     args: Array<any>,
     options: TransactionOptions,
   ) {
-    return this.contract.callTransaction(functionName, args, options);
+    return this.contract.sendTransaction(functionName, args, options);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds support for `eth_call` via `ContractMethodSender.call()`, so that transactions can be simulated. Additionally, revert reason strings are now parsed when calling `call`, `estimate` and `send` for transactions.

**New stuff** ✨

* Add support for `eth_call` for Senders in order to simulate sending the transaction and receive a result or parsed revert error
* Add `reason` property to transaction receipts
* Add `Adapter.callTransaction` method

**Changes** 🏗

* Rename `Contract.callTransaction` to `Contract.sendTransaction` for clarification

Resolves #429 
