### PR TITLE
Update handling of colony creation & upgrading

### DIFF
--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -32,6 +32,7 @@ import Upgrade from './senders/Upgrade';
 import addRecoveryMethods from '../addRecoveryMethods';
 
 import {
+  MAX_VERSION,
   COLONY_ROLE_ADMINISTRATION,
   COLONY_ROLE_ARCHITECTURE,
   COLONY_ROLE_ARBITRATION,
@@ -2321,6 +2322,11 @@ export default class ColonyClient extends ContractClient {
 
     if (!(this.tokenClient instanceof TokenClient)) {
       this.tokenClient = await this.getTokenClient();
+    }
+
+    const { version } = await this.getVersion.call();
+    if (version > MAX_VERSION) {
+      throw new Error(`Only versions ${MAX_VERSION} and below are supported`);
     }
 
     return this;

--- a/packages/colony-js-client/src/ColonyClient/index.js
+++ b/packages/colony-js-client/src/ColonyClient/index.js
@@ -28,6 +28,7 @@ import TransferExpenditure from './senders/TransferExpenditure';
 import DomainAuth, { getDomainIdFromPot } from './senders/DomainAuth';
 import SetAdminRole from './senders/SetAdminRole';
 import SetFounderRole from './senders/SetFounderRole';
+import Upgrade from './senders/Upgrade';
 import addRecoveryMethods from '../addRecoveryMethods';
 
 import {
@@ -2822,6 +2823,12 @@ export default class ColonyClient extends ContractClient {
         },
       ],
     });
+    this.upgrade = new Upgrade({
+      client: this,
+      name: 'upgrade',
+      functionName: 'upgrade',
+      input: [['newVersion', 'number']],
+    });
 
     // Task callers
     const makeTaskCaller = (
@@ -3291,9 +3298,6 @@ export default class ColonyClient extends ContractClient {
     this.addSender('transferExpenditureViaOwnership', {
       functionName: 'transferExpenditure(uint256,address)',
       input: [['expenditureId', 'number'], ['newOwner', 'anyAddress']],
-    });
-    this.addSender('upgrade', {
-      input: [['newVersion', 'number']],
     });
 
     // Meta Colony senders

--- a/packages/colony-js-client/src/ColonyClient/senders/Upgrade.js
+++ b/packages/colony-js-client/src/ColonyClient/senders/Upgrade.js
@@ -1,0 +1,14 @@
+/* @flow */
+/* eslint-disable import/no-cycle */
+
+import ContractClient from '@colony/colony-js-contract-client';
+import { MAX_VERSION } from '../../constants';
+
+export default class Upgrade extends ContractClient.Sender<*, *, *, *> {
+  async send(inputValues: *, options: *) {
+    if (inputValues.newVersion > MAX_VERSION) {
+      throw new Error(`Only versions ${MAX_VERSION} and below are supported`);
+    }
+    return super.send(inputValues, options);
+  }
+}

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -14,6 +14,7 @@ import TokenLockingClient from '../TokenLockingClient/index';
 
 import LookupRegisteredENSDomain from './callers/LookupRegisteredENSDomain';
 import CreateToken from './senders/CreateToken';
+import CreateColony from './senders/CreateColony';
 import addRecoveryMethods from '../addRecoveryMethods';
 
 type Address = string;
@@ -194,17 +195,22 @@ export default class ColonyNetworkClient extends ContractClient {
   createColony: ColonyNetworkClient.Sender<
     {
       tokenAddress: Address, // The address of the token contract that will become the native token for the colony.
+      version: number, // The Colony version to deploy (`0` deploys the current version).
+      colonyName: string, // The ENS name to set for the colony ('' sets no name).
+      orbitdb: string, // The orbitdb address for the ENS name.
+      useExtensionManager: boolean, // Whether or not to give the ExtensionManager root permission.
     },
     {
       SkillAdded: SkillAdded,
       ColonyAdded: ColonyAdded,
       RecoveryRoleSet: RecoveryRoleSet,
+      ColonyLabelRegistered: ColonyLabelRegistered,
     },
     ColonyNetworkClient,
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 'glider',
+      version: 'burgandy-glider',
     },
   >;
 
@@ -1103,6 +1109,25 @@ export default class ColonyNetworkClient extends ContractClient {
     // Custom senders
     this.createToken = new CreateToken({ client: this });
 
+    this.createColony = new CreateColony({
+      client: this,
+      name: 'createColony',
+      functionName: 'createColony',
+      input: [
+        ['tokenAddress', 'address'],
+        ['version', 'number'],
+        ['colonyName', 'string'],
+        ['orbitdb', 'string'],
+        ['useExtensionManager', 'boolean'],
+      ],
+      defaultValues: {
+        version: 0,
+        colonyName: '',
+        orbitdb: '',
+        useExtensionManager: false,
+      },
+    });
+
     // Events
     this.addEvent('AuctionCreated', [
       ['auction', 'address'],
@@ -1284,9 +1309,6 @@ export default class ColonyNetworkClient extends ContractClient {
         ['amount', 'bigNumber'],
         ['skillId', 'number'],
       ],
-    });
-    this.addSender('createColony', {
-      input: [['tokenAddress', 'address']],
     });
     this.addSender('createMetaColony', {
       input: [['tokenAddress', 'address']],

--- a/packages/colony-js-client/src/ColonyNetworkClient/index.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/index.js
@@ -16,6 +16,7 @@ import LookupRegisteredENSDomain from './callers/LookupRegisteredENSDomain';
 import CreateToken from './senders/CreateToken';
 import CreateColony from './senders/CreateColony';
 import addRecoveryMethods from '../addRecoveryMethods';
+import { MAX_VERSION } from '../constants';
 
 type Address = string;
 type AnyAddress = string;
@@ -210,7 +211,7 @@ export default class ColonyNetworkClient extends ContractClient {
     {
       contract: 'ColonyNetwork.sol',
       interface: 'IColonyNetwork.sol',
-      version: 'burgandy-glider',
+      version: 'burgundy-glider',
     },
   >;
 
@@ -1121,7 +1122,7 @@ export default class ColonyNetworkClient extends ContractClient {
         ['useExtensionManager', 'boolean'],
       ],
       defaultValues: {
-        version: 0,
+        version: MAX_VERSION,
         colonyName: '',
         orbitdb: '',
         useExtensionManager: false,

--- a/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateColony.js
+++ b/packages/colony-js-client/src/ColonyNetworkClient/senders/CreateColony.js
@@ -1,0 +1,14 @@
+/* @flow */
+/* eslint-disable import/no-cycle */
+
+import ContractClient from '@colony/colony-js-contract-client';
+import { MAX_VERSION } from '../../constants';
+
+export default class CreateColony extends ContractClient.Sender<*, *, *, *> {
+  async send(inputValues: *, options: *) {
+    if (inputValues.version > MAX_VERSION) {
+      throw new Error(`Only versions ${MAX_VERSION} and below are supported`);
+    }
+    return super.send(inputValues, options);
+  }
+}

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -7,6 +7,7 @@ import ColonyClient from '../ColonyClient';
 import ColonyNetworkClient from '../ColonyNetworkClient';
 import TokenClient from '../TokenClient';
 import TokenLockingClient from '../TokenLockingClient';
+import { MAX_VERSION } from '../constants';
 
 const colonyNetworkEvents = [
   'AuctionCreated',
@@ -216,6 +217,11 @@ describe('ColonyNetworkClient', () => {
             address: 'token address',
           })),
         };
+        client.getVersion = {
+          call: sandbox.fn().mockImplementation(async () => ({
+            version: MAX_VERSION,
+          })),
+        };
       });
 
     const colonyClient = await networkClient.getColonyClientByAddress(
@@ -236,6 +242,7 @@ describe('ColonyNetworkClient', () => {
     expect(colonyClient.getTokenAddress.call).toHaveBeenCalled();
     expect(colonyClient).toHaveProperty('tokenClient', expect.any(TokenClient));
     expect(colonyClient.tokenClient.init).toHaveBeenCalled();
+    expect(colonyClient.getVersion.call).toHaveBeenCalled();
   });
 
   test('Getting a Colony address', async () => {
@@ -291,6 +298,11 @@ describe('ColonyNetworkClient', () => {
             address: 'token address',
           })),
         };
+        client.getVersion = {
+          call: sandbox.fn().mockImplementation(async () => ({
+            version: MAX_VERSION,
+          })),
+        };
       });
 
     const metaColonyClient = await networkClient.getMetaColonyClientByAddress(
@@ -309,5 +321,6 @@ describe('ColonyNetworkClient', () => {
       tokenLockingClient: expect.any(TokenLockingClient),
     });
     expect(metaColonyClient.init).toHaveBeenCalled();
+    expect(metaColonyClient.getVersion.call).toHaveBeenCalled();
   });
 });

