### PR TITLE
SDK v2 changes

### DIFF
--- a/.changeset/cuddly-pets-boil.md
+++ b/.changeset/cuddly-pets-boil.md
@@ -1,0 +1,5 @@
+---
+"@colony/sdk": major
+---
+
+Calling `getBalance` on a Colony without specifying a `teamId` will now return the total balance of the specified token across the whole Colony (including not-yet-claimed funds)

--- a/.changeset/flat-emus-exist.md
+++ b/.changeset/flat-emus-exist.md
@@ -1,0 +1,11 @@
+---
+"@colony/sdk": major
+"@colony/colony-js": minor
+"@colony/core": minor
+---
+
+**`sdk`**
+
+- `getReputation` now returns reputation within a domain as a percentag of the whole reputation within the team
+- `getReputationPoints` can be used to get the previous behavior
+- Added an `initialize` function to the `VotingReputation` extension

--- a/packages/colony-js/docs/api/classes/ReputationClient.md
+++ b/packages/colony-js/docs/api/classes/ReputationClient.md
@@ -20,7 +20,7 @@
 
 ▸ **getMembersReputation**(`skillId`, `customRootHash?`): `Promise`<`MembersReputationResponse`\>
 
-Get a list of all users who have reputation in a domain
+Get a list of all users who have reputation in a team
 
 #### Parameters
 
@@ -95,6 +95,32 @@ Reputation data
 
 ___
 
+### getReputationFraction
+
+▸ **getReputationFraction**(`skillId`, `address`, `customRootHash?`, `decimalPoints?`): `Promise`<`number`\>
+
+Get the reputation fraction for a user address within a team in the Colony
+
+1.000 = user has 100% of the reputation
+0.050 = user has 5% of the reputation
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `skillId` | `BigNumberish` | Skill (for corresponding domain) to check reputation in |
+| `address` | `string` | - |
+| `customRootHash?` | `string` | Optionally define a root hash in the reputation tree (historic point in time) |
+| `decimalPoints?` | `number` | - |
+
+#### Returns
+
+`Promise`<`number`\>
+
+Fraction of reputation a user has in a team
+
+___
+
 ### getReputationWithProofs
 
 ▸ **getReputationWithProofs**(`skillId`, `address`, `customRootHash?`): `Promise`<{ `branchMask`: `string` ; `key`: `string` ; `reputationAmount`: `BigNumber` ; `siblings`: `string`[] ; `value`: `string`  }\>
@@ -112,6 +138,27 @@ Get reputation with proofs (e.g. to check against on-chain data)
 #### Returns
 
 `Promise`<{ `branchMask`: `string` ; `key`: `string` ; `reputationAmount`: `BigNumber` ; `siblings`: `string`[] ; `value`: `string`  }\>
+
+Reputation data
+
+___
+
+### getTotalReputation
+
+▸ **getTotalReputation**(`skillId`, `customRootHash?`): `Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
+
+Get the total amount of reputation points that currently are in a team
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `skillId` | `BigNumberish` | Skill (for corresponding domain) to check reputation in |
+| `customRootHash?` | `string` | Optionally define a root hash in the reputation tree (historic point in time) |
+
+#### Returns
+
+`Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
 
 Reputation data
 

--- a/packages/colony-js/docs/api/enums/ReputationOracleEndpoint.md
+++ b/packages/colony-js/docs/api/enums/ReputationOracleEndpoint.md
@@ -30,4 +30,4 @@ ___
 
 ### XdaiQa
 
-• **XdaiQa** = ``"https://qaxdai.colony.io/reputation/xdai"``
+• **XdaiQa** = ``"https://qa-xdai.colony.io/reputation/xdai"``

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -39,7 +39,7 @@ export enum ReputationOracleEndpoint {
   Mainnet = 'https://colony.io/reputation/mainnet',
   Goerli = 'https://colony.io/reputation/goerli',
   Xdai = 'https://xdai.colony.io/reputation/xdai',
-  XdaiQa = 'https://qaxdai.colony.io/reputation/xdai',
+  XdaiQa = 'https://qa-xdai.colony.io/reputation/xdai',
   Custom = 'http://localhost:3000',
 }
 

