### PR TITLE
Add RecoveryRoleSet event interface to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.7",
+  "version": "3.0.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.7",
+  "version": "3.0.0-alpha.8",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "license": "GPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "license": "GPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/colony-js",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "license": "GPL-3.0-only",

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -8,7 +8,6 @@ import {
   ColonyRole,
   ColonyVersion,
   FundingPotAssociatedType,
-  Network,
   ROOT_DOMAIN_ID,
 } from '../../../constants';
 import { ReputationOracleResponse } from '../../../types';
@@ -34,7 +33,12 @@ import {
 } from '../../../contracts/deploy/TokenAuthority.json';
 import { getExtensionHash } from '../../../helpers';
 
-type AnyIColony = IColonyV1 | IColonyV2 | IColonyV3 | IColonyV4 | IColonyV5;
+export type AnyIColony =
+  | IColonyV1
+  | IColonyV2
+  | IColonyV3
+  | IColonyV4
+  | IColonyV5;
 
 export type ExtendedEstimate<
   T extends AnyIColony = AnyIColony
@@ -890,7 +894,7 @@ async function getMembersReputation(
   );
 
   return response.json();
-};
+}
 
 async function deployTokenAuthority(
   this: ExtendedIColony,

--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -33,12 +33,11 @@ import {
 } from '../../../contracts/deploy/TokenAuthority.json';
 import { getExtensionHash } from '../../../helpers';
 
-export type AnyIColony =
-  | IColonyV1
-  | IColonyV2
-  | IColonyV3
-  | IColonyV4
-  | IColonyV5;
+type AnyIColony = IColonyV1 | IColonyV2 | IColonyV3 | IColonyV4 | IColonyV5;
+
+// This is exposed to type the awkward recovery event client which is basically
+// just an IColonyV4
+export type AwkwardRecoveryRoleEventClient = IColonyV4;
 
 export type ExtendedEstimate<
   T extends AnyIColony = AnyIColony

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,7 +21,7 @@ import {
   getPotDomain as exGetPotDomain,
   getPermissionProofs as exGetPermissionProofs,
   getMoveFundsPermissionProofs as exGetMoveFundsPermissionProofs,
-  AnyIColony,
+  AwkwardRecoveryRoleEventClient,
 } from './clients/Colony/extensions/commonExtensions';
 
 interface ColonyRolesMap {
@@ -92,7 +92,7 @@ export const getBlockTime = async (
  * @returns ethers Log array
  */
 export const getLogs = async (
-  client: ContractClient | AnyIColony,
+  client: ContractClient | AwkwardRecoveryRoleEventClient,
   filter: Filter,
   options: LogOptions = {
     fromBlock: 1,
@@ -121,7 +121,7 @@ export const getLogs = async (
  * @returns Parsed ethers LogDescription array (events)
  */
 export const getEvents = async (
-  client: ContractClient | AnyIColony,
+  client: ContractClient | AwkwardRecoveryRoleEventClient,
   filter: Filter,
   options?: LogOptions,
 ): Promise<LogDescription[]> => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,7 +9,6 @@ import {
 } from 'ethers/utils';
 
 import {
-  Extension,
   ColonyRole,
   ColonyRoles,
   ColonyVersion,
@@ -22,6 +21,7 @@ import {
   getPotDomain as exGetPotDomain,
   getPermissionProofs as exGetPermissionProofs,
   getMoveFundsPermissionProofs as exGetMoveFundsPermissionProofs,
+  AnyIColony,
 } from './clients/Colony/extensions/commonExtensions';
 
 interface ColonyRolesMap {
@@ -92,7 +92,7 @@ export const getBlockTime = async (
  * @returns ethers Log array
  */
 export const getLogs = async (
-  client: ContractClient,
+  client: ContractClient | AnyIColony,
   filter: Filter,
   options: LogOptions = {
     fromBlock: 1,
@@ -121,7 +121,7 @@ export const getLogs = async (
  * @returns Parsed ethers LogDescription array (events)
  */
 export const getEvents = async (
-  client: ContractClient,
+  client: ContractClient | AnyIColony,
   filter: Filter,
   options?: LogOptions,
 ): Promise<LogDescription[]> => {
@@ -252,7 +252,10 @@ export const getColonyRoles = async (
     null,
   );
 
-  const recoveryRoleEvents = await getEvents(client, recoveryRoleSetFilter);
+  const recoveryRoleEvents = await getEvents(
+    client.awkwardRecoveryRoleEventClient,
+    recoveryRoleSetFilter,
+  );
 
   // We construct a map that holds all users with all domains and the roles as Sets
   const rolesMap: ColonyRolesMap = colonyRoleEvents.reduce(


### PR DESCRIPTION
This PR manually adds in the `RecoveryRoleSet` event interface to the `v3` contracts _(as opposed to generating them automatically)_

This was needed, since the `awkwardRecoveryRoleEventClient` did not provide sufficient safeguard for `v3` colonies and so, fetching the `RecoveryRoleSet` events in the [helpers](https://github.com/JoinColony/colonyJS/blob/815b66fef7f484aa792ffa3557358ef657eae274/src/helpers.ts#L255) returns an array containing a `null` value. Eg:

```js
[null]
```

The helpers then [try to deconstruct](https://github.com/JoinColony/colonyJS/blob/815b66fef7f484aa792ffa3557358ef657eae274/src/helpers.ts#L282) a `values` object from this null value, which, in turn, turns into an error that crashes both colonyJS and the app.

See the error in the app:
![Screenshot from 2020-11-23 17-02-45](https://user-images.githubusercontent.com/1193222/99977786-c3a69b00-2dad-11eb-8b2a-31a230e95389.png)

_(The above is actually coming from `apollo` since when the `helpers` throw the respective error, we're actually inside the `ColonyFromName` query)_
