### PR TITLE
Update `typedoc` and use custom template

### DIFF
--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -52,7 +52,7 @@
 - [WhitelistClientV1](interfaces/WhitelistClientV1.md)
 - [WhitelistClientV2](interfaces/WhitelistClientV2.md)
 
-## Type aliases
+## Type Aliases
 
 ### AnyCoinMachineClient
 
@@ -130,11 +130,11 @@ All domains the user with `address` has roles in
 
 ### COLONY\_VERSION\_LATEST
 
-• **COLONY\_VERSION\_LATEST**: `number`
+• `Const` **COLONY\_VERSION\_LATEST**: `number`
 
 ### ExtensionVersions
 
-• **ExtensionVersions**: `Object`
+• `Const` **ExtensionVersions**: `Object`
 
 #### Type declaration
 
@@ -147,7 +147,7 @@ All domains the user with `address` has roles in
 
 ## Functions
 
-### ▸ `Const` **formatColonyRoles**(`roleSetEvents`, `recoveryRoleSetEvents`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
+### ▸ **formatColonyRoles**(`roleSetEvents`, `recoveryRoleSetEvents`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
 #### Parameters
 
@@ -160,130 +160,89 @@ All domains the user with `address` has roles in
 
 `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
-### ▸ `Const` **getBlockTime**(`provider`, `blockHash`): `Promise`<`number`\>
-
-Get the JavaScript timestamp for a block
+### ▸ **getBlockTime**(`provider`, `blockHash`): `Promise`<`number`\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `provider` | `Provider` | ethers compatible Provider |
-| `blockHash` | `string` | Hash of block to get time for |
+| Name | Type |
+| :------ | :------ |
+| `provider` | `Provider` |
+| `blockHash` | `string` |
 
 #### Returns
 
 `Promise`<`number`\>
 
-block timestamp in ms
-
-### ▸ `Const` **getChildIndex**(`client`, `parentDomainId`, `domainId`): `Promise`<`BigNumber`\>
-
-Get the child index for a domain inside its corresponding skills parent children array
-
-E.g. (the values *will* differ for you!):
-domainId = 1
-corresponding skillId = 2
-parent of skillId 2:
-```
-{
- // ...
- children: [2]
-}
-```
-childSkillIndex would be 0 in this case (0-position in children array)
+### ▸ **getChildIndex**(`client`, `parentDomainId`, `domainId`): `Promise`<`BigNumber`\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
-| `parentDomainId` | `BigNumberish` | id of parent domain |
-| `domainId` | `BigNumberish` | id of the domain |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
+| `parentDomainId` | `BigNumberish` |
+| `domainId` | `BigNumberish` |
 
 #### Returns
 
 `Promise`<`BigNumber`\>
 
-Index in the `children` array (see above)
-
-### ▸ `Const` **getColonyNetworkClient**(`network`, `signerOrProvider`, `options?`): [`ColonyNetworkClient`](interfaces/ColonyNetworkClient.md)
-
-The main entry point for accessing the deployed colonyNetwork contracts
-
-Specify a network and an ethers compatible singer or provider to get back an
-initialized and extended (ethers) contract client for the colonyNetwork. From
-here you can access different colonies, extensions, ENS and other features of Colony.
-
-Example
-```ts
-import { getColonyNetworkClient, Network } = from '@colony/colony-js';
-import { providers } from 'ethers';
-
-// For local connections (run an Ethereum node on port 8545);
-const provider = new providers.JsonRpcProvider();
-
-// Just for reading data - to sign transactions we need to pass in a signer.
-const networkClient = await getColonyNetworkClient(Network.Xdai, provider);
-```
+### ▸ **getCoinMachineClient**(`colonyClient`, `address`, `version`): [`AnyCoinMachineClient`](README.md#anycoinmachineclient)
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `network` | [`Network`](enums/Network.md) | One of the available options. See [Network](enums/Network.md). |
-| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) | An [ethers](https://github.com/ethers-io/ethers.js/) compatible signer or provider instance |
-| `options?` | [`NetworkClientOptions`](interfaces/NetworkClientOptions.md) | Here you can supply options for accessing certain contracts (mostly used in local/dev environments) |
+| Name | Type |
+| :------ | :------ |
+| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
+| `address` | `string` |
+| `version` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` |
+
+#### Returns
+
+[`AnyCoinMachineClient`](README.md#anycoinmachineclient)
+
+### ▸ **getColonyNetworkClient**(`network`, `signerOrProvider`, `options?`): [`ColonyNetworkClient`](interfaces/ColonyNetworkClient.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `network` | [`Network`](enums/Network.md) |
+| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) |
+| `options?` | [`NetworkClientOptions`](interfaces/NetworkClientOptions.md) |
 
 #### Returns
 
 [`ColonyNetworkClient`](interfaces/ColonyNetworkClient.md)
 
-### ▸ `Const` **getColonyRoles**(`client`, `options?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
-
-Get an array of all roles in the colony
+### ▸ **getColonyRoles**(`client`, `options?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
-| `options?` | `LogOptions` | - |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
+| `options?` | `LogOptions` |
 
 #### Returns
 
 `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
-Array of user roles in a colony (see above) fetching it's own network events
-
-### ▸ `Const` **getEvents**(`client`, `filter`, `options?`): `Promise`<`LogDescription`[]\>
-
-Get parsed event data from filter
-
-Example:
-```typescript
-// Gets the logs for the `ColonyFundsClaimed` event (not filtered)
-const filter = colonyClient.filters.ColonyFundsClaimed(null, null, null);
-const events = await getEvents(colonyClient, filter);
-```
+### ▸ **getEvents**(`client`, `filter`, `options?`): `Promise`<`LogDescription`[]\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
-| `filter` | `Filter` | ethers compatible Filter object |
-| `options?` | `LogOptions` | Configuration options to filter logs |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) |
+| `filter` | `Filter` |
+| `options?` | `LogOptions` |
 
 #### Returns
 
 `Promise`<`LogDescription`[]\>
 
-Parsed ethers LogDescription array (events)
-
-### ▸ `Const` **getExtensionHash**(`extensionName`): `string`
-
-Hashes to identify the colony extension contracts
+### ▸ **getExtensionHash**(`extensionName`): `string`
 
 #### Parameters
 
@@ -295,26 +254,21 @@ Hashes to identify the colony extension contracts
 
 `string`
 
-### ▸ `Const` **getExtensionPermissionProofs**(`colonyClient`, `domainId`, `address?`): `Promise`<[`BigNumberish`, `BigNumberish`]\>
-
-Wrapper around `getPermissionProofs` to check two types of permissions: Funding and Administration
-To be used for checking an extension's permission in said colony
+### ▸ **getExtensionPermissionProofs**(`colonyClient`, `domainId`, `address?`): `Promise`<[`BigNumberish`, `BigNumberish`]\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> | Any ColonyClient |
-| `domainId` | `BigNumberish` | Domain id the method needs to act in |
-| `address?` | `string` | Address of the extension |
+| Name | Type |
+| :------ | :------ |
+| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
+| `domainId` | `BigNumberish` |
+| `address?` | `string` |
 
 #### Returns
 
 `Promise`<[`BigNumberish`, `BigNumberish`]\>
 
-Tuple of `[permissionDomainId, childSkillIndex]`
-
-### ▸ `Const` **getHistoricColonyRoles**(`client`, `fromBlock?`, `toBlock?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
+### ▸ **getHistoricColonyRoles**(`client`, `fromBlock?`, `toBlock?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
 #### Parameters
 
