### PR TITLE
Fix `getMembersReputation` common extension Types

### DIFF
--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -10,7 +10,10 @@ import {
   FundingPotAssociatedType,
   ROOT_DOMAIN_ID,
 } from '../../../constants';
-import { ReputationOracleResponse } from '../../../types';
+import {
+  ReputationOracleResponse,
+  ReputationOracleAllMembersResponse,
+} from '../../../types';
 
 import { IColony as IColonyV1 } from '../../../contracts/1/IColony';
 import { IColony as IColonyV2 } from '../../../contracts/2/IColony';
@@ -192,7 +195,7 @@ export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
 
   getMembersReputation(
     skillId: BigNumberish,
-  ): Promise<Omit<ReputationOracleResponse, 'reputationAmount'>>;
+  ): Promise<ReputationOracleAllMembersResponse>;
 };
 
 export const getPotDomain = async (
@@ -881,7 +884,7 @@ async function getReputation(
 async function getMembersReputation(
   this: ExtendedIColony,
   skillId: BigNumberish,
-): Promise<Omit<ReputationOracleResponse, 'reputationAmount'>> {
+): Promise<ReputationOracleAllMembersResponse> {
   const { network, reputationOracleEndpoint } = this.networkClient;
 
   const skillIdString = bigNumberify(skillId).toString();

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,7 @@ export interface ReputationOracleResponse {
   value: string;
   reputationAmount: BigNumber;
 }
+
+export interface ReputationOracleAllMembersResponse {
+  addresses: string[];
+}


### PR DESCRIPTION
Just as it says on the tin, this is just a small PR that fixes the `getMembersReputation` common extension return types.

In my eagerness when initially implementing this, I just used the `ReputationOracleResponse` return type, totally ignoring the fact that the oracle gives a different response when just calling for the members of the colony that have reputation.

We're adding a new type interface `ReputationOracleAllMembersResponse`, and wire that up to be returned from the `getMembersReputation` common extensions method.