--- a/packages/sdk/docs/api/classes/Colony.md
+++ b/packages/sdk/docs/api/classes/Colony.md
@@ -593,7 +593,7 @@ console.info(toEth(balance));
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `tokenAddress?` | `string` | The address of the token to get the balance for. Default is the Colony's native token |
-| `teamId?` | `BigNumberish` | The teamId (domainId) of the team to get the balance for. Default is the `Root` team |
+| `teamId?` | `BigNumberish` | The teamId (domainId) of the team to get the balance for. If not given, it will return the total balance of that token across the whole Colony (including non-claimed funds) |
 
 #### Returns
 

--- a/packages/sdk/docs/api/classes/Colony.md
+++ b/packages/sdk/docs/api/classes/Colony.md
@@ -605,22 +605,26 @@ ___
 
 ### getReputation
 
-▸ **getReputation**(`userAddress`, `teamId?`): `Promise`<`BigNumber`\>
+▸ **getReputation**(`userAddress`, `teamId?`, `decimalPoints?`): `Promise`<`number`\>
 
-Get the reputation for a user address within a team in the Colony
+Get the reputation fraction for a user address within a team in the Colony
+
+1.000 = user has 100% of the reputation
+0.050 = user has 5% of the reputation
 
 #### Parameters
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `userAddress` | `string` | `undefined` | The address of the account to check the reputation for |
-| `teamId` | [`Id`](../enums/Id.md) | `Id.RootDomain` | The teamId (domainId) of the team to get the reputation for. Default is the `Root` team |
+| `teamId` | `BigNumberish` | `Id.RootDomain` | The teamId (domainId) of the team to get the reputation for. Default is the `Root` team |
+| `decimalPoints` | `number` | `3` | - |
 
 #### Returns
 
-`Promise`<`BigNumber`\>
+`Promise`<`number`\>
 
-A number quantifying the user addresses' reputation
+A fractional number quantifying the user addresses' reputation
 
 ___
 
@@ -647,6 +651,30 @@ An array of objects containing the following
 | `domainId` | The domainId of the domain the user has reputation in |
 | `skillId` | The corresponding skillId |
 | `reputationAmount` | The reputation amount in that domain |
+
+___
+
+### getReputationPoints
+
+▸ **getReputationPoints**(`userAddress`, `teamId?`): `Promise`<`BigNumber`\>
+
+Get the reputation for a user address within a team in the Colony
+
+Reputation scales with the native token, so will be expressed in equivalents of the native token
+E.g. if the native token has 18 decimals (wei), the reputation will also have 18 decimals
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `userAddress` | `string` | `undefined` | The address of the account to check the reputation for |
+| `teamId` | [`Id`](../enums/Id.md) | `Id.RootDomain` | The teamId (domainId) of the team to get the reputation for. Default is the `Root` team |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+A number quantifying the user addresses' reputation
 
 ___
 

--- a/packages/sdk/docs/api/classes/ReputationClient.md
+++ b/packages/sdk/docs/api/classes/ReputationClient.md
@@ -95,6 +95,25 @@ Reputation data
 
 ___
 
+### getReputationFraction
+
+▸ **getReputationFraction**(`skillId`, `address`, `customRootHash?`, `decimalPoints?`): `Promise`<`number`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `skillId` | `BigNumberish` |
+| `address` | `string` |
+| `customRootHash?` | `string` |
+| `decimalPoints?` | `number` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+___
+
 ### getReputationWithProofs
 
 ▸ **getReputationWithProofs**(`skillId`, `address`, `customRootHash?`): `Promise`<{ `branchMask`: `string` ; `key`: `string` ; `reputationAmount`: `BigNumber` ; `siblings`: `string`[] ; `value`: `string`  }\>
