### PR TITLE
Make payments funded from domain

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -2028,7 +2028,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });
@@ -2054,7 +2054,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });
@@ -2066,7 +2066,7 @@ export default class ColonyClient extends ContractClient {
         // permission proof for OneTX contract
         ['permissionDomainId', 'number'],
         ['childSkillIndex', 'number'],
-        // permission proof for caller
+        // permission proof for caller (user who calls the extension)
         ['callerPermissionDomainId', 'number'],
         ['callerChildSkillIndex', 'number'],
         ['recipient', 'address'],
@@ -2090,13 +2090,13 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION, // TODO: also need to have COLONY_ROLE_FUNDING
+          roles: [COLONY_ROLE_ADMINISTRATION, COLONY_ROLE_FUNDING],
         },
         {
           childSkillIndexNames: ['callerChildSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'callerPermissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION, // TODO: also need to have COLONY_ROLE_FUNDING
+          roles: [COLONY_ROLE_ADMINISTRATION, COLONY_ROLE_FUNDING],
         },
       ],
     });
@@ -2132,7 +2132,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['parentDomainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE,
+          roles: [COLONY_ROLE_ARCHITECTURE],
         },
       ],
     });
@@ -2153,7 +2153,7 @@ export default class ColonyClient extends ContractClient {
             return [domainId];
           },
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });
@@ -2178,7 +2178,7 @@ export default class ColonyClient extends ContractClient {
             await getDomainIdFromPot(toPot, this),
           ],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_FUNDING,
+          roles: [COLONY_ROLE_FUNDING],
         },
       ],
     });
@@ -2198,7 +2198,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
+          roles: [COLONY_ROLE_ARCHITECTURE_SUBDOMAIN], // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2218,7 +2218,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
+          roles: [COLONY_ROLE_ARCHITECTURE_SUBDOMAIN], // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2238,7 +2238,7 @@ export default class ColonyClient extends ContractClient {
           childSkillIndexNames: ['childSkillIndex'],
           domainIds: ['domainId'],
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
+          roles: [COLONY_ROLE_ARCHITECTURE_SUBDOMAIN], // TODO: also should allow COLONY_ROLE_ROOT
         },
       ],
     });
@@ -2261,7 +2261,7 @@ export default class ColonyClient extends ContractClient {
             return [domainId];
           },
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });
@@ -2283,7 +2283,7 @@ export default class ColonyClient extends ContractClient {
             return [domainId];
           },
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });
@@ -2305,7 +2305,7 @@ export default class ColonyClient extends ContractClient {
             return [domainId];
           },
           permissionDomainIdName: 'permissionDomainId',
-          role: COLONY_ROLE_ADMINISTRATION,
+          roles: [COLONY_ROLE_ADMINISTRATION],
         },
       ],
     });

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -19,7 +19,7 @@ type ColonyRole = $Keys<typeof COLONY_ROLES>;
 
 type PermissionType = {|
   // the role required
-  role: ColonyRole,
+  roles: ColonyRole[],
   // name of the input value conatining the domainId, or function to get the domainId
   domainIds:
     | Array<string | ((inputValues: Object) => Promise<number>)>
@@ -146,12 +146,15 @@ export default class DomainAuth<
     const proofs = await Promise.all(
       this._permissions.map(
         async ({
-          role,
+          roles,
           domainIds: inputDomainIds,
           permissionDomainIdName,
           childSkillIndexNames,
           address: inputAddress,
         }) => {
+          // Just check the first role, initially
+          const [role, ...otherRoles] = roles;
+
           // resolve the functions or fetch from inputValues
           const domainIds =
             typeof inputDomainIds === 'function'
@@ -188,6 +191,25 @@ export default class DomainAuth<
             permissionDomains,
             role,
           );
+
+          const allHasRoles = await Promise.all(
+            otherRoles.map(async r => {
+              const { hasRole } = await this.client.hasColonyRole.call({
+                address,
+                domain: highestDomain,
+                role: r,
+              });
+              return hasRole;
+            }),
+          );
+
+          if (!allHasRoles.every(Boolean)) {
+            throw new Error(
+              `We are missing one or more of the permissions ${JSON.stringify(
+                otherRoles,
+              )} in domain ${highestDomain}`,
+            );
+          }
 
           const childSkillIndexes = await Promise.all(
             domainIds.map(async domainId =>

--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -196,7 +196,7 @@ export default class DomainAuth<
             otherRoles.map(async r => {
               const { hasRole } = await this.client.hasColonyRole.call({
                 address,
-                domain: highestDomain,
+                domainId: highestDomain,
                 role: r,
               });
               return hasRole;

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
@@ -32,6 +32,7 @@ export default class MakePayment extends DomainAuth<*, *, *> {
       ...proofs,
     });
 
+    // $FlowFixMe
     return contract.callEstimate('makePayment', args);
   }
 

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePaymentFundedFromDomain.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePaymentFundedFromDomain.js
@@ -1,0 +1,64 @@
+/* @flow */
+/* eslint-disable import/no-cycle */
+
+import DomainAuth from './DomainAuth';
+
+export default class MakePaymentFundedFromDomain extends DomainAuth<*, *, *> {
+  async estimate(inputValues: *) {
+    // if for some reason we don't have the required methods, then throw
+    if (
+      !(
+        this.client.networkClient &&
+        this.client.networkClient.getParentSkillId &&
+        this.client.hasColonyRole
+      )
+    ) {
+      throw new Error('Client not compatible with DomainAuth sender');
+    }
+
+    // combine with default values
+    const inputValuesWithDefaults = {
+      ...(this.defaultValues || {}),
+      ...inputValues,
+    };
+
+    // get proof input values
+    const proofs = await this.getPermissionProofs(inputValuesWithDefaults);
+
+    const contract = await this._getContract();
+
+    const args = this.getValidatedArgs({
+      ...inputValuesWithDefaults,
+      ...proofs,
+    });
+
+    // $FlowFixMe
+    return contract.callEstimate('makePaymentFundedFromDomain', args);
+  }
+
+  async _sendTransaction(args: *, options: *) {
+    const contract = await this._getContract();
+    return contract.callTransaction(
+      'makePaymentFundedFromDomain',
+      args,
+      options,
+    );
+  }
+
+  async _getContract() {
+    const factoryContract = await this.client.adapter.getContract({
+      contractName: 'OneTxPaymentFactory',
+    });
+    const contractAddress = await factoryContract.callConstant(
+      'deployedExtensions',
+      [this.client.contract.address],
+    );
+    if (!contractAddress)
+      throw new Error('OneTxPayment not deployed for this Colony');
+    const contract = await this.client.adapter.getContract({
+      contractAddress,
+      contractName: 'OneTxPayment',
+    });
+    return contract;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the `makePaymentFundedFromDomain` method to the ColonyClient. It's almost the same function as `makePayment` except for the name (and what it does, eventually). Furthermore we're adding checks for multiple roles in the extension contracts (if necessary).

**New stuff** ✨

* `makePaymentFundedFromDomain`

**Changes** 🏗

* Permission proof checks can be applied for multiple roles