### PR TITLE
Fix legacy calls in makePaymentFundedFromDomain sender

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePayment.js
@@ -32,7 +32,6 @@ export default class MakePayment extends DomainAuth<*, *, *> {
       ...proofs,
     });
 
-    // $FlowFixMe
     return contract.callEstimate('makePayment', args);
   }
 

--- a/packages/colony-js-client/src/ColonyClient/senders/MakePaymentFundedFromDomain.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/MakePaymentFundedFromDomain.js
@@ -32,13 +32,12 @@ export default class MakePaymentFundedFromDomain extends DomainAuth<*, *, *> {
       ...proofs,
     });
 
-    // $FlowFixMe
     return contract.callEstimate('makePaymentFundedFromDomain', args);
   }
 
   async _sendTransaction(args: *, options: *) {
     const contract = await this._getContract();
-    return contract.callTransaction(
+    return contract.sendTransaction(
       'makePaymentFundedFromDomain',
       args,
       options,
@@ -55,10 +54,9 @@ export default class MakePaymentFundedFromDomain extends DomainAuth<*, *, *> {
     );
     if (!contractAddress)
       throw new Error('OneTxPayment not deployed for this Colony');
-    const contract = await this.client.adapter.getContract({
+    return this.client.adapter.getContract({
       contractAddress,
       contractName: 'OneTxPayment',
     });
-    return contract;
   }
 }


### PR DESCRIPTION
## Description

For some reason I copied a totally old file and no one noticed. Well, here's the real thing.

**Changes** 🏗

* Updated `makePaymentsFundedFromDomain` to the new version