@@ -114,6 +133,23 @@ Get reputation with proofs (e.g. to check against on-chain data)
 `Promise`<{ `branchMask`: `string` ; `key`: `string` ; `reputationAmount`: `BigNumber` ; `siblings`: `string`[] ; `value`: `string`  }\>
 
 Reputation data
+
+___
+
+### getTotalReputation
+
+▸ **getTotalReputation**(`skillId`, `customRootHash?`): `Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `skillId` | `BigNumberish` |
+| `customRootHash?` | `string` |
+
+#### Returns
+
+`Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
 
 ___
 

--- a/packages/sdk/docs/api/classes/ReputationClient.md
+++ b/packages/sdk/docs/api/classes/ReputationClient.md
@@ -20,7 +20,7 @@
 
 ▸ **getMembersReputation**(`skillId`, `customRootHash?`): `Promise`<`MembersReputationResponse`\>
 
-Get a list of all users who have reputation in a domain
+Get a list of all users who have reputation in a team
 
 #### Parameters
 
@@ -99,18 +99,25 @@ ___
 
 ▸ **getReputationFraction**(`skillId`, `address`, `customRootHash?`, `decimalPoints?`): `Promise`<`number`\>
 
+Get the reputation fraction for a user address within a team in the Colony
+
+1.000 = user has 100% of the reputation
+0.050 = user has 5% of the reputation
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `skillId` | `BigNumberish` |
-| `address` | `string` |
-| `customRootHash?` | `string` |
-| `decimalPoints?` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `skillId` | `BigNumberish` | Skill (for corresponding domain) to check reputation in |
+| `address` | `string` | - |
+| `customRootHash?` | `string` | Optionally define a root hash in the reputation tree (historic point in time) |
+| `decimalPoints?` | `number` | - |
 
 #### Returns
 
 `Promise`<`number`\>
+
+Fraction of reputation a user has in a team
 
 ___
 
