### PR TITLE
Fix setUserRolesWithProofs method

### DIFF
--- a/src/clients/Colony/extensions/extensionsV5.ts
+++ b/src/clients/Colony/extensions/extensionsV5.ts
@@ -2,7 +2,7 @@ import { ContractTransaction } from 'ethers';
 import { BigNumber, BigNumberish, Arrayish } from 'ethers/utils';
 
 import { TransactionOverrides } from '../../../contracts/3';
-import { ColonyRole } from '../../../constants';
+import { ColonyRole, ROOT_DOMAIN_ID } from '../../../constants';
 import { IColony as IColonyV5 } from '../../../contracts/5/IColony';
 import { IColony as IColonyV6 } from '../../../contracts/6/IColony';
 import { ColonyNetworkClient } from '../../ColonyNetworkClient';
@@ -160,10 +160,11 @@ async function setUserRolesWithProofs(
   _roles: Arrayish,
   overrides?: TransactionOverrides,
 ): Promise<ContractTransaction> {
+  const isRootDomain = _domainId === ROOT_DOMAIN_ID.toString();
   const [permissionDomainId, childSkillIndex] = await getPermissionProofs(
     this,
     _domainId,
-    ColonyRole.Architecture,
+    isRootDomain ? ColonyRole.Root : ColonyRole.Architecture,
   );
   return this.setUserRoles(
     permissionDomainId,


### PR DESCRIPTION
This PR fixes setUserRolesWithProofs method. 

Initial implementation was passing Architecture Role to getPermissionProofs method for all domains. To change any permission in root domain we need Root permission, not Architecture permission. 

Adding here check if we're in root domain and passing correct role depend on this