### PR TITLE
Fetch all Colony Members Reputation

### DIFF
--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -859,10 +859,6 @@ async function getReputation(
 
   const { network, reputationOracleEndpoint } = this.networkClient;
 
-  if (network !== Network.Mainnet && network !== Network.Goerli) {
-    throw new Error('This method is only supported on mainnet and goerli');
-  }
-
   const skillIdString = bigNumberify(skillId).toString();
 
   const rootHash = await this.networkClient.getReputationRootHash();

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -879,23 +879,8 @@ async function getMembersReputation(
   this: ExtendedIColony,
   skillId: BigNumberish,
 ): Promise<ReputationOracleResponse> {
-  const { network, reputationOracleEndpoint } = this.networkClient;
-
-  const skillIdString = bigNumberify(skillId).toString();
-
-  const rootHash = await this.networkClient.getReputationRootHash();
-
-  const response = await fetch(
-    `${reputationOracleEndpoint}/${network}/${rootHash}/${this.address}/${skillIdString}`,
-  );
-
-  const result = await response.json();
-
-  return {
-    ...result,
-    reputationAmount: bigNumberify(result.reputationAmount || 0),
-  };
-}
+  return this.getReputation(skillId, '');
+};
 
 async function deployTokenAuthority(
   this: ExtendedIColony,

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -879,6 +879,28 @@ async function getReputation(
   };
 }
 
+async function getMembersReputation(
+  this: ExtendedIColony,
+  skillId: BigNumberish,
+): Promise<ReputationOracleResponse> {
+  const { network, reputationOracleEndpoint } = this.networkClient;
+
+  const skillIdString = bigNumberify(skillId).toString();
+
+  const rootHash = await this.networkClient.getReputationRootHash();
+
+  const response = await fetch(
+    `${reputationOracleEndpoint}/${network}/${rootHash}/${this.address}/${skillIdString}`,
+  );
+
+  const result = await response.json();
+
+  return {
+    ...result,
+    reputationAmount: bigNumberify(result.reputationAmount || 0),
+  };
+}
+
 async function deployTokenAuthority(
   this: ExtendedIColony,
   tokenAddress: string,
@@ -994,6 +1016,7 @@ export const addExtensions = <T extends ExtendedIColony>(
   );
 
   instance.getReputation = getReputation.bind(instance);
+  instance.getMembersReputation = getMembersReputation.bind(instance);
 
   /* eslint-enable no-param-reassign, max-len */
   return instance;

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -186,6 +186,10 @@ export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
     skillId: BigNumberish,
     address: string,
   ): Promise<ReputationOracleResponse>;
+
+  getMembersReputation(
+    skillId: BigNumberish,
+  ): Promise<ReputationOracleResponse>;
 };
 
 export const getPotDomain = async (

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -189,7 +189,7 @@ export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
 
   getMembersReputation(
     skillId: BigNumberish,
-  ): Promise<ReputationOracleResponse>;
+  ): Promise<Omit<ReputationOracleResponse, 'reputationAmount'>>;
 };
 
 export const getPotDomain = async (
@@ -878,8 +878,18 @@ async function getReputation(
 async function getMembersReputation(
   this: ExtendedIColony,
   skillId: BigNumberish,
-): Promise<ReputationOracleResponse> {
-  return this.getReputation(skillId, '');
+): Promise<Omit<ReputationOracleResponse, 'reputationAmount'>> {
+  const { network, reputationOracleEndpoint } = this.networkClient;
+
+  const skillIdString = bigNumberify(skillId).toString();
+
+  const rootHash = await this.networkClient.getReputationRootHash();
+
+  const response = await fetch(
+    `${reputationOracleEndpoint}/${network}/${rootHash}/${this.address}/${skillIdString}`,
+  );
+
+  return response.json();
 };
 
 async function deployTokenAuthority(


### PR DESCRIPTION
## Description

This PR adds in the `getMembersReputation` common extension, that fetches the list of all members who have reputation in the colony, sorted by said reputation.

While I was at it, I've also removed the strict network check for `getReputation`.

**Changes**

- [x] Add `getMembersReputation` method and types to common extensions
- [x] Remove `getReputation` strict network check
