### PR TITLE
Make `deployToken`, `deployTokenAutority` support transaction overrides

### DIFF
--- a/src/clients/Colony/extensions/commonExtensions.ts
+++ b/src/clients/Colony/extensions/commonExtensions.ts
@@ -22,7 +22,7 @@ import { IColony as IColonyV4 } from '../../../contracts/4/IColony';
 import { IColony as IColonyV5 } from '../../../contracts/5/IColony';
 import { IColony as IColonyV6 } from '../../../contracts/colony/6/IColony';
 import { IColony as IColonyV7 } from '../../../contracts/colony/7/IColony';
-import { TransactionOverrides } from '../../../contracts/1';
+import { TransactionOverrides } from '../../../contracts/6';
 import { IColonyFactory } from '../../../contracts/4/IColonyFactory';
 
 import {
@@ -130,6 +130,7 @@ export type ExtendedIColony<T extends AnyIColony = AnyIColony> = T & {
   deployTokenAuthority(
     tokenAddress: string,
     allowedToTransfer: string[],
+    overrides?: TransactionOverrides,
   ): Promise<ContractTransaction>;
 
   setArchitectureRoleWithProofs(
@@ -962,6 +963,7 @@ async function deployTokenAuthority(
   this: ExtendedIColony,
   tokenAddress: string,
   allowedToTransfer: string[],
+  overrides?: TransactionOverrides,
 ): Promise<ContractTransaction> {
   const tokenAuthorityFactory = new ContractFactory(
     tokenAuthorityAbi,
@@ -972,6 +974,7 @@ async function deployTokenAuthority(
     tokenAddress,
     this.address,
     allowedToTransfer,
+    overrides,
   );
   await tokenAuthorityContract.deployed();
   return tokenAuthorityContract.deployTransaction;

--- a/src/clients/ColonyNetworkClient.ts
+++ b/src/clients/ColonyNetworkClient.ts
@@ -14,6 +14,7 @@ import { ColonyVersion } from '../versions';
 // @TODO this _HAS_ to be the newest version _ALWAYS_. Let's try to figure out a way to make sure of this
 import { IColonyNetwork__factory as IColonyNetworkFactory } from '../contracts/6/factories/IColonyNetwork__factory';
 import { IColonyNetwork } from '../contracts/6/IColonyNetwork';
+import { TransactionOverrides } from '../contracts/6';
 import {
   abi as tokenAbi,
   bytecode as tokenBytecode,
@@ -78,6 +79,7 @@ export interface ColonyNetworkClient extends IColonyNetwork {
     name: string,
     symbol: string,
     decimals?: number,
+    overrides?: TransactionOverrides,
   ): Promise<ContractTransaction>;
   /**
    * Gets the TokenLockingClient
@@ -281,13 +283,19 @@ const getColonyNetworkClient = (
     name: string,
     symbol: string,
     decimals = 18,
+    overrides?: TransactionOverrides,
   ): Promise<ContractTransaction> => {
     const tokenFactory = new ContractFactory(
       tokenAbi,
       tokenBytecode,
       networkClient.signer,
     );
-    const tokenContract = await tokenFactory.deploy(name, symbol, decimals);
+    const tokenContract = await tokenFactory.deploy(
+      name,
+      symbol,
+      decimals,
+      overrides,
+    );
     await tokenContract.deployed();
     return tokenContract.deployTransaction;
   };


### PR DESCRIPTION
## Description

This PR fixes the `deployToken` method _(from the `networkClient`)_ and the `deployTokenAuthority` method _(from the `colonyClient`)_ to support [transaction overrides](https://github.com/JoinColony/colonyJS/blob/542d28f9222f05dfd6efcbea27439d0e480706d0/src/contracts/colony/7/index.d.ts#L10-L17) so that we can manually, or dynamically from the gas oracle, estimate the gas prices and gas limits when sending those transaction to the network(s).

Note that this patches just the above two method calls, but here is a need to make sure all our extra methods and extensions support `overrides` otherwise **we'll run into trouble again**. I've opened a issue tracking this: #495