### PR TITLE
Fix DomainAuth to use parent for architecture

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -2198,7 +2198,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
         },
       ],
     });
@@ -2218,7 +2218,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
         },
       ],
     });
@@ -2238,7 +2238,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN, // TODO: also should allow COLONY_ROLE_ROOT
+          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
         },
       ],
     });

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -6,6 +6,7 @@ import ContractClient from '@colony/colony-js-contract-client';
 import type { ContractMethodSenderArgs } from '@colony/colony-js-contract-client';
 
 import {
+  COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
   COLONY_ROLES,
   FUNDING_POT_TYPE_DOMAIN,
   FUNDING_POT_TYPE_PAYMENT,
@@ -304,7 +305,11 @@ export default class DomainAuth<
       domainId,
       role,
     });
-    if (hasDomainPermission) return domainId;
+
+    // Architecture can only architect child domains
+    if (hasDomainPermission && role !== COLONY_ROLE_ARCHITECTURE_SUBDOMAIN) {
+      return domainId;
+    }
 
     // if we have permission in root domain, return that
     const { hasRole: hasRootPermission } = await this.client.hasColonyRole.call(


### PR DESCRIPTION
## Description

We were incorrectly using architecture permission in a domain as proof that we can set roles in that domain. This is wrong, since architecture allows you to set roles only in child domains of the domain in which it's set.

**Changes** 🏗

* Don't allow architecture permission as proof in same domain in `DomainAuth` sender

**Deletions** ⚰️

* Removed irrelevant comments

Contributes to https://github.com/JoinColony/colonyDapp/issues/1883