@@ -328,122 +282,113 @@ Tuple of `[permissionDomainId, childSkillIndex]`
 
 `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
-### ▸ `Const` **getLogs**(`client`, `filter`, `options?`): `Promise`<`Log`[]\>
-
-Get raw (unparsed logs) from filter
-
-Example:
-```typescript
-// Gets the logs for the `ColonyFundsClaimed` event (not filtered)
-const filter = colonyClient.filters.ColonyFundsClaimed(null, null, null);
-const logs = await getLogs(colonyClient, filter);
-```
+### ▸ **getLogs**(`client`, `filter`, `options?`): `Promise`<`Log`[]\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
-| `filter` | `Filter` | ethers compatible Filter object |
-| `options` | `LogOptions` | Configuration options to filter logs |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) |
+| `filter` | `Filter` |
+| `options` | `LogOptions` |
 
 #### Returns
 
 `Promise`<`Log`[]\>
 
-ethers Log array
-
-### ▸ `Const` **getMultipleEvents**(`client`, `filters`, `options?`): `Promise`<`LogDescription`[]\>
-
-Get multiple events from multiple filters
-
-**`remarks`** only works when all events are emitted by the same contract!
+### ▸ **getMultipleEvents**(`client`, `filters`, `options?`): `Promise`<`LogDescription`[]\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
-| `filters` | `EventFilter`[] | - |
-| `options?` | `LogOptions` | Configuration options to filter logs |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) |
+| `filters` | `EventFilter`[] |
+| `options?` | `LogOptions` |
 
 #### Returns
 
 `Promise`<`LogDescription`[]\>
 
-Parsed ethers LogDescription array (events)
-
-### ▸ `Const` **getPermissionProofs**(`client`, `domainId`, `role`, `customAddress?`): `Promise`<[`BigNumber`, `BigNumber`]\>
-
-Get the permission proofs for a user address and a certain role
-
-Certain methods on Colony contracts require so called "permission proofs". These are made up by
-the `permissionDomainId` and the `childSkillIndex`. We shall attempt an explanation here.
-
-Domains within a colony can be nested and all the permissions in a parent domain apply for all child domains.
-Yet at the time of calling a domain-permissioned method the contracts are unaware of the parent domain
-a certain user has the required permission in. So when we these methods are called we have to supply them
-the id of the parent domain the user has the permission in (it could also be the very same domain id they
-want to act in!). Furthermore for the contracts the unidirectional chain downwards we have to supply
-the method wuth the index of the domains associated skill in its parents children array
-(`childSkillIndex`, see [[`getChildIndex`]]).
-The contracts are then able to verify the permissions (the role) claimed by the caller.
-
-tl;dr:
-
-* `permissionDomainId`: id of the parent domain of the required domain the user has the required permission in
-* `childSkillIndex`: the child index for a domain inside its corresponding skills parent children array
+### ▸ **getOneTxPaymentClient**(`colonyClient`, `address`, `version`): [`AnyOneTxPaymentClient`](README.md#anyonetxpaymentclient)
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
-| `domainId` | `BigNumberish` | Domain id the method needs to act in |
-| `role` | [`ColonyRole`](enums/ColonyRole.md) | Permissioning role that the methods needs to function |
-| `customAddress?` | `string` | A custom address to get the permission proofs for (defaults to the signer's address) |
+| Name | Type |
+| :------ | :------ |
+| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
+| `address` | `string` |
+| `version` | ``2`` \| ``1`` \| ``3`` |
+
+#### Returns
+
+[`AnyOneTxPaymentClient`](README.md#anyonetxpaymentclient)
+
+### ▸ **getPermissionProofs**(`client`, `domainId`, `role`, `customAddress?`): `Promise`<[`BigNumber`, `BigNumber`]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
+| `domainId` | `BigNumberish` |
+| `role` | [`ColonyRole`](enums/ColonyRole.md) |
+| `customAddress?` | `string` |
 
 #### Returns
 
 `Promise`<[`BigNumber`, `BigNumber`]\>
 
-Tuple of `[permissionDomainId, childSkillIndex]`
-
-### ▸ `Const` **getPotDomain**(`client`, `potId`): `Promise`<`BigNumberish`\>
-
-Get the associated domain for a pot id
-
-**`remarks`** pots can be associated with different types, like domains, payments or tasks
-See [[`FundingPotAssociatedType`]] for details
+### ▸ **getPotDomain**(`client`, `potId`): `Promise`<`BigNumberish`\>
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
-| `potId` | `BigNumberish` | The funding pot id |
+| Name | Type |
+| :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
+| `potId` | `BigNumberish` |
 
 #### Returns
 
 `Promise`<`BigNumberish`\>
 
-The associated domainId
-
-### ▸ `Const` **isExtensionCompatible**(`extension`, `extensionVersion`, `colonyVersion`): `boolean`
-
-Checks the compatibility of an extension version with a colony version it requests to be installed in
-Returns `true` if an extension version is compatible with the given colony version
+### ▸ **getUtilsClient**(`address`, `signerOrProvider`): `UtilsClient`
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `extension` | [`Extension`](enums/Extension.md) | A valid `Extension` contract name |
-| `extensionVersion` | `ExtensionVersion` | The version of the extension to check against the colony |
-| `colonyVersion` | ``1`` \| ``6`` \| ``2`` \| ``4`` \| ``3`` \| ``5`` \| ``7`` \| ``8`` \| ``9`` | The version of the colony to check for |
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) |
+
+#### Returns
+
+`UtilsClient`
+
+### ▸ **getWhitelistClient**(`colonyClient`, `address`, `version`): [`AnyWhitelistClient`](README.md#anywhitelistclient)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
+| `address` | `string` |
+| `version` | ``2`` \| ``1`` |
+
+#### Returns
+
+[`AnyWhitelistClient`](README.md#anywhitelistclient)
+
+### ▸ **isExtensionCompatible**(`extension`, `extensionVersion`, `colonyVersion`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `extension` | [`Extension`](enums/Extension.md) |
+| `extensionVersion` | `ExtensionVersion` |
+| `colonyVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` |
 
 #### Returns
 
 `boolean`
-
-indication whether extension in given version is compatible with colony at the given version

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -162,54 +162,78 @@ All domains the user with `address` has roles in
 
 ### ▸ **getBlockTime**(`provider`, `blockHash`): `Promise`<`number`\>
 
+Get the JavaScript timestamp for a block
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `provider` | `Provider` |
-| `blockHash` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `provider` | `Provider` | ethers compatible Provider |
+| `blockHash` | `string` | Hash of block to get time for |
 
 #### Returns
 
 `Promise`<`number`\>
 
+block timestamp in ms
+
 ### ▸ **getChildIndex**(`client`, `parentDomainId`, `domainId`): `Promise`<`BigNumber`\>
+
+Get the child index for a domain inside its corresponding skills parent children array
+
+E.g. (the values *will* differ for you!):
+domainId = 1
+corresponding skillId = 2
+parent of skillId 2:
+```
+{
+ // ...
+ children: [2]
+}
+```
+childSkillIndex would be 0 in this case (0-position in children array)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
-| `parentDomainId` | `BigNumberish` |
-| `domainId` | `BigNumberish` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
+| `parentDomainId` | `BigNumberish` | id of parent domain |
+| `domainId` | `BigNumberish` | id of the domain |
 
 #### Returns
 
 `Promise`<`BigNumber`\>
 
-### ▸ **getCoinMachineClient**(`colonyClient`, `address`, `version`): [`AnyCoinMachineClient`](README.md#anycoinmachineclient)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
-| `address` | `string` |
-| `version` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` |
-
-#### Returns
-
-[`AnyCoinMachineClient`](README.md#anycoinmachineclient)
+Index in the `children` array (see above)
 
 ### ▸ **getColonyNetworkClient**(`network`, `signerOrProvider`, `options?`): [`ColonyNetworkClient`](interfaces/ColonyNetworkClient.md)
 
+The main entry point for accessing the deployed colonyNetwork contracts
+
+Specify a network and an ethers compatible singer or provider to get back an
+initialized and extended (ethers) contract client for the colonyNetwork. From
+here you can access different colonies, extensions, ENS and other features of Colony.
+
+Example
+```ts
+import { getColonyNetworkClient, Network } = from '@colony/colony-js';
+import { providers } from 'ethers';
+
+// For local connections (run an Ethereum node on port 8545);
+const provider = new providers.JsonRpcProvider();
+
+// Just for reading data - to sign transactions we need to pass in a signer.
+const networkClient = await getColonyNetworkClient(Network.Xdai, provider);
+```
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `network` | [`Network`](enums/Network.md) |
-| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) |
-| `options?` | [`NetworkClientOptions`](interfaces/NetworkClientOptions.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `network` | [`Network`](enums/Network.md) | One of the available options. See [Network](enums/Network.md). |
+| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) | An [ethers](https://github.com/ethers-io/ethers.js/) compatible signer or provider instance |
+| `options?` | [`NetworkClientOptions`](interfaces/NetworkClientOptions.md) | Here you can supply options for accessing certain contracts (mostly used in local/dev environments) |
 
 #### Returns
 
@@ -217,32 +241,49 @@ All domains the user with `address` has roles in
 
 ### ▸ **getColonyRoles**(`client`, `options?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
+Get an array of all roles in the colony
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
-| `options?` | `LogOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
+| `options?` | `LogOptions` | - |
 
 #### Returns
 
 `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
+Array of user roles in a colony (see above) fetching it's own network events
+
 ### ▸ **getEvents**(`client`, `filter`, `options?`): `Promise`<`LogDescription`[]\>
+
+Get parsed event data from filter
+
+Example:
+```typescript
+// Gets the logs for the `ColonyFundsClaimed` event (not filtered)
+const filter = colonyClient.filters.ColonyFundsClaimed(null, null, null);
+const events = await getEvents(colonyClient, filter);
+```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) |
-| `filter` | `Filter` |
-| `options?` | `LogOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
+| `filter` | `Filter` | ethers compatible Filter object |
+| `options?` | `LogOptions` | Configuration options to filter logs |
 
 #### Returns
 
 `Promise`<`LogDescription`[]\>
 
+Parsed ethers LogDescription array (events)
+
 ### ▸ **getExtensionHash**(`extensionName`): `string`
+
+Hashes to identify the colony extension contracts
 
 #### Parameters
 
@@ -256,17 +297,22 @@ All domains the user with `address` has roles in
 
 ### ▸ **getExtensionPermissionProofs**(`colonyClient`, `domainId`, `address?`): `Promise`<[`BigNumberish`, `BigNumberish`]\>
 
+Wrapper around `getPermissionProofs` to check two types of permissions: Funding and Administration
+To be used for checking an extension's permission in said colony
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
-| `domainId` | `BigNumberish` |
-| `address?` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> | Any ColonyClient |
+| `domainId` | `BigNumberish` | Domain id the method needs to act in |
+| `address?` | `string` | Address of the extension |
 
 #### Returns
 
 `Promise`<[`BigNumberish`, `BigNumberish`]\>
+
+Tuple of `[permissionDomainId, childSkillIndex]`
 
 ### ▸ **getHistoricColonyRoles**(`client`, `fromBlock?`, `toBlock?`): `Promise`<[`ColonyRoles`](README.md#colonyroles)\>
 
@@ -284,111 +330,120 @@ All domains the user with `address` has roles in
 
 ### ▸ **getLogs**(`client`, `filter`, `options?`): `Promise`<`Log`[]\>
 
+Get raw (unparsed logs) from filter
+
+Example:
+```typescript
+// Gets the logs for the `ColonyFundsClaimed` event (not filtered)
+const filter = colonyClient.filters.ColonyFundsClaimed(null, null, null);
+const logs = await getLogs(colonyClient, filter);
+```
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) |
-| `filter` | `Filter` |
-| `options` | `LogOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
+| `filter` | `Filter` | ethers compatible Filter object |
+| `options` | `LogOptions` | Configuration options to filter logs |
 
 #### Returns
 
 `Promise`<`Log`[]\>
 
+ethers Log array
+
 ### ▸ **getMultipleEvents**(`client`, `filters`, `options?`): `Promise`<`LogDescription`[]\>