@@ -140,16 +147,20 @@ ___
 
 ▸ **getTotalReputation**(`skillId`, `customRootHash?`): `Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
 
+Get the total amount of reputation points that currently are in a team
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `skillId` | `BigNumberish` |
-| `customRootHash?` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `skillId` | `BigNumberish` | Skill (for corresponding domain) to check reputation in |
+| `customRootHash?` | `string` | Optionally define a root hash in the reputation tree (historic point in time) |
 
 #### Returns
 
 `Promise`<{ `key`: `string` ; `reputationAmount`: `BigNumber` ; `value`: `string`  }\>
+
+Reputation data
 
 ___
 

--- a/packages/sdk/docs/api/classes/VotingReputation.md
+++ b/packages/sdk/docs/api/classes/VotingReputation.md
@@ -4,6 +4,11 @@
 
 The `VotingReputation` extension allows any member of a Colony to propose a Motion to take an `action` that will pass after a security delay unless somebody Objects. This applies to all actions, such as creating an expenditure, managing funds, or managing teams.
 
+### Extension parameters
+
+Before the `VotingReputation` extension can be used you need to initialize it using a few parameters that heavily influence the Motion lifecycle.
+For that please see the [initialize](VotingReputation.md#initialize) function and also [this document](https://docs.colony.io/use/governance/motions-and-disputes/parameters) for an in-depth explanation of the various parameters.
+
 ### What is a Motion?
 
 Within Colony a Motion is an on-chain proposal whose two sides (_Yay_ or _Nay_) can be supported by staking the Colony's native token for that side. Motions _always_ have an `action` attached to them which is a contract transaction that can take place in a Colony. For example, Motions could be created to move funds from one team to another, for paying someone that did work or minting new native tokens (even arbitrary transaction on any contract in the name of the Colony are supported!).
@@ -475,6 +480,29 @@ Get the amounts remaining for Yay/Nay sides to be activated
 `Promise`<{ `remainingToFullyNayStaked`: `BigNumber` ; `remainingToFullyYayStaked`: `BigNumber`  }\>
 
 An object containing the remaining amounts
+
+___
+
+### initialize
+
+▸ **initialize**(`totalStakeFraction`, `voterRewardFraction`, `userMinStakeFraction`, `maxVoteFraction`, `stakePeriod`, `submitPeriod`, `revealPeriod`, `escalationPeriod`): [`MetaTxCreator`](MetaTxCreator.md)<`SupportedVotingReputationContract`, ``"initialise"``, {}, [`MetadataType`](../enums/MetadataType.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `totalStakeFraction` | `BigNumber` |
+| `voterRewardFraction` | `BigNumber` |
+| `userMinStakeFraction` | `BigNumber` |
+| `maxVoteFraction` | `BigNumber` |
+| `stakePeriod` | `number` |
+| `submitPeriod` | `number` |
+| `revealPeriod` | `number` |
+| `escalationPeriod` | `number` |
+
+#### Returns
+
+[`MetaTxCreator`](MetaTxCreator.md)<`SupportedVotingReputationContract`, ``"initialise"``, {}, [`MetadataType`](../enums/MetadataType.md)\>
 
 ___
 

--- a/packages/sdk/docs/api/classes/VotingReputation.md
+++ b/packages/sdk/docs/api/classes/VotingReputation.md
@@ -487,22 +487,58 @@ ___
 
 ▸ **initialize**(`totalStakeFraction`, `voterRewardFraction`, `userMinStakeFraction`, `maxVoteFraction`, `stakePeriod`, `submitPeriod`, `revealPeriod`, `escalationPeriod`): [`MetaTxCreator`](MetaTxCreator.md)<`SupportedVotingReputationContract`, ``"initialise"``, {}, [`MetadataType`](../enums/MetadataType.md)\>
 
+Before you can use the extension you need to initialize it by calling this function.
+
+**`Remarks`**
+
+- Fractions are in wei to allow for precise adjustments (you can use the `w` helper method to specify fractions - see example)
+- All periods values are given in seconds
+
+See also [this page](https://docs.colony.io/use/governance/motions-and-disputes/parameters) for a detailed explanation of the parameters.
+
+**`Example`**
+
+```typescript
+import { w } from '@colony/sdk';
+
+// Immediately executing async function
+(async function() {
+  // After installing the extension, initialize the extension with the dApp's default values
+  await colony.ext.motions.initialize(
+    w`0.01`,
+    w`0.2`,
+    w`0.01`,
+    w`0.7`,
+    72 * 60 * 60,
+    72 * 60 * 60,
+    72 * 60 * 60,
+    72 * 60 * 60,
+  ).tx().mined();
+})();
+```
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `totalStakeFraction` | `BigNumber` |
-| `voterRewardFraction` | `BigNumber` |
-| `userMinStakeFraction` | `BigNumber` |
-| `maxVoteFraction` | `BigNumber` |
-| `stakePeriod` | `number` |
-| `submitPeriod` | `number` |
-| `revealPeriod` | `number` |
-| `escalationPeriod` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `totalStakeFraction` | `BigNumber` | The fraction of the domain's reputation we need to stake |
+| `voterRewardFraction` | `BigNumber` | The fraction of the total stake paid out to voters as rewards |
+| `userMinStakeFraction` | `BigNumber` | The minimum per-user stake as fraction of total stake |
+| `maxVoteFraction` | `BigNumber` | The fraction of the domain's reputation which must submit for quick-end |
+| `stakePeriod` | `number` | The length of the staking period in seconds |
+| `submitPeriod` | `number` | The length of the submit period in seconds |
+| `revealPeriod` | `number` | The length of the reveal period in seconds |
+| `escalationPeriod` | `number` | The length of the escalation period in seconds |
 
 #### Returns
 
 [`MetaTxCreator`](MetaTxCreator.md)<`SupportedVotingReputationContract`, ``"initialise"``, {}, [`MetadataType`](../enums/MetadataType.md)\>
+
+A transaction creator
+
+#### Event data
+
+No event data attached
 
 ___
 

--- a/packages/sdk/src/ColonyNetwork/Colony.ts
+++ b/packages/sdk/src/ColonyNetwork/Colony.ts
@@ -890,13 +890,40 @@ export class Colony {
   }
 
   /**
+   * Get the reputation fraction for a user address within a team in the Colony
+   *
+   * 1.000 = user has 100% of the reputation
+   * 0.050 = user has 5% of the reputation
+   *
+   * @param userAddress - The address of the account to check the reputation for
+   * @param teamId - The teamId (domainId) of the team to get the reputation for. Default is the `Root` team
+   * @returns A fractional number quantifying the user addresses' reputation
+   */
+  async getReputation(
+    userAddress: string,
+    teamId: BigNumberish = Id.RootDomain,
+    decimalPoints = 3,
+  ) {
+    const { skillId } = await this.colony.getDomain(teamId);
+    return this.reputation.getReputationFraction(
+      skillId,
+      userAddress,
+      undefined,
+      decimalPoints,
+    );
+  }
+
+  /**
    * Get the reputation for a user address within a team in the Colony
+   *
+   * Reputation scales with the native token, so will be expressed in equivalents of the native token
+   * E.g. if the native token has 18 decimals (wei), the reputation will also have 18 decimals
    *
    * @param userAddress - The address of the account to check the reputation for
    * @param teamId - The teamId (domainId) of the team to get the reputation for. Default is the `Root` team
    * @returns A number quantifying the user addresses' reputation
    */
-  async getReputation(userAddress: string, teamId = Id.RootDomain) {
+  async getReputationPoints(userAddress: string, teamId = Id.RootDomain) {
     const { skillId } = await this.colony.getDomain(teamId);
     const { reputationAmount } = await this.reputation.getReputation(
       skillId,

--- a/packages/sdk/src/ColonyNetwork/VotingReputation.ts
+++ b/packages/sdk/src/ColonyNetwork/VotingReputation.ts
@@ -306,7 +306,7 @@ export class VotingReputation {
     return this.votingReputationContract;
   }
 
-  /*
+  /**
    * Before you can use the extension you need to initialize it by calling this function.
    *
    * @remarks
@@ -335,14 +335,14 @@ export class VotingReputation {
    * })();
    * ```
    *
