### PR TITLE
Conditionally initialize the oneTxPaymentClient

### DIFF
--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -94,7 +94,7 @@ export type ExtendedEstimate<
 export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
   clientType: ClientType.ColonyClient;
   networkClient: ColonyNetworkClient;
-  oneTxPaymentClient: OneTxPaymentClient;
+  oneTxPaymentClient?: OneTxPaymentClient;
   tokenClient: TokenClient;
 
   awkwardRecoveryRoleEventClient: IColonyV4;

--- a/src/clients/ColonyNetworkClient.ts
+++ b/src/clients/ColonyNetworkClient.ts
@@ -1,6 +1,7 @@
 import { ContractFactory, ContractTransaction, Signer } from 'ethers';
 import { Provider } from 'ethers/providers';
 import { BigNumber } from 'ethers/utils';
+import { AddressZero } from 'ethers/constants';
 
 import { ColonyClient } from '../index';
 
@@ -213,10 +214,13 @@ const getColonyNetworkClient = (
     const oneTxPaymentAddress = await networkClient.oneTxPaymentFactoryClient.deployedExtensions(
       colonyClient.address,
     );
-    colonyClient.oneTxPaymentClient = getOneTxPaymentClient(
-      oneTxPaymentAddress,
-      colonyClient,
-    );
+
+    if (oneTxPaymentAddress !== AddressZero) {
+      colonyClient.oneTxPaymentClient = getOneTxPaymentClient(
+        oneTxPaymentAddress,
+        colonyClient,
+      );
+    }
 
     return colonyClient;
   };


### PR DESCRIPTION
## Description

If the found address of the `OneTxPaymentClient` is the zero-address, it is not deployed yet. So we don't add the client to the `colonyClient` on initialization.