### PR TITLE
Latest version is 3 until the app is updated

### DIFF
--- a/packages/colony-js-contract-loader-network/src/NetworkLoader.js
+++ b/packages/colony-js-contract-loader-network/src/NetworkLoader.js
@@ -16,7 +16,7 @@ const DEFAULT_NETWORK = NETWORKS.MAINNET;
 
 type Network = $Values<typeof NETWORKS>;
 
-const LATEST_VERSION = 4;
+const LATEST_VERSION = 3;
 
 const CONTRACTS_MANIFEST = {
   versioned: {


### PR DESCRIPTION
There was a [change to an event](https://github.com/JoinColony/colonyNetwork/pull/693#discussion_r341070143) I had forgotten about, so version 3 colonies are not transparently supported by the v4 interfaces. As a result, for now, let's make colonyJS forget v4 contracts exist.