--- a/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
+++ b/packages/colony-js-client/src/__tests__/ColonyNetworkClient.test.js
@@ -134,6 +134,10 @@ describe('ColonyNetworkClient', () => {
     );
     expect(networkClient.createColony.input).toEqual([
       ['tokenAddress', 'address'],
+      ['version', 'number'],
+      ['colonyName', 'string'],
+      ['orbitdb', 'string'],
+      ['useExtensionManager', 'boolean'],
     ]);
 
     const response = {

--- a/packages/colony-js-client/src/constants.js
+++ b/packages/colony-js-client/src/constants.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+export const MAX_VERSION = 3; // Auburn glider
+
 export const COLONY_ROLE_ADMINISTRATION = 'ADMINISTRATION';
 export const COLONY_ROLE_ARBITRATION = 'ARBITRATION';
 export const COLONY_ROLE_ARCHITECTURE = 'ARCHITECTURE';

--- a/packages/colony-js-client/src/constants.js
+++ b/packages/colony-js-client/src/constants.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export const MAX_VERSION = 3; // Auburn glider
+export const MAX_VERSION = 4; // Burgundy glider
 
 export const COLONY_ROLE_ADMINISTRATION = 'ADMINISTRATION';
 export const COLONY_ROLE_ARBITRATION = 'ARBITRATION';


### PR DESCRIPTION
- [x] Introduce a `MAX_VERSION` constant indicating the highest Colony version supported.
- [x] Create a custom sender for the `upgrade` function, which checks against `MAX_VERSION`.
- [x] Use the overloaded `createColony` with no-op defaults.
- [x] Handle the case of a user initiating a `ColonyClient` for an unsupported colony.