+
+Get multiple events from multiple filters
+
+**`remarks`** only works when all events are emitted by the same contract!
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`ContractClient`](README.md#contractclient) |
-| `filters` | `EventFilter`[] |
-| `options?` | `LogOptions` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`ContractClient`](README.md#contractclient) | Any of the intantiated contract clients |
+| `filters` | `EventFilter`[] | - |
+| `options?` | `LogOptions` | Configuration options to filter logs |
 
 #### Returns
 
 `Promise`<`LogDescription`[]\>
 
-### ▸ **getOneTxPaymentClient**(`colonyClient`, `address`, `version`): [`AnyOneTxPaymentClient`](README.md#anyonetxpaymentclient)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
-| `address` | `string` |
-| `version` | ``2`` \| ``1`` \| ``3`` |
-
-#### Returns
-
-[`AnyOneTxPaymentClient`](README.md#anyonetxpaymentclient)
+Parsed ethers LogDescription array (events)
 
 ### ▸ **getPermissionProofs**(`client`, `domainId`, `role`, `customAddress?`): `Promise`<[`BigNumber`, `BigNumber`]\>
 
+Get the permission proofs for a user address and a certain role
+
+Certain methods on Colony contracts require so called "permission proofs". These are made up by
+the `permissionDomainId` and the `childSkillIndex`. We shall attempt an explanation here.
+
+Domains within a colony can be nested and all the permissions in a parent domain apply for all child domains.
+Yet at the time of calling a domain-permissioned method the contracts are unaware of the parent domain
+a certain user has the required permission in. So when we these methods are called we have to supply them
+the id of the parent domain the user has the permission in (it could also be the very same domain id they
+want to act in!). Furthermore for the contracts the unidirectional chain downwards we have to supply
+the method wuth the index of the domains associated skill in its parents children array
+(`childSkillIndex`, see [[`getChildIndex`]]).
+The contracts are then able to verify the permissions (the role) claimed by the caller.
+
+tl;dr:
+
+* `permissionDomainId`: id of the parent domain of the required domain the user has the required permission in
+* `childSkillIndex`: the child index for a domain inside its corresponding skills parent children array
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
-| `domainId` | `BigNumberish` |
-| `role` | [`ColonyRole`](enums/ColonyRole.md) |
-| `customAddress?` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
+| `domainId` | `BigNumberish` | Domain id the method needs to act in |
+| `role` | [`ColonyRole`](enums/ColonyRole.md) | Permissioning role that the methods needs to function |
+| `customAddress?` | `string` | A custom address to get the permission proofs for (defaults to the signer's address) |
 
 #### Returns
 
 `Promise`<[`BigNumber`, `BigNumber`]\>
 
+Tuple of `[permissionDomainId, childSkillIndex]`
+
 ### ▸ **getPotDomain**(`client`, `potId`): `Promise`<`BigNumberish`\>
+
+Get the associated domain for a pot id
+
+**`remarks`** pots can be associated with different types, like domains, payments or tasks
+See [[`FundingPotAssociatedType`]] for details
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `client` | [`AnyColonyClient`](README.md#anycolonyclient) |
-| `potId` | `BigNumberish` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [`AnyColonyClient`](README.md#anycolonyclient) | Any ColonyClient |
+| `potId` | `BigNumberish` | The funding pot id |
 
 #### Returns
 
 `Promise`<`BigNumberish`\>
 
-### ▸ **getUtilsClient**(`address`, `signerOrProvider`): `UtilsClient`
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `address` | `string` |
-| `signerOrProvider` | [`SignerOrProvider`](README.md#signerorprovider) |
-
-#### Returns
-
-`UtilsClient`
-
-### ▸ **getWhitelistClient**(`colonyClient`, `address`, `version`): [`AnyWhitelistClient`](README.md#anywhitelistclient)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `colonyClient` | `AugmentedIColony`<`AnyIColony`\> |
-| `address` | `string` |
-| `version` | ``2`` \| ``1`` |
-
-#### Returns
-
-[`AnyWhitelistClient`](README.md#anywhitelistclient)
+The associated domainId
 
 ### ▸ **isExtensionCompatible**(`extension`, `extensionVersion`, `colonyVersion`): `boolean`
 
+Checks the compatibility of an extension version with a colony version it requests to be installed in
+Returns `true` if an extension version is compatible with the given colony version
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `extension` | [`Extension`](enums/Extension.md) |
-| `extensionVersion` | `ExtensionVersion` |
-| `colonyVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `extension` | [`Extension`](enums/Extension.md) | A valid `Extension` contract name |
+| `extensionVersion` | `ExtensionVersion` | The version of the extension to check against the colony |
+| `colonyVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` | The version of the colony to check for |
 
 #### Returns
 
 `boolean`
+
+indication whether extension in given version is compatible with colony at the given version

--- a/docs/reference/api/enums/ClientType.md
+++ b/docs/reference/api/enums/ClientType.md
@@ -3,43 +3,42 @@
 The type for a specific contract-client (extended ethers `Contract`).
 This is being used for TypeScript's discriminative unions (to make assumptions about what functionality is available on this contract)
 
-**`remarks`**
-Every contract-client in ColonyJS needs to have a clientType property which a value of this enum needs to be assigned to
+**`remarks`** Every contract-client in ColonyJS needs to have a clientType property which a value of this enum needs to be assigned to
 
-## Enumeration members
+## Enumeration Members
 
 ### CoinMachineClient
 
-• **CoinMachineClient** = `"CoinMachineClient"`
+• **CoinMachineClient**
 
 ### ColonyClient
 
-• **ColonyClient** = `"ColonyClient"`
+• **ColonyClient**
 
 ### NetworkClient
 
-• **NetworkClient** = `"NetworkClient"`
+• **NetworkClient**
 
 ### OneTxPaymentClient
 
-• **OneTxPaymentClient** = `"OneTxPaymentClient"`
+• **OneTxPaymentClient**
 
 ### TokenClient
 
-• **TokenClient** = `"TokenClient"`
+• **TokenClient**
 
 ### TokenLockingClient
 
-• **TokenLockingClient** = `"TokenLockingClient"`
+• **TokenLockingClient**
 
 ### UtilsClient
 
-• **UtilsClient** = `"UtilsClient"`
+• **UtilsClient**
 
 ### VotingReputationClient
 
-• **VotingReputationClient** = `"VotingReputationClient"`
+• **VotingReputationClient**
 
 ### WhitelistClient
 
-• **WhitelistClient** = `"WhitelistClient"`
+• **WhitelistClient**

--- a/docs/reference/api/enums/ColonyNetworkAddress.md
+++ b/docs/reference/api/enums/ColonyNetworkAddress.md
@@ -2,40 +2,40 @@
 
 Addresses of the deployed ColonyNetwork EtherRouter contracts in all networks
 
-## Enumeration members
+## Enumeration Members
 
 ### Custom
 
-• **Custom** = `""`
+• **Custom**
 
 Placeholder for a locally deployed EtherRouter address
 
 ### Gnosis
 
-• **Gnosis** = `"0x78163f593D1Fa151B4B7cacD146586aD2b686294"`
+• **Gnosis**
 
 The ColonyNetwork EtherRouter address on Gnosis chain
 
 ### Goerli
 
-• **Goerli** = `"0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B"`
+• **Goerli**
 
 The ColonyNetwork EtherRouter address on the Görli testnet
 
 ### Mainnet
 
-• **Mainnet** = `"0x5346D0f80e2816FaD329F2c140c870ffc3c3E2Ef"`
+• **Mainnet**
 
 The ColonyNetwork EtherRouter address on mainnet
 
 ### Xdai
 
-• **Xdai** = `"0x78163f593D1Fa151B4B7cacD146586aD2b686294"`
+• **Xdai**
 
 The ColonyNetwork EtherRouter address on Gnosis chain (alias)
 
 ### XdaiQa
 
-• **XdaiQa** = `"0x78163f593D1Fa151B4B7cacD146586aD2b686294"`
+• **XdaiQa**
 
 The ColonyNetwork EtherRouter fork address on Gnosis chain

--- a/docs/reference/api/enums/ColonyRole.md
+++ b/docs/reference/api/enums/ColonyRole.md
@@ -2,35 +2,34 @@
 
 Available roles in the colonyNetwork. Find out more here: https://github.com/JoinColony/colonyNetwork/blob/develop/docs/_Docs_Permissions.md
 
-## Enumeration members
+## Enumeration Members
 
 ### Administration
 
-• **Administration** = `6`
+• **Administration**
 
 ### Arbitration
 
-• **Arbitration** = `2`
+• **Arbitration**
 
 ### Architecture
 
-• **Architecture** = `3`
+• **Architecture**
 
 ### ArchitectureSubdomain
 
-• **ArchitectureSubdomain** = `4`
+• **ArchitectureSubdomain**
 
-**`deprecated`**
-The `ArchitectureSubdomain` role has been deprecated and should not be used
+**`deprecated`** The `ArchitectureSubdomain` role has been deprecated and should not be used
 
 ### Funding
 
-• **Funding** = `5`
+• **Funding**
 
 ### Recovery
 
-• **Recovery** = `0`
+• **Recovery**
 
 ### Root
 
-• **Root** = `1`
+• **Root**

--- a/docs/reference/api/enums/Core.md
+++ b/docs/reference/api/enums/Core.md
@@ -2,8 +2,8 @@
 
 Versioned core contract names
 
-## Enumeration members
+## Enumeration Members
 
 ### IColony
 
-• **IColony** = `"IColony"`
+• **IColony**

--- a/docs/reference/api/enums/Extension.md
+++ b/docs/reference/api/enums/Extension.md
@@ -2,20 +2,20 @@
 
 Extension contract names
 
-## Enumeration members
+## Enumeration Members
 
 ### CoinMachine
 
-• **CoinMachine** = `"CoinMachine"`
+• **CoinMachine**
 
 ### OneTxPayment
 
-• **OneTxPayment** = `"OneTxPayment"`
+• **OneTxPayment**
 
 ### VotingReputation
 
-• **VotingReputation** = `"VotingReputation"`
+• **VotingReputation**
 
 ### Whitelist
 
-• **Whitelist** = `"Whitelist"`
+• **Whitelist**

--- a/docs/reference/api/enums/FundingPotAssociatedType.md
+++ b/docs/reference/api/enums/FundingPotAssociatedType.md
@@ -3,24 +3,24 @@
 Funding pots can have different types in a colony.
 See [here](https://github.com/JoinColony/colonyNetwork/blob/develop/docs/_TLDR_Pots.md#types-of-pots) for more details
 
-## Enumeration members
+## Enumeration Members
 
 ### Domain
 
-• **Domain** = `1`
+• **Domain**
 
 ### Expenditure
 
-• **Expenditure** = `4`
+• **Expenditure**
 
 ### Payment
 
-• **Payment** = `3`
+• **Payment**
 
 ### Task
 
-• **Task** = `2`
+• **Task**
 
 ### Unassigned
 
-• **Unassigned** = `0`
+• **Unassigned**

--- a/docs/reference/api/enums/Id.md
+++ b/docs/reference/api/enums/Id.md
@@ -2,22 +2,22 @@
 
 Shortcuts to certain IDs within Colony
 
-## Enumeration members
+## Enumeration Members
 
 ### RootDomain
 
-• **RootDomain** = `1`
+• **RootDomain**
 
 The id of the root-domain in all colonies
 
 ### RootPot
 
-• **RootPot** = `1`
+• **RootPot**
 
 The id of the root fundig pot in all colonies
 
 ### SkillIgnore
 
-• **SkillIgnore** = `0`
+• **SkillIgnore**
 
 Ignore the skill id for this method (global skill 0)

--- a/docs/reference/api/enums/MotionState.md
+++ b/docs/reference/api/enums/MotionState.md
@@ -2,36 +2,36 @@
 
 These are the various states a Motion might find itself in
 
-## Enumeration members
+## Enumeration Members
 
 ### Closed
 
-• **Closed** = `4`
+• **Closed**
 
 ### Failed
 
-• **Failed** = `7`
+• **Failed**
 
 ### Finalizable
 
-• **Finalizable** = `5`
+• **Finalizable**
 
 ### Finalized
 
-• **Finalized** = `6`
+• **Finalized**
 
 ### Null
 
-• **Null** = `0`
+• **Null**
 
 ### Reveal
 
-• **Reveal** = `3`
+• **Reveal**
 
 ### Staking
 
-• **Staking** = `1`
+• **Staking**
 
 ### Submit
 
-• **Submit** = `2`
+• **Submit**

--- a/docs/reference/api/enums/Network.md
+++ b/docs/reference/api/enums/Network.md
@@ -2,24 +2,24 @@
 
 Supported Ethereum networks. Use `Custom` if you'd like to bring your own deployment (e.g. local)
 
-## Enumeration members
+## Enumeration Members
 
 ### Custom
 
-• **Custom** = `"Custom"`
+• **Custom**
 
 ### Goerli
 
-• **Goerli** = `"Goerli"`
+• **Goerli**
 
 ### Mainnet
 
-• **Mainnet** = `"Mainnet"`
+• **Mainnet**
 
 ### Xdai
 
-• **Xdai** = `"Xdai"`
+• **Xdai**
 
 ### XdaiQa
 
-• **XdaiQa** = `"XdaiQa"`
+• **XdaiQa**

--- a/docs/reference/api/enums/ReputationMinerEndpoints.md
+++ b/docs/reference/api/enums/ReputationMinerEndpoints.md
@@ -1,19 +1,19 @@
 # Enumeration: ReputationMinerEndpoints
 
-## Enumeration members
+## Enumeration Members
 
 ### UserReputationInAllDomains
 
-• **UserReputationInAllDomains** = `"UserReputationInAllDomains"`
+• **UserReputationInAllDomains**
 
 ### UserReputationInSingleDomainWithProofs
 
-• **UserReputationInSingleDomainWithProofs** = `"UserReputationInSingleDomainWithProofs"`
+• **UserReputationInSingleDomainWithProofs**
 
 ### UserReputationInSingleDomainWithoutProofs
 
-• **UserReputationInSingleDomainWithoutProofs** = `"UserReputationInSingleDomainWithoutProofs"`
+• **UserReputationInSingleDomainWithoutProofs**
 
 ### UsersWithReputationInColony
 
-• **UsersWithReputationInColony** = `"UsersWithReputationInColony"`
+• **UsersWithReputationInColony**

--- a/docs/reference/api/enums/ReputationOracleEndpoint.md
+++ b/docs/reference/api/enums/ReputationOracleEndpoint.md
@@ -2,28 +2,28 @@
 
 HTTP endpoint of the official colony reputation oracle
 
-## Enumeration members
+## Enumeration Members
 
 ### Custom
 
-• **Custom** = `"http://localhost:3000"`
+• **Custom**
 
 ### Gnosis
 
-• **Gnosis** = `"https://xdai.colony.io/reputation/xdai"`
+• **Gnosis**
 
 ### Goerli
 
-• **Goerli** = `"https://colony.io/reputation/goerli"`
+• **Goerli**
 
 ### Mainnet
 
-• **Mainnet** = `"https://colony.io/reputation/mainnet"`
+• **Mainnet**
 
 ### Xdai
 
-• **Xdai** = `"https://xdai.colony.io/reputation/xdai"`
+• **Xdai**
 
 ### XdaiQa
 
-• **XdaiQa** = `"https://qaxdai.colony.io/reputation/xdai"`
+• **XdaiQa**

--- a/docs/reference/api/enums/TokenClientType.md
+++ b/docs/reference/api/enums/TokenClientType.md
@@ -4,16 +4,16 @@ We support different TokenClients, especially the ColonyToken client with
 its advanced functionality (to `.mint()` tokens for example). Other tokens
 require certain adjustments (like the original Dai (SAI))
 
-## Enumeration members
+## Enumeration Members
 
 ### Colony
 
-• **Colony** = `"Colony"`
+• **Colony**
 
 ### Erc20
 
-• **Erc20** = `"Erc20"`
+• **Erc20**
 
 ### Sai
 
-• **Sai** = `"Sai"`
+• **Sai**

--- a/docs/reference/api/enums/Tokens.Gnosis.md
+++ b/docs/reference/api/enums/Tokens.Gnosis.md
@@ -4,16 +4,16 @@
 
 Tokens deployed on Gnosis Chain
 
-## Enumeration members
+## Enumeration Members
 
 ### CLNY
 
-• **CLNY** = `"0xc9B6218AffE8Aba68a13899Cbf7cF7f14DDd304C"`
+• **CLNY**
 
 CLNY on Gnosis Chain
 
 ### XDAI
 
-• **XDAI** = `"0x0000000000000000000000000000000000000000"`
+• **XDAI**
 
 XDAI on Gnosis Chain

--- a/docs/reference/api/enums/Tokens.Mainnet.md
+++ b/docs/reference/api/enums/Tokens.Mainnet.md
@@ -4,16 +4,16 @@
 
 Tokens deployed on Mainnet
 
-## Enumeration members
+## Enumeration Members
 
 ### ETH
 
-• **ETH** = `"0x0000000000000000000000000000000000000000"`
+• **ETH**
 
 ETH on Mainnet
 
 ### Mainnet
 
-• **Mainnet** = `"0x3E828ac5C480069D4765654Fb4b8733b910b13b2"`
+• **Mainnet**
 
 CLNY on Mainnet

--- a/docs/reference/api/interfaces/CoinMachineClientV1.md
+++ b/docs/reference/api/interfaces/CoinMachineClientV1.md
@@ -2,12 +2,6 @@
 
 An instantiated [ethers](https://docs.ethers.io/v5/) contract for the [CoinMachine contract](https://github.com/JoinColony/colonyNetwork/blob/develop/contracts/extensions/CoinMachine.sol) in version 1, with certain augmentations added. Pay attention to the existence of `...WithProofs` or `...Checked` functions as these provide convenient helpers to figure out permission proofs and contract checks for you.
 
-## Hierarchy
-
-- `AugmentedCoinMachine`<`CoinMachine`\>
-
-  ↳ **`CoinMachineClientV1`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +12,9 @@ An instantiated [ethers](https://docs.ethers.io/v5/) contract for the [CoinMachi
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -72,10 +58,6 @@ An instantiated [ethers](https://docs.ethers.io/v5/) contract for the [CoinMachi
 ### clientVersion
 
 • **clientVersion**: ``1``
-
-#### Overrides
-
-AugmentedCoinMachine.clientVersion
 
 ### coinMachineEvents
 
@@ -324,7 +306,7 @@ Purchase tokens from Coin Machine.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/CoinMachineClientV2.md
+++ b/docs/reference/api/interfaces/CoinMachineClientV2.md
@@ -1,11 +1,5 @@
 # Interface: CoinMachineClientV2
 
-## Hierarchy
-
-- `AugmentedCoinMachine`<`CoinMachine`\>
-
-  ↳ **`CoinMachineClientV2`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -82,10 +68,6 @@
 ### clientVersion
 
 • **clientVersion**: ``2``
-
-#### Overrides
-
-AugmentedCoinMachine.clientVersion
 
 ### coinMachineEvents
 
@@ -374,7 +356,7 @@ Purchase tokens from Coin Machine.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/CoinMachineClientV3.md
+++ b/docs/reference/api/interfaces/CoinMachineClientV3.md
@@ -1,11 +1,5 @@
 # Interface: CoinMachineClientV3
 
-## Hierarchy
-
-- `AugmentedCoinMachine`<`CoinMachine`\>
-
-  ↳ **`CoinMachineClientV3`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -82,10 +68,6 @@
 ### clientVersion
 
 • **clientVersion**: ``3``
-
-#### Overrides
-
-AugmentedCoinMachine.clientVersion
 
 ### coinMachineEvents
 
@@ -374,7 +356,7 @@ Purchase tokens from Coin Machine.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/CoinMachineClientV4.md
+++ b/docs/reference/api/interfaces/CoinMachineClientV4.md
@@ -1,11 +1,5 @@
 # Interface: CoinMachineClientV4
 
-## Hierarchy
-
-- `AugmentedCoinMachine`<`CoinMachine`\>
-
-  ↳ **`CoinMachineClientV4`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -82,10 +68,6 @@
 ### clientVersion
 
 • **clientVersion**: ``4``
-
-#### Overrides
-
-AugmentedCoinMachine.clientVersion
 
 ### coinMachineEvents
 
@@ -374,7 +356,7 @@ Purchase tokens from Coin Machine.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/CoinMachineClientV5.md
+++ b/docs/reference/api/interfaces/CoinMachineClientV5.md
@@ -1,11 +1,5 @@
 # Interface: CoinMachineClientV5
 
-## Hierarchy
-
-- `AugmentedCoinMachine`<`CoinMachine`\>
-
-  ↳ **`CoinMachineClientV5`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -86,10 +72,6 @@
 ### clientVersion
 
 • **clientVersion**: ``5``
-
-#### Overrides
-
-AugmentedCoinMachine.clientVersion
 
 ### coinMachineEvents
 
@@ -392,7 +374,7 @@ Purchase tokens from Coin Machine.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/ColonyClientV1.md
+++ b/docs/reference/api/interfaces/ColonyClientV1.md
@@ -1,17 +1,5 @@
 # Interface: ColonyClientV1
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `AddDomainAugmentsA`<`IColony`\>
-
-- `SetPaymentDomainAugments`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-  ↳ **`ColonyClientV1`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -22,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -45,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``1``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -65,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV1Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -241,9 +213,7 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 
 ### ▸ **addDomainWithProofs**(`_parentDomainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [addDomain](ColonyClientV1.md#adddomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [addDomain](ColonyClientV1.md#adddomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -480,7 +450,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -882,8 +852,7 @@ count The payment count
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV1.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV1.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1277,9 +1246,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV1.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV1.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -1610,9 +1577,7 @@ Sets the domain on an existing payment. Secured function to authorised members
 
 ### ▸ **setPaymentDomainWithProofs**(`_id`, `_domainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setPaymentDomain](ColonyClientV1.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setPaymentDomain](ColonyClientV1.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV2.md
+++ b/docs/reference/api/interfaces/ColonyClientV2.md
@@ -1,17 +1,5 @@
 # Interface: ColonyClientV2
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `AddDomainAugmentsA`<`IColony`\>
-
-- `SetPaymentDomainAugments`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-  ↳ **`ColonyClientV2`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -22,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -45,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``2``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -65,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV2Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -235,9 +207,7 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 
 ### ▸ **addDomainWithProofs**(`_parentDomainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [addDomain](ColonyClientV2.md#adddomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [addDomain](ColonyClientV2.md#adddomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -474,7 +444,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -876,8 +846,7 @@ count The payment count
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV2.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV2.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1273,9 +1242,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV2.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV2.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -1606,9 +1573,7 @@ Sets the domain on an existing payment. Secured function to authorised members
 
 ### ▸ **setPaymentDomainWithProofs**(`_id`, `_domainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setPaymentDomain](ColonyClientV2.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setPaymentDomain](ColonyClientV2.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV3.md
+++ b/docs/reference/api/interfaces/ColonyClientV3.md
@@ -1,19 +1,5 @@
 # Interface: ColonyClientV3
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `AddDomainAugmentsA`<`IColony`\>
-
-- `SetPaymentDomainAugments`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-  ↳ **`ColonyClientV3`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -24,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -47,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``3``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -67,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV3Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -237,9 +207,7 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 
 ### ▸ **addDomainWithProofs**(`_parentDomainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [addDomain](ColonyClientV3.md#adddomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [addDomain](ColonyClientV3.md#adddomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -476,7 +444,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -908,8 +876,7 @@ count The payment count
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV3.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV3.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1305,9 +1272,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV3.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV3.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -1675,9 +1640,7 @@ Sets the domain on an existing payment. Secured function to authorised members
 
 ### ▸ **setPaymentDomainWithProofs**(`_id`, `_domainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setPaymentDomain](ColonyClientV3.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setPaymentDomain](ColonyClientV3.md#setpaymentdomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV4.md
+++ b/docs/reference/api/interfaces/ColonyClientV4.md
@@ -1,23 +1,5 @@
 # Interface: ColonyClientV4
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `AddDomainAugmentsA`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-- `SetExpenditureClaimDelayAugments`<`IColony`\>
-
-- `SetExpenditurePayoutModifierAugments`<`IColony`\>
-
-  ↳ **`ColonyClientV4`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -28,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -51,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``4``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -71,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV4Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -255,9 +221,7 @@ Add a colony domain, and its respective local skill under skill with id `_parent
 
 ### ▸ **addDomainWithProofs**(`_parentDomainId`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [addDomain](ColonyClientV4.md#adddomain), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [addDomain](ColonyClientV4.md#adddomain), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -526,7 +490,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1028,8 +992,7 @@ count The payment count
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV4.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV4.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1517,9 +1480,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV4.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV4.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -1851,9 +1812,7 @@ Set the claim delay on an expenditure slot. Can only be called by Arbitration ro
 
 ### ▸ **setExpenditureClaimDelayWithProofs**(`_id`, `_slot`, `_claimDelay`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditureClaimDelay](ColonyClientV4.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditureClaimDelay](ColonyClientV4.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -1909,9 +1868,7 @@ Set the payout modifier on an expenditure slot. Can only be called by Arbitratio
 
 ### ▸ **setExpenditurePayoutModifierWithProofs**(`_id`, `_slot`, `_payoutModifier`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditurePayoutModifier](ColonyClientV4.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditurePayoutModifier](ColonyClientV4.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2428,9 +2385,7 @@ Updates the expenditure owner. Can only be called by Arbitration role.
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV4.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV4.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV5.md
+++ b/docs/reference/api/interfaces/ColonyClientV5.md
@@ -1,25 +1,5 @@
 # Interface: ColonyClientV5
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `ColonyAugmentsV5`<`IColony`\>
-
-- `AddDomainAugmentsB`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-- `SetExpenditureClaimDelayAugments`<`IColony`\>
-
-- `SetExpenditurePayoutModifierAugments`<`IColony`\>
-
-  ↳ **`ColonyClientV5`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -30,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -53,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``5``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -73,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV5Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -637,7 +601,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1344,8 +1308,7 @@ Get the number of payments in the colony.
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV5.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV5.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1882,9 +1845,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV5.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV5.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2230,9 +2191,7 @@ DEPRECATED Set the claim delay on an expenditure slot. Can only be called by Arb
 
 ### ▸ **setExpenditureClaimDelayWithProofs**(`_id`, `_slot`, `_claimDelay`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditureClaimDelay](ColonyClientV5.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditureClaimDelay](ColonyClientV5.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2288,9 +2247,7 @@ DEPRECATED Set the payout modifier on an expenditure slot. Can only be called by
 
 ### ▸ **setExpenditurePayoutModifierWithProofs**(`_id`, `_slot`, `_payoutModifier`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditurePayoutModifier](ColonyClientV5.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditurePayoutModifier](ColonyClientV5.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2886,9 +2843,7 @@ DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV5.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV5.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV6.md
+++ b/docs/reference/api/interfaces/ColonyClientV6.md
@@ -1,25 +1,5 @@
 # Interface: ColonyClientV6
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `ColonyAugmentsV5`<`IColony`\>
-
-- `AddDomainAugmentsB`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsA`<`IColony`\>
-
-- `SetExpenditureClaimDelayAugments`<`IColony`\>
-
-- `SetExpenditurePayoutModifierAugments`<`IColony`\>
-
-  ↳ **`ColonyClientV6`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -30,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -53,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``6``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -73,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV6Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -637,7 +601,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1344,8 +1308,7 @@ Get the number of payments in the colony.
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV6.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV6.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1882,9 +1845,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots](ColonyClientV6.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots](ColonyClientV6.md#movefundsbetweenpots), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2230,9 +2191,7 @@ DEPRECATED Set the claim delay on an expenditure slot. Can only be called by Arb
 
 ### ▸ **setExpenditureClaimDelayWithProofs**(`_id`, `_slot`, `_claimDelay`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditureClaimDelay](ColonyClientV6.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditureClaimDelay](ColonyClientV6.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2288,9 +2247,7 @@ DEPRECATED Set the payout modifier on an expenditure slot. Can only be called by
 
 ### ▸ **setExpenditurePayoutModifierWithProofs**(`_id`, `_slot`, `_payoutModifier`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditurePayoutModifier](ColonyClientV6.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditurePayoutModifier](ColonyClientV6.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2886,9 +2843,7 @@ DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV6.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV6.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV7.md
+++ b/docs/reference/api/interfaces/ColonyClientV7.md
@@ -1,25 +1,5 @@
 # Interface: ColonyClientV7
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `ColonyAugmentsV5`<`IColony`\>
-
-- `AddDomainAugmentsB`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsB`<`IColony`\>
-
-- `SetExpenditureClaimDelayAugments`<`IColony`\>
-
-- `SetExpenditurePayoutModifierAugments`<`IColony`\>
-
-  ↳ **`ColonyClientV7`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -30,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -53,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``7``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -73,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV7Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -637,7 +601,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1344,8 +1308,7 @@ Get the number of payments in the colony.
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV7.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV7.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1936,9 +1899,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs(uint256,uint256,uint256,address)**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV7.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV7.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2304,9 +2265,7 @@ DEPRECATED Set the claim delay on an expenditure slot. Can only be called by Arb
 
 ### ▸ **setExpenditureClaimDelayWithProofs**(`_id`, `_slot`, `_claimDelay`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditureClaimDelay](ColonyClientV7.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditureClaimDelay](ColonyClientV7.md#setexpenditureclaimdelay), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2362,9 +2321,7 @@ DEPRECATED Set the payout modifier on an expenditure slot. Can only be called by
 
 ### ▸ **setExpenditurePayoutModifierWithProofs**(`_id`, `_slot`, `_payoutModifier`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [setExpenditurePayoutModifier](ColonyClientV7.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [setExpenditurePayoutModifier](ColonyClientV7.md#setexpenditurepayoutmodifier), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -2960,9 +2917,7 @@ DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV7.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV7.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV8.md
+++ b/docs/reference/api/interfaces/ColonyClientV8.md
@@ -1,21 +1,5 @@
 # Interface: ColonyClientV8
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `ColonyAugmentsV5`<`IColony`\>
-
-- `AddDomainAugmentsB`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsB`<`IColony`\>
-
-  ↳ **`ColonyClientV8`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -26,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -49,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``8``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -69,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV8Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -645,7 +613,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1352,8 +1320,7 @@ Get the number of payments in the colony.
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV8.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV8.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -1993,9 +1960,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs(uint256,uint256,uint256,address)**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV8.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV8.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -3089,9 +3054,7 @@ DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV8.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV8.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyClientV9.md
+++ b/docs/reference/api/interfaces/ColonyClientV9.md
@@ -1,23 +1,5 @@
 # Interface: ColonyClientV9
 
-## Hierarchy
-
-- `AugmentedIColony`<`IColony`\>
-
-- `ColonyAugmentsV3`<`IColony`\>
-
-- `ColonyAugmentsV4`<`IColony`\>
-
-- `ColonyAugmentsV5`<`IColony`\>
-
-- `ColonyAugmentsV6`<`IColony`\>
-
-- `AddDomainAugmentsB`<`IColony`\>
-
-- `MoveFundsBetweenPotsAugmentsB`<`IColony`\>
-
-  ↳ **`ColonyClientV9`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -28,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -51,10 +25,6 @@
 ### clientVersion
 
 • **clientVersion**: ``9``
-
-#### Overrides
-
-AugmentedIColony.clientVersion
 
 ### colonyEvents
 
@@ -71,10 +41,6 @@ It's an ethers contract with only events to filter
 ### estimateGas
 
 • **estimateGas**: `ColonyClientV9Estimate`
-
-#### Overrides
-
-AugmentedIColony.estimateGas
 
 ### filters
 
@@ -671,7 +637,7 @@ Mark a task as complete after the due date has passed. This allows the task to b
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -1478,8 +1444,7 @@ Get the number of payments in the colony.
 Get the reputation for an address and a certain skill.
 If you need the skillId for a certain domain you can use the [getDomain](ColonyClientV9.md#getdomain) function.
 
-**`remarks`**
-This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
+**`remarks`** This function also retrieves the proofs (`branchMask`, `siblings`) that are needed to verify the reputation on chain.
 If you don't need to do that (e.g. in order to proof the reputation when calling a contract method), you should probably just use
 the [getReputationWithoutProofs](ColonyClientV9.md#getreputationwithoutproofs) method as it requires fewer computations
 
@@ -2147,9 +2112,7 @@ Move a given amount: `_amount` of `_token` funds from funding pot with id `_from
 
 ### ▸ **moveFundsBetweenPotsWithProofs(uint256,uint256,uint256,address)**(`_fromPot`, `_toPot`, `_amount`, `_token`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV9.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)](ColonyClientV9.md#movefundsbetweenpots(uint256,uint256,uint256,uint256,uint256,uint256,address)), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters
@@ -3243,9 +3206,7 @@ DEPRECATED Updates the expenditure owner. Can only be called by Arbitration role
 
 ### ▸ **transferExpenditureViaArbitrationWithProofs**(`_id`, `_newOwner`, `overrides?`): `Promise`<`ContractTransaction`\>
 
-**`deprecated`**
-
-Same as [transferExpenditureViaArbitration](ColonyClientV9.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
+**`deprecated`** Same as [transferExpenditureViaArbitration](ColonyClientV9.md#transferexpenditureviaarbitration), but let colonyJS figure out the permission proofs for you.
 Always prefer this method, except when you have good reason not to.
 
 #### Parameters

--- a/docs/reference/api/interfaces/ColonyNetworkClient.md
+++ b/docs/reference/api/interfaces/ColonyNetworkClient.md
@@ -1,11 +1,5 @@
 # Interface: ColonyNetworkClient
 
-## Hierarchy
-
-- `IColonyNetwork`
-
-  ↳ **`ColonyNetworkClient`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -137,10 +123,6 @@
 ### estimateGas
 
 • **estimateGas**: `ExtendedEstimate`
-
-#### Overrides
-
-IColonyNetwork.estimateGas
 
 ### filters
 
@@ -659,7 +641,7 @@ Used by a user to claim any mining rewards due to them. This will place them in 
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -757,8 +739,7 @@ Create the Meta Colony, same as a normal colony plus the root skill.
 
 Deploy an ERC20 token contract, compatible with Colony
 
-**`remarks`**
-For valid values see the spec here: https://eips.ethereum.org/EIPS/eip-20
+**`remarks`** For valid values see the spec here: https://eips.ethereum.org/EIPS/eip-20
 
 #### Parameters
 
@@ -1538,8 +1519,7 @@ Reverse lookup a username from an address.
 
 Like [[`lookupRegisteredENSDomain`]], but also working on the Goerli testnet
 
-**`remarks`**
-On Goerli, all ens domains have the `.test` suffix. The contracts return `.eth` anyways.
+**`remarks`** On Goerli, all ens domains have the `.test` suffix. The contracts return `.eth` anyways.
 We patch the original function to fix this problem. On any other network it will return the
 original function
 

--- a/docs/reference/api/interfaces/ColonyTokenClient.md
+++ b/docs/reference/api/interfaces/ColonyTokenClient.md
@@ -2,12 +2,6 @@
 
 A ColonyToken has special abilities that go beyond the capabilities of an ERC20 token
 
-## Hierarchy
-
-- `MetaTxToken`
-
-  ↳ **`ColonyTokenClient`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +12,9 @@ A ColonyToken has special abilities that go beyond the capabilities of an ERC20 
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -80,10 +66,6 @@ A ColonyToken has special abilities that go beyond the capabilities of an ERC20 
 ### estimateGas
 
 • **estimateGas**: { `DOMAIN_SEPARATOR`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `PERMIT_TYPEHASH`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `allowance`: (`src`: `string`, `guy`: `string`, `overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `approve`: (`guy`: `string`, `wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `authority`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `balanceOf`: (`src`: `string`, `overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `burn(address,uint256)`: (`guy`: `string`, `wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `burn(uint256)`: (`wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `decimals`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `executeMetaTransaction`: (`_user`: `string`, `_payload`: `BytesLike`, `_sigR`: `BytesLike`, `_sigS`: `BytesLike`, `_sigV`: `BigNumberish`, `overrides?`: `PayableOverrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `getChainId`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `getMetatransactionNonce`: (`_user`: `string`, `overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `locked`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `mint(address,uint256)`: (`guy`: `string`, `wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `mint(uint256)`: (`wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `name`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `owner`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `permit`: (`owner`: `string`, `spender`: `string`, `value`: `BigNumberish`, `deadline`: `BigNumberish`, `v`: `BigNumberish`, `r`: `BytesLike`, `s`: `BytesLike`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `setAuthority`: (`authority_`: `string`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `setOwner`: (`owner_`: `string`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `symbol`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `totalSupply`: (`overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\> ; `transfer`: (`dst`: `string`, `wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `transferFrom`: (`src`: `string`, `dst`: `string`, `wad`: `BigNumberish`, `overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `unlock`: (`overrides?`: `Overrides` & { `from?`: `string` \| `Promise`<`string`\>  }) => `Promise`<`BigNumber`\> ; `verify`: (`_owner`: `string`, `_nonce`: `BigNumberish`, `_chainId`: `BigNumberish`, `_payload`: `BytesLike`, `_sigR`: `BytesLike`, `_sigS`: `BytesLike`, `_sigV`: `BigNumberish`, `overrides?`: `CallOverrides`) => `Promise`<`BigNumber`\>  } & { `deployTokenAuthority`: (`colonyAddress`: `string`, `allowedToTransfer`: `string`[], `overrides?`: `TxOverrides`) => `Promise`<`BigNumber`\>  }
-
-#### Overrides
-
-MetaTxToken.estimateGas
 
 ### filters
 
@@ -376,7 +358,7 @@ MetaTxToken.estimateGas
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 
@@ -400,8 +382,7 @@ Deploy a TokenAuthority contract for this Colony for a specific token
 The TokenAuthority enables certain addresses to transfer the tokens, even if it's locked
 It also enables the assigned Colony to mint tokens
 
-**`remarks`**
-Only works with tokens that allow for an authority to be set (e.g. tokens deployed with Colony)
+**`remarks`** Only works with tokens that allow for an authority to be set (e.g. tokens deployed with Colony)
 
 #### Parameters
 

--- a/docs/reference/api/interfaces/DaiTokenClient.md
+++ b/docs/reference/api/interfaces/DaiTokenClient.md
@@ -2,12 +2,6 @@
 
 The SAI token. It requires special treatment as it's deprecated
 
-## Hierarchy
-
-- `TokenSAI`
-
-  ↳ **`DaiTokenClient`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +12,9 @@ The SAI token. It requires special treatment as it's deprecated
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -262,7 +248,7 @@ The SAI token. It requires special treatment as it's deprecated
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/Erc20TokenClient.md
+++ b/docs/reference/api/interfaces/Erc20TokenClient.md
@@ -2,12 +2,6 @@
 
 A standard ERC20 token
 
-## Hierarchy
-
-- `TokenERC20`
-
-  ↳ **`Erc20TokenClient`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +12,9 @@ A standard ERC20 token
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -262,7 +248,7 @@ A standard ERC20 token
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/OneTxPaymentClientV1.md
+++ b/docs/reference/api/interfaces/OneTxPaymentClientV1.md
@@ -1,11 +1,5 @@
 # Interface: OneTxPaymentClientV1
 
-## Hierarchy
-
-- `AugmentedOneTxPayment`<`OneTxPayment`\>
-
-  ↳ **`OneTxPaymentClientV1`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -63,10 +49,6 @@
 
 • **clientVersion**: ``1``
 
-#### Overrides
-
-AugmentedOneTxPayment.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -80,10 +62,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `OneTxPaymentEstimate`
-
-#### Overrides
-
-AugmentedOneTxPayment.estimateGas
 
 ### filters
 
@@ -258,7 +236,7 @@ It's an ethers contract with only events to filter
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/OneTxPaymentClientV2.md
+++ b/docs/reference/api/interfaces/OneTxPaymentClientV2.md
@@ -1,11 +1,5 @@
 # Interface: OneTxPaymentClientV2
 
-## Hierarchy
-
-- `AugmentedOneTxPayment`<`OneTxPayment`\>
-
-  ↳ **`OneTxPaymentClientV2`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -64,10 +50,6 @@
 
 • **clientVersion**: ``2``
 
-#### Overrides
-
-AugmentedOneTxPayment.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -81,10 +63,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `OneTxPaymentEstimate`
-
-#### Overrides
-
-AugmentedOneTxPayment.estimateGas
 
 ### filters
 
@@ -261,7 +239,7 @@ It's an ethers contract with only events to filter
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/OneTxPaymentClientV3.md
+++ b/docs/reference/api/interfaces/OneTxPaymentClientV3.md
@@ -1,11 +1,5 @@
 # Interface: OneTxPaymentClientV3
 
-## Hierarchy
-
-- `AugmentedOneTxPayment`<`OneTxPayment`\>
-
-  ↳ **`OneTxPaymentClientV3`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -68,10 +54,6 @@
 
 • **clientVersion**: ``3``
 
-#### Overrides
-
-AugmentedOneTxPayment.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -85,10 +67,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `OneTxPaymentEstimate`
-
-#### Overrides
-
-AugmentedOneTxPayment.estimateGas
 
 ### filters
 
@@ -275,7 +253,7 @@ It's an ethers contract with only events to filter
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/TokenLockingClient.md
+++ b/docs/reference/api/interfaces/TokenLockingClient.md
@@ -1,11 +1,5 @@
 # Interface: TokenLockingClient
 
-## Hierarchy
-
-- `TokenLocking`
-
-  ↳ **`TokenLockingClient`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -346,7 +332,7 @@
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/VotingReputationClientV1.md
+++ b/docs/reference/api/interfaces/VotingReputationClientV1.md
@@ -1,11 +1,5 @@
 # Interface: VotingReputationClientV1
 
-## Hierarchy
-
-- `AugmentedVotingReputation`<`VotingReputation`\>
-
-  ↳ **`VotingReputationClientV1`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -86,10 +72,6 @@
 ### clientVersion
 
 • **clientVersion**: ``1``
-
-#### Overrides
-
-AugmentedVotingReputation.clientVersion
 
 ### colonyClient
 
@@ -377,7 +359,7 @@ Always prefer this method, except when you have good reason not to.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/VotingReputationClientV2.md
+++ b/docs/reference/api/interfaces/VotingReputationClientV2.md
@@ -1,13 +1,5 @@
 # Interface: VotingReputationClientV2
 
-## Hierarchy
-
-- `AugmentedVotingReputation`<`VotingReputation`\>
-
-- `AugmentsV2`<`VotingReputation`\>
-
-  ↳ **`VotingReputationClientV2`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -92,10 +76,6 @@
 
 • **clientVersion**: ``2``
 
-#### Overrides
-
-AugmentedVotingReputation.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -109,10 +89,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `VotingReputationEstimate`
-
-#### Overrides
-
-AugmentedVotingReputation.estimateGas
 
 ### filters
 
@@ -392,7 +368,7 @@ Always prefer this method, except when you have good reason not to.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/VotingReputationClientV3.md
+++ b/docs/reference/api/interfaces/VotingReputationClientV3.md
@@ -1,13 +1,5 @@
 # Interface: VotingReputationClientV3
 
-## Hierarchy
-
-- `AugmentedVotingReputation`<`VotingReputation`\>
-
-- `AugmentsV2`<`VotingReputation`\>
-
-  ↳ **`VotingReputationClientV3`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -93,10 +77,6 @@
 
 • **clientVersion**: ``3``
 
-#### Overrides
-
-AugmentedVotingReputation.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -110,10 +90,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `VotingReputationEstimate`
-
-#### Overrides
-
-AugmentedVotingReputation.estimateGas
 
 ### filters
 
@@ -395,7 +371,7 @@ Always prefer this method, except when you have good reason not to.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/VotingReputationClientV4.md
+++ b/docs/reference/api/interfaces/VotingReputationClientV4.md
@@ -1,13 +1,5 @@
 # Interface: VotingReputationClientV4
 
-## Hierarchy
-
-- `AugmentedVotingReputation`<`VotingReputation`\>
-
-- `AugmentsV2`<`VotingReputation`\>
-
-  ↳ **`VotingReputationClientV4`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -18,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -97,10 +81,6 @@
 
 • **clientVersion**: ``4``
 
-#### Overrides
-
-AugmentedVotingReputation.clientVersion
-
 ### colonyClient
 
 • **colonyClient**: `AugmentedIColony`<`AnyIColony`\>
@@ -114,10 +94,6 @@ An instance of the corresponding ColonyClient
 ### estimateGas
 
 • **estimateGas**: `VotingReputationEstimate`
-
-#### Overrides
-
-AugmentedVotingReputation.estimateGas
 
 ### filters
 
@@ -409,7 +385,7 @@ Always prefer this method, except when you have good reason not to.
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/WhitelistClientV1.md
+++ b/docs/reference/api/interfaces/WhitelistClientV1.md
@@ -1,11 +1,5 @@
 # Interface: WhitelistClientV1
 
-## Hierarchy
-
-- `AugmentedWhitelst`<`Whitelist`\>
-
-  ↳ **`WhitelistClientV1`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -69,10 +55,6 @@
 ### clientVersion
 
 • **clientVersion**: ``1``
-
-#### Overrides
-
-AugmentedWhitelst.clientVersion
 
 ### colonyClient
 
@@ -319,7 +301,7 @@ Sets user statuses in the whitelist
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/interfaces/WhitelistClientV2.md
+++ b/docs/reference/api/interfaces/WhitelistClientV2.md
@@ -1,11 +1,5 @@
 # Interface: WhitelistClientV2
 
-## Hierarchy
-
-- `AugmentedWhitelst`<`Whitelist`\>
-
-  ↳ **`WhitelistClientV2`**
-
 ## Properties
 
 ### \_deployedPromise
@@ -16,17 +10,9 @@
 
 • **\_runningEvents**: `Object`
 
-#### Index signature
-
-▪ [eventTag: `string`]: `RunningEvent`
-
 ### \_wrappedEmits
 
 • **\_wrappedEmits**: `Object`
-
-#### Index signature
-
-▪ [eventTag: `string`]: (...`args`: `any`[]) => `void`
 
 ### address
 
@@ -73,10 +59,6 @@
 ### clientVersion
 
 • **clientVersion**: ``2``
-
-#### Overrides
-
-AugmentedWhitelst.clientVersion
 
 ### colonyClient
 
@@ -337,7 +319,7 @@ Sets user statuses in the whitelist
 
 | Name | Type |
 | :------ | :------ |
-| `signerOrProvider` | `string` \| `Signer` \| `Provider` |
+| `signerOrProvider` | `string` \| `Provider` \| `Signer` |
 
 #### Returns
 

--- a/docs/reference/api/modules/ColonyDataTypes.md
+++ b/docs/reference/api/modules/ColonyDataTypes.md
@@ -1,6 +1,6 @@
 # Namespace: ColonyDataTypes
 
-## Type aliases
+## Type Aliases
 
 ### DomainStruct
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@colony/eslint-config-colony": "^9.0.2",
+        "@colony/typedoc-plugin-markdown": "^3.15.0",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/abstract-provider": "^5.5.1",
         "@typechain/ethers-v5": "^10.0.0",
@@ -43,9 +44,9 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.5.0",
         "typechain": "^8.0.0",
-        "typedoc": "^0.22.11",
-        "typedoc-plugin-markdown": "^3.12.1",
-        "typescript": "^4.5.5",
+        "typedoc": "^0.23.2",
+        "typedoc-plugin-markdown": "^3.13.1",
+        "typescript": "^4.7.4",
         "yargs": "^17.3.1",
         "yarn": "^1.22.17"
       },
@@ -571,6 +572,18 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
         "prettier": "^2.5.1"
+      }
+    },
+    "node_modules/@colony/typedoc-plugin-markdown": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@colony/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.0.tgz",
+      "integrity": "sha512-+SuGbna/Pek57uJmE+J95yqpQjsMZkKtt6B/fdNM7jZP9vV28BbtTVuLaQzvjIXFrx2DKdEQzvdI4QHFcgV03w==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -8771,9 +8784,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -11482,43 +11495,63 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
-      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
+      "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.10",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.10.0"
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.12.1.tgz",
-      "integrity": "sha512-gMntJq7+JlGJZ5sVjrkzO/rG2dsmNBbWk5ZkcKvYu6QOeBwGcK5tzEyS0aqnFTJj9GCHCB+brAnTuKtAyotNwA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.1.tgz",
+      "integrity": "sha512-Gx7pmvFNXAxbE9N2MuQNi5RwMVSH9lPxDBAaBNftaZ+ZzMO8YkDwir6aoXcWNq50qgG/eTs5CiKvLe33OVm2iQ==",
       "dev": true,
       "dependencies": {
         "handlebars": "^4.7.7"
       },
       "peerDependencies": {
-        "typedoc": ">=0.22.0"
+        "typedoc": ">=0.23.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11538,9 +11571,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -11993,7 +12026,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "node_modules/wordwrapjs": {
@@ -12594,6 +12627,15 @@
       "integrity": "sha512-M/tql9dGwG5rSKWQckkYeiCciqL/CCCTUXYRIndeRElMLeTR97VyVU5jdUU/ZpRY4i4JdEgf/yXaoPiq/HmKnQ==",
       "dev": true,
       "requires": {}
+    },
+    "@colony/typedoc-plugin-markdown": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@colony/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.0.tgz",
+      "integrity": "sha512-+SuGbna/Pek57uJmE+J95yqpQjsMZkKtt6B/fdNM7jZP9vV28BbtTVuLaQzvjIXFrx2DKdEQzvdI4QHFcgV03w==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -18652,9 +18694,9 @@
       }
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true
     },
     "merge-stream": {
@@ -20631,31 +20673,50 @@
       }
     },
     "typedoc": {
-      "version": "0.22.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
-      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
+      "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.10",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.10.0"
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "typedoc-plugin-markdown": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.12.1.tgz",
-      "integrity": "sha512-gMntJq7+JlGJZ5sVjrkzO/rG2dsmNBbWk5ZkcKvYu6QOeBwGcK5tzEyS0aqnFTJj9GCHCB+brAnTuKtAyotNwA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.1.tgz",
+      "integrity": "sha512-Gx7pmvFNXAxbE9N2MuQNi5RwMVSH9lPxDBAaBNftaZ+ZzMO8YkDwir6aoXcWNq50qgG/eTs5CiKvLe33OVm2iQ==",
       "dev": true,
       "requires": {
         "handlebars": "^4.7.7"
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "typical": {
@@ -20665,9 +20726,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
+      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
       "dev": true,
       "optional": true
     },
@@ -21021,7 +21082,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wordwrapjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.5.0",
         "typechain": "^8.0.0",
-        "typedoc": "^0.23.2",
-        "typedoc-plugin-markdown": "^3.13.1",
+        "typedoc": "^0.23.5",
         "typescript": "^4.7.4",
         "yargs": "^17.3.1",
         "yarn": "^1.22.17"
@@ -11495,9 +11494,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
-      "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.5.tgz",
+      "integrity": "sha512-5ydWUOe4E9Z3a/r33cC5X5CJPLnFDKIondHYtdnEnO0sa/s8f+Nrfe+LBGOk/UTkV2IPYyL1Gm1PtUKIihklyw==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
@@ -11513,18 +11512,6 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.1.tgz",
-      "integrity": "sha512-Gx7pmvFNXAxbE9N2MuQNi5RwMVSH9lPxDBAaBNftaZ+ZzMO8YkDwir6aoXcWNq50qgG/eTs5CiKvLe33OVm2iQ==",
-      "dev": true,
-      "dependencies": {
-        "handlebars": "^4.7.7"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.23.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -11571,9 +11558,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
+      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -20673,9 +20660,9 @@
       }
     },
     "typedoc": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.2.tgz",
-      "integrity": "sha512-THpC4vtb3wu1yck6YHzEc4ck6W4lScf8TD0Rg7XAetDih8BzP+ErYO0/6DtdzYcZyKkDwEoujkMeWW7CffCbrQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.5.tgz",
+      "integrity": "sha512-5ydWUOe4E9Z3a/r33cC5X5CJPLnFDKIondHYtdnEnO0sa/s8f+Nrfe+LBGOk/UTkV2IPYyL1Gm1PtUKIihklyw==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
@@ -20704,15 +20691,6 @@
         }
       }
     },
-    "typedoc-plugin-markdown": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.1.tgz",
-      "integrity": "sha512-Gx7pmvFNXAxbE9N2MuQNi5RwMVSH9lPxDBAaBNftaZ+ZzMO8YkDwir6aoXcWNq50qgG/eTs5CiKvLe33OVm2iQ==",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.7.7"
-      }
-    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -20726,9 +20704,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
+      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@colony/eslint-config-colony": "^9.0.2",
+    "@colony/typedoc-plugin-markdown": "^3.15.0",
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@typechain/ethers-v5": "^10.0.0",
@@ -78,9 +79,9 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.5.0",
     "typechain": "^8.0.0",
-    "typedoc": "^0.22.11",
-    "typedoc-plugin-markdown": "^3.12.1",
-    "typescript": "^4.5.5",
+    "typedoc": "^0.23.2",
+    "typedoc-plugin-markdown": "^3.13.1",
+    "typescript": "^4.7.4",
     "yargs": "^17.3.1",
     "yarn": "^1.22.17"
   },

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.5.0",
     "typechain": "^8.0.0",
-    "typedoc": "^0.23.2",
-    "typedoc-plugin-markdown": "^3.13.1",
+    "typedoc": "^0.23.5",
     "typescript": "^4.7.4",
     "yargs": "^17.3.1",
     "yarn": "^1.22.17"

--- a/src/__tests__/integration.ts
+++ b/src/__tests__/integration.ts
@@ -3,7 +3,8 @@ import { readFileSync } from 'fs';
 import { Wallet, providers } from 'ethers';
 import execa, { ExecaChildProcess } from 'execa';
 
-import { Network, getColonyNetworkClient } from '..';
+import { Network } from '../types';
+import getColonyNetworkClient from '../clients/ColonyNetworkClient';
 
 const NETWORK_PATH = resolvePath(__dirname, '../../vendor/colonyNetwork');
 

--- a/src/clients/Core/ColonyClientV1.ts
+++ b/src/clients/Core/ColonyClientV1.ts
@@ -1,4 +1,4 @@
-import { SignerOrProvider } from '../..';
+import { SignerOrProvider } from '../../types';
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/1/factories/IColony__factory';
 import { IColony } from '../../contracts/IColony/1/IColony';
 import { ColonyNetworkClient } from '../ColonyNetworkClient';

--- a/src/clients/Core/ColonyClientV2.ts
+++ b/src/clients/Core/ColonyClientV2.ts
@@ -1,4 +1,4 @@
-import { SignerOrProvider } from '../..';
+import { SignerOrProvider } from '../../types';
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/2/factories/IColony__factory';
 import { IColony } from '../../contracts/IColony/2/IColony';
 import { ColonyNetworkClient } from '../ColonyNetworkClient';

--- a/src/clients/Core/ColonyVersionClient.ts
+++ b/src/clients/Core/ColonyVersionClient.ts
@@ -1,6 +1,7 @@
 // A minimal version of the ColonyClient contract that only supports the `version` method
 import { BigNumber, Contract } from 'ethers';
-import { SignerOrProvider } from '../..';
+
+import { SignerOrProvider } from '../../types';
 
 interface ColonyVersionClient extends Contract {
   version(): Promise<BigNumber>;

--- a/src/clients/Extensions/ExtensionVersionClient.ts
+++ b/src/clients/Extensions/ExtensionVersionClient.ts
@@ -2,7 +2,7 @@
 
 import { Contract, BigNumber } from 'ethers';
 
-import { SignerOrProvider } from '../..';
+import { SignerOrProvider } from '../../types';
 
 interface ExtensionVersionClient extends Contract {
   version(): Promise<BigNumber>;

--- a/src/clients/Extensions/VotingReputation/augments/commonAugments.ts
+++ b/src/clients/Extensions/VotingReputation/augments/commonAugments.ts
@@ -11,16 +11,14 @@ import {
   getPermissionProofs,
   getChildIndex,
 } from '../../../Core/augments/commonAugments';
-import { ColonyRole, TxOverrides } from '../../../../types';
-
-import { VotingReputationVersion } from '../exports';
+import { ColonyRole, ClientType, TxOverrides } from '../../../../types';
 import { AnyVotingReputation } from '../../../../contracts/VotingReputation/exports';
-import { ClientType } from '../../../..';
 import { parsePermissionedAction } from '../../../../utils';
 import {
   VotingReputationEvents,
   VotingReputationEvents__factory as VotingReputationEventsFactory,
 } from '../../../../contracts';
+import { VotingReputationVersion } from '../exports';
 
 const { MaxUint256 } = constants;
 

--- a/src/clients/Extensions/exports.ts
+++ b/src/clients/Extensions/exports.ts
@@ -1,8 +1,9 @@
 import { constants } from 'ethers';
 
-import { ColonyVersion, getExtensionHash } from '../..';
 import { assertExhaustiveSwitch } from '../../utils';
+import { getExtensionHash } from '../../helpers';
 import { AugmentedIColony } from '../Core/augments/commonAugments';
+import { ColonyVersion } from '../Core/exports';
 
 import {
   getCoinMachineClient,

--- a/src/clients/UtilsClient.ts
+++ b/src/clients/UtilsClient.ts
@@ -1,8 +1,7 @@
 import { BigNumber, BytesLike, CallOverrides } from 'ethers';
 
-import { ClientType, SignerOrProvider } from '../types';
+import { ClientType, ColonyRole, SignerOrProvider } from '../types';
 
-import { ColonyRole } from '..';
 import { Utils, Utils__factory as UtilsFactory } from '../contracts';
 import { nonNullable } from '../utils';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ type ReputationOracleResponseType<R> =
     ? ReputationOracleColonyResponse
     : never;
 
-/*
+/**
  * Format role events into an Array of all roles in the colony
  *
  * E.g.:

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,7 +6,7 @@
   "excludeInternal": true,
   "excludePrivate": true,
   "excludeProtected": true,
-  "plugin": "typedoc-plugin-markdown",
+  "plugin": "@colony/typedoc-plugin-markdown",
   "githubPages": false,
   "disableSources": true,
   "readme": "none",


### PR DESCRIPTION
This PR updates `typedoc` to v0.23.5 and uses our custom `@colony/typedoc-plugin-markdown` template
