### PR TITLE
Return default domain id for rewards pot

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/DomainAuth.js
@@ -8,9 +8,11 @@ import type { ContractMethodSenderArgs } from '@colony/colony-js-contract-client
 import {
   COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
   COLONY_ROLES,
+  DEFAULT_DOMAIN_ID,
   FUNDING_POT_TYPE_DOMAIN,
   FUNDING_POT_TYPE_PAYMENT,
   FUNDING_POT_TYPE_TASK,
+  REWARDS_POT_ID
 } from '../../constants';
 
 import type { ColonyClient } from '../../index';
@@ -33,6 +35,9 @@ type PermissionType = {|
 |};
 
 export const getDomainIdFromPot = async (potId: number, colonyClient: *) => {
+  if (potId === REWARDS_POT_ID) {
+    return DEFAULT_DOMAIN_ID;
+  }
   const { type, typeId } = await colonyClient.getFundingPot.call({ potId });
   if (type === FUNDING_POT_TYPE_DOMAIN) {
     return typeId;

--- a/packages/colony-js-client/src/constants.js
+++ b/packages/colony-js-client/src/constants.js
@@ -35,6 +35,8 @@ export const FUNDING_POT_TYPES = {
   [FUNDING_POT_TYPE_PAYMENT]: 3,
 };
 
+export const REWARDS_POT_ID = 0;
+
 export const TASK_RATING_EXCELLENT = 'EXCELLENT';
 export const TASK_RATING_NONE = 'NONE';
 export const TASK_RATING_SATISFACTORY = 'SATISFACTORY';


### PR DESCRIPTION
## Description

Trying to move funds to the rewards pot currently fails while trying to work out the domain proof. This PR handles moving funds to the rewards domain.

**Changes** 🏗

Adds a check to `getDomainIdFromPot` for the rewards pot and returns the default domain id