### PR TITLE
Add customRootHash param to getReputation method

### DIFF
--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -198,6 +198,7 @@ export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
   getReputation(
     skillId: BigNumberish,
     address: string,
+    customRootHash?: string,
   ): Promise<ReputationOracleResponse>;
 
   getMembersReputation(
@@ -865,6 +866,7 @@ async function getReputation(
   this: ExtendedIColony,
   skillId: BigNumberish,
   address: string,
+  customRootHash?: string,
 ): Promise<ReputationOracleResponse> {
   if (!isAddress(address)) {
     throw new Error('Please provide a valid address');
@@ -874,7 +876,7 @@ async function getReputation(
 
   const skillIdString = bigNumberify(skillId).toString();
 
-  const rootHash = await this.networkClient.getReputationRootHash();
+  const rootHash = customRootHash ? customRootHash : await this.networkClient.getReputationRootHash();
 
   const response = await fetch(
     `${reputationOracleEndpoint}/${network}/${rootHash}/${this.address}/${skillIdString}/${address}`,


### PR DESCRIPTION
In cases where you need reputation proof to do things on a motion(like staking), you need to use the root hash provided in the `motion` data, which may not be the current root hash. Otherwise, the values provided will be wrong.

Contributes to DEV-256