-   * @param totalStakeFraction The fraction of the domain's reputation we need to stake
-   * @param voterRewardFraction The fraction of the total stake paid out to voters as rewards
-   * @param userMinStakeFraction The minimum per-user stake as fraction of total stake
-   * @param maxVoteFraction The fraction of the domain's reputation which must submit for quick-end
-   * @param stakePeriod The length of the staking period in seconds
-   * @param submitPeriod The length of the submit period in seconds
-   * @param revealPeriod The length of the reveal period in seconds
-   * @param escalationPeriod The length of the escalation period in seconds
+   * @param totalStakeFraction - The fraction of the domain's reputation we need to stake
+   * @param voterRewardFraction - The fraction of the total stake paid out to voters as rewards
+   * @param userMinStakeFraction - The minimum per-user stake as fraction of total stake
+   * @param maxVoteFraction - The fraction of the domain's reputation which must submit for quick-end
+   * @param stakePeriod - The length of the staking period in seconds
+   * @param submitPeriod - The length of the submit period in seconds
+   * @param revealPeriod - The length of the reveal period in seconds
+   * @param escalationPeriod - The length of the escalation period in seconds
    *
    * @returns A transaction creator
    *


### PR DESCRIPTION
## Description

A collection of changes made in Colony SDK for the next (v2) version

**Changes** 🏗

- `getBalance` default team is now the whole Colony
- `getReputation` now returns reputation within a domain as a percentag of the whole reputation within the team
- `getReputationPoints` can be used to get the previous behavior
- Added an `initialize` function to the `VotingReputation` extension
- Fixed `qa-xdai` reputation endpoint URL
