### PR TITLE
More v2 changes

### DIFF
--- a/.changeset/chatty-cooks-know.md
+++ b/.changeset/chatty-cooks-know.md
@@ -1,0 +1,9 @@
+---
+"@colony/contractor": minor
+"@colony/core": minor
+"@colony/sdk": minor
+---
+
+Add support for `glwss4` contracts in Colony SDK. No API changes were necessary.
+Contractor was bumped to v1.0.1 of the `@colony/abis` package
+In `core`, a guard was added to prevent trying to get permission proofs without an address.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["colony-typescript-for-build-only-{{MODULE_TYPE}}"]
+  "ignore": [
+    "colony-js",
+    "colony-typescript-for-build-only-{{MODULE_TYPE}}"
+  ]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: pnpm --filter "@colony/contractor" install --ignore-scripts
-    - run: pnpm --filter "@colony/contractor" run build
+    - run: pnpm --filter "contractor" install --ignore-scripts
+    - run: pnpm --filter "contractor" run build
     - run: pnpm install --frozen-lockfile
     - run: pnpm run lint
-    - run: pnpm run build
-      env:
-        NODE_OPTIONS: "--max-old-space-size=8192"
-    - run: npm run test
+    - run: pnpm --filter "!colony-js" run build
+    - run: pnpm --filter "!colony-js" run test
       env:
         CI: true
-        NODE_OPTIONS: "--max-old-space-size=8192"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,14 +14,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '16.x'
-    - run: pnpm --filter "@colony/contractor" install --ignore-scripts
-    - run: pnpm --filter "@colony/contractor" run build
+    - run: pnpm --filter "contractor" install --ignore-scripts
+    - run: pnpm --filter "contractor" run build
     - run: pnpm install --frozen-lockfile
     # Exclude the build of sdk and colony-js as it's not necessary for the docs to build
     - run: pnpm --filter '!sdk' --filter '!colony-js' run build
-    - run: pnpm run build-docs
-      env:
-        NODE_OPTIONS: "--max-old-space-size=8192"
+    - run: pnpm --filter "!colony-js" run build-docs
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "chore: Generate docs"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: pnpm --filter "@colony/contractor" install --ignore-scripts
-      - run: pnpm --filter "@colony/contractor" run build
+      - run: pnpm --filter "contractor" install --ignore-scripts
+      - run: pnpm --filter "contractor" run build
       - run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -32,6 +32,5 @@ jobs:
           version: pnpm run version
           publish: pnpm run release
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sdk-examples.yml
+++ b/.github/workflows/sdk-examples.yml
@@ -20,19 +20,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: pnpm --filter "@colony/contractor" install --ignore-scripts
-    - run: pnpm --filter "@colony/contractor" run build
+    - run: pnpm --filter "contractor" install --ignore-scripts
+    - run: pnpm --filter "contractor" run build
     - run: pnpm install --frozen-lockfile
-    - run: pnpm run lint
-    - run: pnpm run build
-      env:
-        NODE_OPTIONS: "--max-old-space-size=8192"
-    - run: pnpm run test
-      env:
-        CI: true
-        NODE_OPTIONS: "--max-old-space-size=8192"
-    - run: npm run no-git-changes
-    - run: pnpm --filter "@colony/sdk" run build-examples
+    - run: pnpm --filter "sdk" run build-examples
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@releases/v4
       with:

--- a/packages/colony-js/docs/api/interfaces/ColonyNetworkClient.md
+++ b/packages/colony-js/docs/api/interfaces/ColonyNetworkClient.md
@@ -1625,7 +1625,7 @@ Called to deploy a token authority
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `_token` | `string` | The address of the otken |
+| `_token` | `string` | The address of the token |
 | `_colony` | `string` | The address of the colony in control of the token |
 | `_allowedToTransfer` | `string`[] | An array of addresses that are allowed to transfer the token even if it's locked |
 | `overrides?` | `Overrides` & { `from?`: `string`  } | - |
@@ -1651,7 +1651,7 @@ Called to deploy a token authority
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `_token` | `string` | The address of the otken |
+| `_token` | `string` | The address of the token |
 | `_colony` | `string` | The address of the colony in control of the token |
 | `_allowedToTransfer` | `string`[] | An array of addresses that are allowed to transfer the token even if it's locked |
 | `overrides?` | `Overrides` & { `from?`: `string`  } | - |

--- a/packages/colony-js/src/clients/Core/ColonyClientV13.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV13.ts
@@ -1,0 +1,73 @@
+import { SignerOrProvider } from '@colony/core';
+
+import { IColony__factory as IColonyFactory } from '../../contracts/IColony/13/factories/IColony__factory.js';
+import { IColony } from '../../contracts/IColony/13/IColony.js';
+import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import {
+  AugmentedIColony,
+  AugmentedEstimate,
+} from './augments/commonAugments.js';
+import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import {
+  addAugments,
+  ColonyAugmentsV7,
+  AugmentedEstimateV7,
+} from './augments/augmentsV7.js';
+import {
+  AddDomainAugmentsB,
+  AddDomainEstimateGasB,
+  addAugmentsB as addAddDomainAugments,
+} from './augments/AddDomain.js';
+import {
+  MoveFundsBetweenPotsAugmentsB,
+  MoveFundsBetweenPotsEstimateGasB,
+  addAugmentsB as addMoveFundsBetweenPotsAugments,
+} from './augments/MoveFundsBetweenPots.js';
+
+interface ColonyClientV13Estimate
+  extends AugmentedEstimate<IColony>,
+    AugmentedEstimateV7,
+    AddDomainEstimateGasB,
+    MoveFundsBetweenPotsEstimateGasB {}
+
+export interface ColonyClientV13
+  extends AugmentedIColony<IColony>,
+    ColonyAugmentsV3<IColony>,
+    ColonyAugmentsV4<IColony>,
+    ColonyAugmentsV5<IColony>,
+    ColonyAugmentsV6<IColony>,
+    ColonyAugmentsV7<IColony>,
+    AddDomainAugmentsB<IColony>,
+    MoveFundsBetweenPotsAugmentsB<IColony> {
+  clientVersion: 13;
+  estimateGas: ColonyClientV13Estimate;
+
+  // This is only to hide certain internal ethers.js properties from the docs
+  /** @internal */
+  callStatic: IColony['callStatic'];
+  /** @internal */
+  functions: IColony['functions'];
+  /** @internal */
+  populateTransaction: IColony['populateTransaction'];
+}
+
+export default function getColonyClient(
+  this: ColonyNetworkClient,
+  address: string,
+  signerOrProvider: SignerOrProvider,
+): ColonyClientV13 {
+  const colonyClient = IColonyFactory.connect(
+    address,
+    signerOrProvider,
+  ) as ColonyClientV13;
+
+  colonyClient.clientVersion = 13;
+  addAugments(colonyClient, this);
+  addAddDomainAugments(colonyClient);
+  addMoveFundsBetweenPotsAugments(colonyClient);
+
+  return colonyClient as ColonyClientV13;
+}

--- a/packages/colony-js/src/clients/Core/augments/AddDomain.ts
+++ b/packages/colony-js/src/clients/Core/augments/AddDomain.ts
@@ -18,6 +18,7 @@ import {
   IColonyV10,
   IColonyV11,
   IColonyV12,
+  IColonyV13,
 } from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 
@@ -33,7 +34,8 @@ type ValidColonyB =
   | IColonyV9
   | IColonyV10
   | IColonyV11
-  | IColonyV12;
+  | IColonyV12
+  | IColonyV13;
 
 export interface AddDomainEstimateGasA {
   /**

--- a/packages/colony-js/src/clients/Core/augments/MoveFundsBetweenPots.ts
+++ b/packages/colony-js/src/clients/Core/augments/MoveFundsBetweenPots.ts
@@ -21,6 +21,7 @@ import {
   IColonyV10,
   IColonyV11,
   IColonyV12,
+  IColonyV13,
 } from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 
@@ -40,7 +41,8 @@ type ValidColonyB =
   | IColonyV9
   | IColonyV10
   | IColonyV11
-  | IColonyV12;
+  | IColonyV12
+  | IColonyV13;
 
 const getMoveFundsPermissionProofsA = async (
   contract: AugmentedIColony,

--- a/packages/colony-js/src/clients/Core/augments/augmentsV3.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV3.ts
@@ -17,6 +17,7 @@ import {
   IColonyV10,
   IColonyV11,
   IColonyV12,
+  IColonyV13,
 } from '../contracts.js';
 import {
   addAugments as addCommonAugments,
@@ -33,7 +34,8 @@ type ValidColony =
   | IColonyV9
   | IColonyV10
   | IColonyV11
-  | IColonyV12;
+  | IColonyV12
+  | IColonyV13;
 
 export interface AugmentedEstimateV3 {
   /**

--- a/packages/colony-js/src/clients/Core/augments/augmentsV4.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV4.ts
@@ -16,6 +16,7 @@ import {
   IColonyV10,
   IColonyV11,
   IColonyV12,
+  IColonyV13,
 } from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 import {
@@ -33,7 +34,8 @@ type ValidColony =
   | IColonyV9
   | IColonyV10
   | IColonyV11
-  | IColonyV12;
+  | IColonyV12
+  | IColonyV13;
 
 export interface AugmentedEstimateV4 extends AugmentedEstimateV3 {
   /**

--- a/packages/colony-js/src/clients/Core/augments/augmentsV5.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV5.ts
@@ -27,6 +27,7 @@ import {
   IColonyV10,
   IColonyV11,
   IColonyV12,
+  IColonyV13,
 } from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 import { ColonyAugmentsV3 } from './augmentsV3.js';
@@ -44,7 +45,8 @@ type ValidColony =
   | IColonyV9
   | IColonyV10
   | IColonyV11
-  | IColonyV12;
+  | IColonyV12
+  | IColonyV13;
 
 /*
  * Estimates

--- a/packages/colony-js/src/clients/Core/augments/augmentsV6.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV6.ts
@@ -6,7 +6,13 @@ import {
 } from '@colony/core';
 
 import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
-import { IColonyV9, IColonyV10, IColonyV11, IColonyV12 } from '../contracts.js';
+import {
+  IColonyV9,
+  IColonyV10,
+  IColonyV11,
+  IColonyV12,
+  IColonyV13,
+} from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 import { ColonyAugmentsV3 } from './augmentsV3.js';
 import { ColonyAugmentsV4 } from './augmentsV4.js';
@@ -16,7 +22,12 @@ import {
   AugmentedEstimateV5,
 } from './augmentsV5.js';
 
-type ValidColony = IColonyV9 | IColonyV10 | IColonyV11 | IColonyV12;
+type ValidColony =
+  | IColonyV9
+  | IColonyV10
+  | IColonyV11
+  | IColonyV12
+  | IColonyV13;
 
 /*
  * Estimates

--- a/packages/colony-js/src/clients/Core/augments/augmentsV7.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV7.ts
@@ -6,7 +6,12 @@ import {
 } from '@colony/core';
 
 import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
-import { IColonyV10, IColonyV11, IColonyV12 } from '../contracts.js';
+import {
+  IColonyV10,
+  IColonyV11,
+  IColonyV12,
+  IColonyV13,
+} from '../contracts.js';
 import { AugmentedIColony } from './commonAugments.js';
 import { ColonyAugmentsV3 } from './augmentsV3.js';
 import { ColonyAugmentsV4 } from './augmentsV4.js';
@@ -17,7 +22,7 @@ import {
   AugmentedEstimateV6,
 } from './augmentsV6.js';
 
-type ValidColony = IColonyV10 | IColonyV11 | IColonyV12;
+type ValidColony = IColonyV10 | IColonyV11 | IColonyV12 | IColonyV13;
 
 /*
  * Estimates

--- a/packages/colony-js/src/clients/Core/contracts.ts
+++ b/packages/colony-js/src/clients/Core/contracts.ts
@@ -11,6 +11,7 @@ import type { IColony as IColony9 } from '../../contracts/IColony/9/index.js';
 import type { IColony as IColony10 } from '../../contracts/IColony/10/index.js';
 import type { IColony as IColony11 } from '../../contracts/IColony/11/index.js';
 import type { IColony as IColony12 } from '../../contracts/IColony/12/index.js';
+import type { IColony as IColony13 } from '../../contracts/IColony/13/index.js';
 
 // Always adjust to the latest Colony version
 export { IColony__factory as IColonyFactory } from '../../contracts/IColony/12/factories/IColony__factory.js';
@@ -27,6 +28,7 @@ export type IColonyV9 = IColony9;
 export type IColonyV10 = IColony10;
 export type IColonyV11 = IColony11;
 export type IColonyV12 = IColony12;
+export type IColonyV13 = IColony13;
 
 export type AnyIColony =
   | IColony1
@@ -40,4 +42,5 @@ export type AnyIColony =
   | IColony9
   | IColony10
   | IColony11
-  | IColony12;
+  | IColony12
+  | IColony13;

--- a/packages/colony-js/src/clients/Core/exports.ts
+++ b/packages/colony-js/src/clients/Core/exports.ts
@@ -16,6 +16,7 @@ import getColonyClientV9, { ColonyClientV9 } from './ColonyClientV9.js';
 import getColonyClientV10, { ColonyClientV10 } from './ColonyClientV10.js';
 import getColonyClientV11, { ColonyClientV11 } from './ColonyClientV11.js';
 import getColonyClientV12, { ColonyClientV12 } from './ColonyClientV12.js';
+import getColonyClientV13, { ColonyClientV13 } from './ColonyClientV13.js';
 
 export { ColonyClientV1 } from './ColonyClientV1.js';
 export { ColonyClientV2 } from './ColonyClientV2.js';
@@ -29,6 +30,7 @@ export { ColonyClientV9 } from './ColonyClientV9.js';
 export { ColonyClientV10 } from './ColonyClientV10.js';
 export { ColonyClientV11 } from './ColonyClientV11.js';
 export { ColonyClientV12 } from './ColonyClientV12.js';
+export { ColonyClientV13 } from './ColonyClientV13.js';
 
 export type AnyColonyClient =
   | ColonyClientV1
@@ -42,7 +44,8 @@ export type AnyColonyClient =
   | ColonyClientV9
   | ColonyClientV10
   | ColonyClientV11
-  | ColonyClientV12;
+  | ColonyClientV12
+  | ColonyClientV13;
 
 /** Versioned core contract names */
 export enum Core {
@@ -169,6 +172,14 @@ export async function getColonyClient(
     }
     case 12: {
       colonyClient = getColonyClientV12.call(
+        this,
+        colonyAddress,
+        signerOrProvider,
+      );
+      break;
+    }
+    case 13: {
+      colonyClient = getColonyClientV13.call(
         this,
         colonyAddress,
         signerOrProvider,

--- a/packages/colony-js/src/clients/Extensions/CoinMachine/CoinMachineClientV8.ts
+++ b/packages/colony-js/src/clients/Extensions/CoinMachine/CoinMachineClientV8.ts
@@ -1,0 +1,26 @@
+import { CoinMachine__factory as CoinMachineFactory } from '../../../contracts/CoinMachine/8/factories/CoinMachine__factory.js';
+import { CoinMachine } from '../../../contracts/CoinMachine/8/CoinMachine.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedCoinMachine,
+} from './augments/commonAugments.js';
+
+export interface CoinMachineClientV8 extends AugmentedCoinMachine<CoinMachine> {
+  clientVersion: 8;
+}
+
+export default function getCoinMachineClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): CoinMachineClientV8 {
+  const coinMachineClient = CoinMachineFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as CoinMachineClientV8;
+
+  coinMachineClient.clientVersion = 8;
+  addAugments(coinMachineClient, colonyClient);
+
+  return coinMachineClient;
+}

--- a/packages/colony-js/src/clients/Extensions/CoinMachine/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/CoinMachine/contracts.ts
@@ -6,9 +6,10 @@ import type { CoinMachine as CoinMachine4 } from '../../../contracts/CoinMachine
 import type { CoinMachine as CoinMachine5 } from '../../../contracts/CoinMachine/5/index.js';
 import type { CoinMachine as CoinMachine6 } from '../../../contracts/CoinMachine/6/index.js';
 import type { CoinMachine as CoinMachine7 } from '../../../contracts/CoinMachine/7/index.js';
+import type { CoinMachine as CoinMachine8 } from '../../../contracts/CoinMachine/8/index.js';
 
 // Always adjust to the latest factory
-export { CoinMachine__factory as CoinMachineFactory } from '../../../contracts/CoinMachine/7/factories/CoinMachine__factory.js';
+export { CoinMachine__factory as CoinMachineFactory } from '../../../contracts/CoinMachine/8/factories/CoinMachine__factory.js';
 
 export type CoinMachineV1 = CoinMachine1;
 export type CoinMachineV2 = CoinMachine2;
@@ -17,6 +18,7 @@ export type CoinMachineV4 = CoinMachine4;
 export type CoinMachineV5 = CoinMachine5;
 export type CoinMachineV6 = CoinMachine6;
 export type CoinMachineV7 = CoinMachine7;
+export type CoinMachineV8 = CoinMachine8;
 
 export type AnyCoinMachine =
   | CoinMachine1
@@ -25,4 +27,5 @@ export type AnyCoinMachine =
   | CoinMachine4
   | CoinMachine5
   | CoinMachine6
-  | CoinMachine7;
+  | CoinMachine7
+  | CoinMachine8;

--- a/packages/colony-js/src/clients/Extensions/CoinMachine/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/CoinMachine/exports.ts
@@ -25,6 +25,9 @@ import getCoinMachineClientV6, {
 import getCoinMachineClientV7, {
   CoinMachineClientV7,
 } from './CoinMachineClientV7.js';
+import getCoinMachineClientV8, {
+  CoinMachineClientV8,
+} from './CoinMachineClientV8.js';
 
 export { CoinMachineClientV1 } from './CoinMachineClientV1.js';
 export { CoinMachineClientV2 } from './CoinMachineClientV2.js';
@@ -33,6 +36,7 @@ export { CoinMachineClientV4 } from './CoinMachineClientV4.js';
 export { CoinMachineClientV5 } from './CoinMachineClientV5.js';
 export { CoinMachineClientV6 } from './CoinMachineClientV6.js';
 export { CoinMachineClientV7 } from './CoinMachineClientV7.js';
+export { CoinMachineClientV8 } from './CoinMachineClientV8.js';
 
 export type AnyCoinMachineClient =
   | CoinMachineClientV1
@@ -41,7 +45,8 @@ export type AnyCoinMachineClient =
   | CoinMachineClientV4
   | CoinMachineClientV5
   | CoinMachineClientV6
-  | CoinMachineClientV7;
+  | CoinMachineClientV7
+  | CoinMachineClientV8;
 
 /** @internal */
 export const getCoinMachineClient = (
@@ -64,6 +69,8 @@ export const getCoinMachineClient = (
       return getCoinMachineClientV6(colonyClient, address);
     case 7:
       return getCoinMachineClientV7(colonyClient, address);
+    case 8:
+      return getCoinMachineClientV8(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/EvaluatedExpenditureClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/EvaluatedExpenditureClientV4.ts
@@ -1,0 +1,28 @@
+import { EvaluatedExpenditure__factory as EvaluatedExpenditureFactory } from '../../../contracts/EvaluatedExpenditure/4/factories/EvaluatedExpenditure__factory.js';
+import { EvaluatedExpenditure } from '../../../contracts/EvaluatedExpenditure/4/EvaluatedExpenditure.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedEvaluatedExpenditure,
+  ValidColony,
+} from './augments/commonAugments.js';
+
+export interface EvaluatedExpenditureClientV4
+  extends AugmentedEvaluatedExpenditure<EvaluatedExpenditure> {
+  clientVersion: 4;
+}
+
+export default function getEvaluatedExpenditureClient(
+  colonyClient: AugmentedIColony<ValidColony>,
+  address: string,
+): EvaluatedExpenditureClientV4 {
+  const evaluatedExpenditureClient = EvaluatedExpenditureFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as EvaluatedExpenditureClientV4;
+
+  evaluatedExpenditureClient.clientVersion = 4;
+  addAugments(evaluatedExpenditureClient, colonyClient);
+
+  return evaluatedExpenditureClient;
+}

--- a/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/augments/commonAugments.ts
@@ -20,6 +20,9 @@ import {
   IColonyV8,
   IColonyV9,
   IColonyV10,
+  IColonyV11,
+  IColonyV12,
+  IColonyV13,
 } from '../../../Core/contracts.js';
 import { AnyEvaluatedExpenditure } from '../contracts.js';
 
@@ -30,7 +33,10 @@ export type ValidColony =
   | IColonyV7
   | IColonyV8
   | IColonyV9
-  | IColonyV10;
+  | IColonyV10
+  | IColonyV11
+  | IColonyV12
+  | IColonyV13;
 
 export type AugmentedEstimate<
   T extends AnyEvaluatedExpenditure = AnyEvaluatedExpenditure,

--- a/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/contracts.ts
@@ -2,15 +2,18 @@
 import type { EvaluatedExpenditure as EvaluatedExpenditure1 } from '../../../contracts/EvaluatedExpenditure/1/index.js';
 import type { EvaluatedExpenditure as EvaluatedExpenditure2 } from '../../../contracts/EvaluatedExpenditure/2/index.js';
 import type { EvaluatedExpenditure as EvaluatedExpenditure3 } from '../../../contracts/EvaluatedExpenditure/3/index.js';
+import type { EvaluatedExpenditure as EvaluatedExpenditure4 } from '../../../contracts/EvaluatedExpenditure/4/index.js';
 
 // Always adjust to the latest factory
-export { EvaluatedExpenditure__factory as EvaluatedExpenditureFactory } from '../../../contracts/EvaluatedExpenditure/3/factories/EvaluatedExpenditure__factory.js';
+export { EvaluatedExpenditure__factory as EvaluatedExpenditureFactory } from '../../../contracts/EvaluatedExpenditure/4/factories/EvaluatedExpenditure__factory.js';
 
 export type EvaluatedExpenditureV1 = EvaluatedExpenditure1;
 export type EvaluatedExpenditureV2 = EvaluatedExpenditure2;
 export type EvaluatedExpenditureV3 = EvaluatedExpenditure3;
+export type EvaluatedExpenditureV4 = EvaluatedExpenditure4;
 
 export type AnyEvaluatedExpenditure =
   | EvaluatedExpenditure1
   | EvaluatedExpenditure2
-  | EvaluatedExpenditure3;
+  | EvaluatedExpenditure3
+  | EvaluatedExpenditure4;

--- a/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/EvaluatedExpenditure/exports.ts
@@ -14,15 +14,20 @@ import getEvaluatedExpenditureClientV2, {
 import getEvaluatedExpenditureClientV3, {
   EvaluatedExpenditureClientV3,
 } from './EvaluatedExpenditureClientV3.js';
+import getEvaluatedExpenditureClientV4, {
+  EvaluatedExpenditureClientV4,
+} from './EvaluatedExpenditureClientV4.js';
 
 export { EvaluatedExpenditureClientV1 } from './EvaluatedExpenditureClientV1.js';
 export { EvaluatedExpenditureClientV2 } from './EvaluatedExpenditureClientV2.js';
 export { EvaluatedExpenditureClientV3 } from './EvaluatedExpenditureClientV3.js';
+export { EvaluatedExpenditureClientV4 } from './EvaluatedExpenditureClientV4.js';
 
 export type AnyEvaluatedExpenditureClient =
   | EvaluatedExpenditureClientV1
   | EvaluatedExpenditureClientV2
-  | EvaluatedExpenditureClientV3;
+  | EvaluatedExpenditureClientV3
+  | EvaluatedExpenditureClientV4;
 
 /** @internal */
 export const getEvaluatedExpenditureClient = (
@@ -43,6 +48,11 @@ export const getEvaluatedExpenditureClient = (
       );
     case 3:
       return getEvaluatedExpenditureClientV3(
+        colonyClient as AugmentedIColony<ValidColony>,
+        address,
+      );
+    case 4:
+      return getEvaluatedExpenditureClientV4(
         colonyClient as AugmentedIColony<ValidColony>,
         address,
       );

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV5.ts
@@ -1,0 +1,27 @@
+import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts/FundingQueue/5/factories/FundingQueue__factory.js';
+import { FundingQueue } from '../../../contracts/FundingQueue/5/FundingQueue.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedFundingQueue,
+} from './augments/commonAugments.js';
+
+export interface FundingQueueClientV5
+  extends AugmentedFundingQueue<FundingQueue> {
+  clientVersion: 5;
+}
+
+export default function getFundingQueueClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): FundingQueueClientV5 {
+  const fundingQueueClient = FundingQueueFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as FundingQueueClientV5;
+
+  fundingQueueClient.clientVersion = 5;
+  addAugments(fundingQueueClient, colonyClient);
+
+  return fundingQueueClient;
+}

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/contracts.ts
@@ -3,17 +3,20 @@ import type { FundingQueue as FundingQueue1 } from '../../../contracts/FundingQu
 import type { FundingQueue as FundingQueue2 } from '../../../contracts/FundingQueue/2/index.js';
 import type { FundingQueue as FundingQueue3 } from '../../../contracts/FundingQueue/3/index.js';
 import type { FundingQueue as FundingQueue4 } from '../../../contracts/FundingQueue/4/index.js';
+import type { FundingQueue as FundingQueue5 } from '../../../contracts/FundingQueue/5/index.js';
 
 // Always adjust to the latest factory
-export { FundingQueue__factory as FundingQueueFactory } from '../../../contracts/FundingQueue/4/factories/FundingQueue__factory.js';
+export { FundingQueue__factory as FundingQueueFactory } from '../../../contracts/FundingQueue/5/factories/FundingQueue__factory.js';
 
 export type FundingQueueV1 = FundingQueue1;
 export type FundingQueueV2 = FundingQueue2;
 export type FundingQueueV3 = FundingQueue3;
 export type FundingQueueV4 = FundingQueue4;
+export type FundingQueueV5 = FundingQueue5;
 
 export type AnyFundingQueue =
   | FundingQueue1
   | FundingQueue2
   | FundingQueue3
-  | FundingQueue4;
+  | FundingQueue4
+  | FundingQueue5;

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/exports.ts
@@ -16,17 +16,22 @@ import getFundingQueueClientV3, {
 import getFundingQueueClientV4, {
   FundingQueueClientV4,
 } from './FundingQueueClientV4.js';
+import getFundingQueueClientV5, {
+  FundingQueueClientV5,
+} from './FundingQueueClientV5.js';
 
 export { FundingQueueClientV1 } from './FundingQueueClientV1.js';
 export { FundingQueueClientV2 } from './FundingQueueClientV2.js';
 export { FundingQueueClientV3 } from './FundingQueueClientV3.js';
 export { FundingQueueClientV4 } from './FundingQueueClientV4.js';
+export { FundingQueueClientV5 } from './FundingQueueClientV5.js';
 
 export type AnyFundingQueueClient =
   | FundingQueueClientV1
   | FundingQueueClientV2
   | FundingQueueClientV3
-  | FundingQueueClientV4;
+  | FundingQueueClientV4
+  | FundingQueueClientV5;
 
 /** @internal */
 export const getFundingQueueClient = (
@@ -43,6 +48,8 @@ export const getFundingQueueClient = (
       return getFundingQueueClientV3(colonyClient, address);
     case 4:
       return getFundingQueueClientV4(colonyClient, address);
+    case 5:
+      return getFundingQueueClientV5(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV5.ts
@@ -1,0 +1,33 @@
+import { ClientType } from '../../../constants.js';
+import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts/OneTxPayment/5/factories/OneTxPayment__factory.js';
+import { OneTxPayment } from '../../../contracts/OneTxPayment/5/OneTxPayment.js';
+import {
+  addAugments,
+  AugmentedEstimate,
+  AugmentedOneTxPayment,
+} from './augments/commonAugments.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+
+type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;
+
+export interface OneTxPaymentClientV5
+  extends AugmentedOneTxPayment<OneTxPayment> {
+  clientVersion: 5;
+  estimateGas: OneTxPaymentEstimate;
+}
+
+export default function getOneTxPaymentClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): OneTxPaymentClientV5 {
+  const oneTxPaymentClient = OneTxPaymentFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as OneTxPaymentClientV5;
+
+  oneTxPaymentClient.clientType = ClientType.OneTxPaymentClient;
+  oneTxPaymentClient.clientVersion = 5;
+  addAugments(oneTxPaymentClient, colonyClient);
+
+  return oneTxPaymentClient;
+}

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/contracts.ts
@@ -3,17 +3,20 @@ import type { OneTxPayment as OneTxPayment1 } from '../../../contracts/OneTxPaym
 import type { OneTxPayment as OneTxPayment2 } from '../../../contracts/OneTxPayment/2/index.js';
 import type { OneTxPayment as OneTxPayment3 } from '../../../contracts/OneTxPayment/3/index.js';
 import type { OneTxPayment as OneTxPayment4 } from '../../../contracts/OneTxPayment/4/index.js';
+import type { OneTxPayment as OneTxPayment5 } from '../../../contracts/OneTxPayment/5/index.js';
 
 // Always adjust to the latest factory
-export { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts/OneTxPayment/4/factories/OneTxPayment__factory.js';
+export { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts/OneTxPayment/5/factories/OneTxPayment__factory.js';
 
 export type OneTxPaymentV1 = OneTxPayment1;
 export type OneTxPaymentV2 = OneTxPayment2;
 export type OneTxPaymentV3 = OneTxPayment3;
 export type OneTxPaymentV4 = OneTxPayment4;
+export type OneTxPaymentV5 = OneTxPayment5;
 
 export type AnyOneTxPayment =
   | OneTxPayment1
   | OneTxPayment2
   | OneTxPayment3
-  | OneTxPayment4;
+  | OneTxPayment4
+  | OneTxPayment5;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/exports.ts
@@ -16,17 +16,22 @@ import getOneTxPaymentClientV3, {
 import getOneTxPaymentClientV4, {
   OneTxPaymentClientV4,
 } from './OneTxPaymentClientV4.js';
+import getOneTxPaymentClientV5, {
+  OneTxPaymentClientV5,
+} from './OneTxPaymentClientV5.js';
 
 export { OneTxPaymentClientV1 } from './OneTxPaymentClientV1.js';
 export { OneTxPaymentClientV2 } from './OneTxPaymentClientV2.js';
 export { OneTxPaymentClientV3 } from './OneTxPaymentClientV3.js';
 export { OneTxPaymentClientV4 } from './OneTxPaymentClientV4.js';
+export { OneTxPaymentClientV5 } from './OneTxPaymentClientV5.js';
 
 export type AnyOneTxPaymentClient =
   | OneTxPaymentClientV1
   | OneTxPaymentClientV2
   | OneTxPaymentClientV3
-  | OneTxPaymentClientV4;
+  | OneTxPaymentClientV4
+  | OneTxPaymentClientV5;
 
 /** @internal */
 export const getOneTxPaymentClient = (
@@ -43,6 +48,8 @@ export const getOneTxPaymentClient = (
       return getOneTxPaymentClientV3(colonyClient, address);
     case 4:
       return getOneTxPaymentClientV4(colonyClient, address);
+    case 5:
+      return getOneTxPaymentClientV5(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV2.ts
@@ -1,0 +1,27 @@
+import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from '../../../contracts/ReputationBootstrapper/2/factories/ReputationBootstrapper__factory.js';
+import { ReputationBootstrapper } from '../../../contracts/ReputationBootstrapper/2/ReputationBootstrapper.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedReputationBootstrapper,
+} from './augments/commonAugments.js';
+
+export interface ReputationBootstrapperClientV2
+  extends AugmentedReputationBootstrapper<ReputationBootstrapper> {
+  clientVersion: 2;
+}
+
+export default function getReputationBootstrapperClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): ReputationBootstrapperClientV2 {
+  const reputationBootstrapperClient = ReputationBootstrapperFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as ReputationBootstrapperClientV2;
+
+  reputationBootstrapperClient.clientVersion = 2;
+  addAugments(reputationBootstrapperClient, colonyClient);
+
+  return reputationBootstrapperClient;
+}

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/contracts.ts
@@ -1,9 +1,13 @@
 // Always add the next ReputationBootstrapper version here
 import type { ReputationBootstrapper as ReputationBootstrapper1 } from '../../../contracts/ReputationBootstrapper/1/index.js';
+import type { ReputationBootstrapper as ReputationBootstrapper2 } from '../../../contracts/ReputationBootstrapper/2/index.js';
 
 // Always adjust to the latest factory
-export { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from '../../../contracts/ReputationBootstrapper/1/factories/ReputationBootstrapper__factory.js';
+export { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from '../../../contracts/ReputationBootstrapper/2/factories/ReputationBootstrapper__factory.js';
 
 export type ReputationBootstrapperV1 = ReputationBootstrapper1;
+export type ReputationBootstrapperV2 = ReputationBootstrapper2;
 
-export type AnyReputationBootstrapper = ReputationBootstrapper1;
+export type AnyReputationBootstrapper =
+  | ReputationBootstrapper1
+  | ReputationBootstrapper2;

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/exports.ts
@@ -7,10 +7,16 @@ import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
 import getReputationBootstrapperClientV1, {
   ReputationBootstrapperClientV1,
 } from './ReputationBootstrapperClientV1.js';
+import getReputationBootstrapperClientV2, {
+  ReputationBootstrapperClientV2,
+} from './ReputationBootstrapperClientV2.js';
 
 export { ReputationBootstrapperClientV1 } from './ReputationBootstrapperClientV1.js';
+export { ReputationBootstrapperClientV2 } from './ReputationBootstrapperClientV2.js';
 
-export type AnyReputationBootstrapperClient = ReputationBootstrapperClientV1;
+export type AnyReputationBootstrapperClient =
+  | ReputationBootstrapperClientV1
+  | ReputationBootstrapperClientV2;
 
 /** @internal */
 export const getReputationBootstrapperClient = (
@@ -21,6 +27,8 @@ export const getReputationBootstrapperClient = (
   switch (version) {
     case 1:
       return getReputationBootstrapperClientV1(colonyClient, address);
+    case 2:
+      return getReputationBootstrapperClientV2(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV3.ts
@@ -1,0 +1,28 @@
+import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/3/factories/StakedExpenditure__factory.js';
+import { StakedExpenditure } from '../../../contracts/StakedExpenditure/3/index.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedStakedExpenditure,
+  ValidColony,
+} from './augments/commonAugments.js';
+
+export interface StakedExpenditureClientV3
+  extends AugmentedStakedExpenditure<StakedExpenditure> {
+  clientVersion: 3;
+}
+
+export default function getStakedExpenditureClient(
+  colonyClient: AugmentedIColony<ValidColony>,
+  address: string,
+): StakedExpenditureClientV3 {
+  const evaluatedExpenditureClient = StakedExpenditureFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as StakedExpenditureClientV3;
+
+  evaluatedExpenditureClient.clientVersion = 3;
+  addAugments(evaluatedExpenditureClient, colonyClient);
+
+  return evaluatedExpenditureClient;
+}

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/augments/commonAugments.ts
@@ -25,6 +25,9 @@ import {
   IColonyV8,
   IColonyV9,
   IColonyV10,
+  IColonyV11,
+  IColonyV12,
+  IColonyV13,
 } from '../../../Core/contracts.js';
 import { AnyStakedExpenditure } from '../contracts.js';
 
@@ -35,7 +38,10 @@ export type ValidColony =
   | IColonyV7
   | IColonyV8
   | IColonyV9
-  | IColonyV10;
+  | IColonyV10
+  | IColonyV11
+  | IColonyV12
+  | IColonyV13;
 
 export type AugmentedEstimate<
   T extends AnyStakedExpenditure = AnyStakedExpenditure,

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/contracts.ts
@@ -1,11 +1,16 @@
 // Always add the next StakedExpenditure version here
 import type { StakedExpenditure as StakedExpenditure1 } from '../../../contracts/StakedExpenditure/1/index.js';
 import type { StakedExpenditure as StakedExpenditure2 } from '../../../contracts/StakedExpenditure/2/index.js';
+import type { StakedExpenditure as StakedExpenditure3 } from '../../../contracts/StakedExpenditure/3/index.js';
 
 // Always adjust to the latest factory
-export { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/2/factories/StakedExpenditure__factory.js';
+export { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/3/factories/StakedExpenditure__factory.js';
 
 export type StakedExpenditureV1 = StakedExpenditure1;
 export type StakedExpenditureV2 = StakedExpenditure2;
+export type StakedExpenditureV3 = StakedExpenditure3;
 
-export type AnyStakedExpenditure = StakedExpenditure1 | StakedExpenditure2;
+export type AnyStakedExpenditure =
+  | StakedExpenditure1
+  | StakedExpenditure2
+  | StakedExpenditure3;

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/exports.ts
@@ -11,13 +11,18 @@ import getStakedExpenditureClientV1, {
 import getStakedExpenditureClientV2, {
   StakedExpenditureClientV2,
 } from './StakedExpenditureClientV2.js';
+import getStakedExpenditureClientV3, {
+  StakedExpenditureClientV3,
+} from './StakedExpenditureClientV3.js';
 
 export { StakedExpenditureClientV1 } from './StakedExpenditureClientV1.js';
 export { StakedExpenditureClientV2 } from './StakedExpenditureClientV2.js';
+export { StakedExpenditureClientV3 } from './StakedExpenditureClientV3.js';
 
 export type AnyStakedExpenditureClient =
   | StakedExpenditureClientV1
-  | StakedExpenditureClientV2;
+  | StakedExpenditureClientV2
+  | StakedExpenditureClientV3;
 
 /** @internal */
 export const getStakedExpenditureClient = (
@@ -33,6 +38,11 @@ export const getStakedExpenditureClient = (
       );
     case 2:
       return getStakedExpenditureClientV2(
+        colonyClient as AugmentedIColony<ValidColony>,
+        address,
+      );
+    case 3:
+      return getStakedExpenditureClientV3(
         colonyClient as AugmentedIColony<ValidColony>,
         address,
       );

--- a/packages/colony-js/src/clients/Extensions/StreamingPayments/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/StreamingPayments/augments/commonAugments.ts
@@ -25,6 +25,9 @@ import {
   IColonyV8,
   IColonyV9,
   IColonyV10,
+  IColonyV11,
+  IColonyV12,
+  IColonyV13,
 } from '../../../Core/contracts.js';
 import { AnyStreamingPayments } from '../contracts.js';
 
@@ -37,7 +40,10 @@ export type ValidColony =
   | IColonyV7
   | IColonyV8
   | IColonyV9
-  | IColonyV10;
+  | IColonyV10
+  | IColonyV11
+  | IColonyV12
+  | IColonyV13;
 
 export type AugmentedEstimate<
   T extends AnyStreamingPayments = AnyStreamingPayments,
@@ -148,11 +154,11 @@ export type AugmentedStreamingPayments<
   colonyClient: AugmentedIColony<ValidColony>;
 
   /**
-   * The stakedExpenditureEvents contract supports all events across all versions.
+   * The streamingPaymentsEvents contract supports all events across all versions.
    * Isn't that amazing?
    * It's an ethers contract with only events to filter
    */
-  stakedExpenditureEvents: StreamingPaymentsEvents;
+  streamingPaymentsEvents: StreamingPaymentsEvents;
 
   estimateGas: T['estimateGas'] & AugmentedEstimate;
 
@@ -668,7 +674,7 @@ export const addAugments = <T extends AugmentedStreamingPayments>(
   instance.clientType = ClientType.StreamingPaymentsClient;
   instance.colonyClient = colonyClient;
 
-  instance.stakedExpenditureEvents = StreamingPaymentsEventsFactory.connect(
+  instance.streamingPaymentsEvents = StreamingPaymentsEventsFactory.connect(
     instance.address,
     instance.signer || instance.provider,
   );

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV5.ts
@@ -1,0 +1,27 @@
+import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contracts/TokenSupplier/5/factories/TokenSupplier__factory.js';
+import { TokenSupplier } from '../../../contracts/TokenSupplier/5/TokenSupplier.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedTokenSupplier,
+} from './augments/commonAugments.js';
+
+export interface TokenSupplierClientV5
+  extends AugmentedTokenSupplier<TokenSupplier> {
+  clientVersion: 5;
+}
+
+export default function getTokenSupplierClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): TokenSupplierClientV5 {
+  const tokenSupplierClient = TokenSupplierFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as TokenSupplierClientV5;
+
+  tokenSupplierClient.clientVersion = 5;
+  addAugments(tokenSupplierClient, colonyClient);
+
+  return tokenSupplierClient;
+}

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/contracts.ts
@@ -3,17 +3,20 @@ import type { TokenSupplier as TokenSupplier1 } from '../../../contracts/TokenSu
 import type { TokenSupplier as TokenSupplier2 } from '../../../contracts/TokenSupplier/2/index.js';
 import type { TokenSupplier as TokenSupplier3 } from '../../../contracts/TokenSupplier/3/index.js';
 import type { TokenSupplier as TokenSupplier4 } from '../../../contracts/TokenSupplier/4/index.js';
+import type { TokenSupplier as TokenSupplier5 } from '../../../contracts/TokenSupplier/5/index.js';
 
 // Always adjust to the latest factory
-export { TokenSupplier__factory as TokenSupplierFactory } from '../../../contracts/TokenSupplier/4/factories/TokenSupplier__factory.js';
+export { TokenSupplier__factory as TokenSupplierFactory } from '../../../contracts/TokenSupplier/5/factories/TokenSupplier__factory.js';
 
 export type TokenSupplierV1 = TokenSupplier1;
 export type TokenSupplierV2 = TokenSupplier2;
 export type TokenSupplierV3 = TokenSupplier3;
 export type TokenSupplierV4 = TokenSupplier4;
+export type TokenSupplierV5 = TokenSupplier5;
 
 export type AnyTokenSupplier =
   | TokenSupplier1
   | TokenSupplier2
   | TokenSupplier3
-  | TokenSupplier4;
+  | TokenSupplier4
+  | TokenSupplier5;

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/exports.ts
@@ -16,17 +16,22 @@ import getTokenSupplierClientV3, {
 import getTokenSupplierClientV4, {
   TokenSupplierClientV4,
 } from './TokenSupplierClientV4.js';
+import getTokenSupplierClientV5, {
+  TokenSupplierClientV5,
+} from './TokenSupplierClientV5.js';
 
 export { TokenSupplierClientV1 } from './TokenSupplierClientV1.js';
 export { TokenSupplierClientV2 } from './TokenSupplierClientV2.js';
 export { TokenSupplierClientV3 } from './TokenSupplierClientV3.js';
 export { TokenSupplierClientV4 } from './TokenSupplierClientV4.js';
+export { TokenSupplierClientV5 } from './TokenSupplierClientV5.js';
 
 export type AnyTokenSupplierClient =
   | TokenSupplierClientV1
   | TokenSupplierClientV2
   | TokenSupplierClientV3
-  | TokenSupplierClientV4;
+  | TokenSupplierClientV4
+  | TokenSupplierClientV5;
 
 /** @internal */
 export const getTokenSupplierClient = (
@@ -43,6 +48,8 @@ export const getTokenSupplierClient = (
       return getTokenSupplierClientV3(colonyClient, address);
     case 4:
       return getTokenSupplierClientV4(colonyClient, address);
+    case 5:
+      return getTokenSupplierClientV5(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV9.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV9.ts
@@ -1,0 +1,38 @@
+import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/9/factories/IVotingReputation__factory.js';
+import { IVotingReputation } from '../../../contracts/IVotingReputation/9/IVotingReputation.js';
+import {
+  AugmentedEstimate,
+  AugmentedVotingReputation,
+} from './augments/commonAugments.js';
+import {
+  addAugments,
+  AugmentedEstimateV2,
+  AugmentsV2,
+} from './augments/augmentsV2.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+
+interface VotingReputationEstimate
+  extends AugmentedEstimate<IVotingReputation>,
+    AugmentedEstimateV2 {}
+
+export interface VotingReputationClientV9
+  extends AugmentedVotingReputation<IVotingReputation>,
+    AugmentsV2<IVotingReputation> {
+  clientVersion: 9;
+  estimateGas: VotingReputationEstimate;
+}
+
+export default function getVotingReputationClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): VotingReputationClientV9 {
+  const votingReputationClient = VotingReputationFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as VotingReputationClientV9;
+
+  votingReputationClient.clientVersion = 9;
+  addAugments(votingReputationClient, colonyClient);
+
+  return votingReputationClient;
+}

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/contracts.ts
@@ -7,8 +7,9 @@ import type { VotingReputation as VotingReputation5 } from '../../../contracts/V
 import type { IVotingReputation as VotingReputation6 } from '../../../contracts/IVotingReputation/6/index.js';
 import type { IVotingReputation as VotingReputation7 } from '../../../contracts/IVotingReputation/7/index.js';
 import type { IVotingReputation as VotingReputation8 } from '../../../contracts/IVotingReputation/8/index.js';
+import type { IVotingReputation as VotingReputation9 } from '../../../contracts/IVotingReputation/9/index.js';
 
-export { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/8/factories/IVotingReputation__factory.js';
+export { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/9/factories/IVotingReputation__factory.js';
 
 export type VotingReputationV1 = VotingReputation1;
 export type VotingReputationV2 = VotingReputation2;
@@ -18,6 +19,7 @@ export type VotingReputationV5 = VotingReputation5;
 export type VotingReputationV6 = VotingReputation6;
 export type VotingReputationV7 = VotingReputation7;
 export type VotingReputationV8 = VotingReputation8;
+export type VotingReputationV9 = VotingReputation9;
 
 export type AnyVotingReputation =
   | VotingReputation1
@@ -27,4 +29,5 @@ export type AnyVotingReputation =
   | VotingReputation5
   | VotingReputation6
   | VotingReputation7
-  | VotingReputation8;
+  | VotingReputation8
+  | VotingReputation9;

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/exports.ts
@@ -28,6 +28,9 @@ import getVotingReputationClientV7, {
 import getVotingReputationClientV8, {
   VotingReputationClientV8,
 } from './VotingReputationClientV8.js';
+import getVotingReputationClientV9, {
+  VotingReputationClientV9,
+} from './VotingReputationClientV9.js';
 
 export { VotingReputationClientV1 } from './VotingReputationClientV1.js';
 export { VotingReputationClientV2 } from './VotingReputationClientV2.js';
@@ -37,6 +40,7 @@ export { VotingReputationClientV5 } from './VotingReputationClientV5.js';
 export { VotingReputationClientV6 } from './VotingReputationClientV6.js';
 export { VotingReputationClientV7 } from './VotingReputationClientV7.js';
 export { VotingReputationClientV8 } from './VotingReputationClientV8.js';
+export { VotingReputationClientV9 } from './VotingReputationClientV9.js';
 
 export type AnyVotingReputationClient =
   | VotingReputationClientV1
@@ -46,7 +50,8 @@ export type AnyVotingReputationClient =
   | VotingReputationClientV5
   | VotingReputationClientV6
   | VotingReputationClientV7
-  | VotingReputationClientV8;
+  | VotingReputationClientV8
+  | VotingReputationClientV9;
 
 /** @internal */
 export function getVotingReputationClient(
@@ -71,6 +76,8 @@ export function getVotingReputationClient(
       return getVotingReputationClientV7(colonyClient, address);
     case 8:
       return getVotingReputationClientV8(colonyClient, address);
+    case 9:
+      return getVotingReputationClientV9(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/colony-js/src/clients/Extensions/Whitelist/WhitelistClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/Whitelist/WhitelistClientV4.ts
@@ -1,0 +1,23 @@
+import { Whitelist__factory as WhitelistFactory } from '../../../contracts/Whitelist/4/factories/Whitelist__factory.js';
+import { Whitelist } from '../../../contracts/Whitelist/4/Whitelist.js';
+import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { addAugments, AugmentedWhitelist } from './augments/commonAugments.js';
+
+export interface WhitelistClientV4 extends AugmentedWhitelist<Whitelist> {
+  clientVersion: 4;
+}
+
+export default function getWhitelistClient(
+  colonyClient: AugmentedIColony,
+  address: string,
+): WhitelistClientV4 {
+  const whitelistClient = WhitelistFactory.connect(
+    address,
+    colonyClient.signer || colonyClient.provider,
+  ) as WhitelistClientV4;
+
+  whitelistClient.clientVersion = 4;
+  addAugments(whitelistClient, colonyClient);
+
+  return whitelistClient;
+}

--- a/packages/colony-js/src/clients/Extensions/Whitelist/contracts.ts
+++ b/packages/colony-js/src/clients/Extensions/Whitelist/contracts.ts
@@ -2,12 +2,14 @@
 import type { Whitelist as Whitelist1 } from '../../../contracts/Whitelist/1/index.js';
 import type { Whitelist as Whitelist2 } from '../../../contracts/Whitelist/2/index.js';
 import type { Whitelist as Whitelist3 } from '../../../contracts/Whitelist/3/index.js';
+import type { Whitelist as Whitelist4 } from '../../../contracts/Whitelist/4/index.js';
 
 // Always adjust to the latest factory
-export { Whitelist__factory as WhitelistFactory } from '../../../contracts/Whitelist/3/factories/Whitelist__factory.js';
+export { Whitelist__factory as WhitelistFactory } from '../../../contracts/Whitelist/4/factories/Whitelist__factory.js';
 
 export type WhitelistV1 = Whitelist1;
 export type WhitelistV2 = Whitelist2;
 export type WhitelistV3 = Whitelist3;
+export type WhitelistV4 = Whitelist4;
 
-export type AnyWhitelist = Whitelist1 | Whitelist2 | Whitelist3;
+export type AnyWhitelist = Whitelist1 | Whitelist2 | Whitelist3 | Whitelist4;

--- a/packages/colony-js/src/clients/Extensions/Whitelist/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/Whitelist/exports.ts
@@ -13,15 +13,20 @@ import getWhitelistClientV2, {
 import getWhitelistClientV3, {
   WhitelistClientV3,
 } from './WhitelistClientV3.js';
+import getWhitelistClientV4, {
+  WhitelistClientV4,
+} from './WhitelistClientV4.js';
 
 export { WhitelistClientV1 } from './WhitelistClientV1.js';
 export { WhitelistClientV2 } from './WhitelistClientV2.js';
 export { WhitelistClientV3 } from './WhitelistClientV3.js';
+export { WhitelistClientV4 } from './WhitelistClientV4.js';
 
 export type AnyWhitelistClient =
   | WhitelistClientV1
   | WhitelistClientV2
-  | WhitelistClientV3;
+  | WhitelistClientV3
+  | WhitelistClientV4;
 
 /** @internal */
 export const getWhitelistClient = (
@@ -36,6 +41,8 @@ export const getWhitelistClient = (
       return getWhitelistClientV2(colonyClient, address);
     case 3:
       return getWhitelistClientV3(colonyClient, address);
+    case 4:
+      return getWhitelistClientV4(colonyClient, address);
     default:
       return assertExhaustiveSwitch(
         version,

--- a/packages/contractor/package.json
+++ b/packages/contractor/package.json
@@ -30,14 +30,14 @@
   },
   "homepage": "https://docs.colony.io/develop",
   "dependencies": {
-    "@colony/abis": "^0.2.2",
-    "@typechain/ethers-v5": "^11.0.0",
-    "@typechain/ethers-v6": "^0.4.0",
+    "@colony/abis": "^1.0.1",
+    "@typechain/ethers-v5": "^11.1.0",
+    "@typechain/ethers-v6": "^0.4.2",
     "@types/mkdirp": "^1.0.2",
     "@types/yargs": "^17.0.24",
     "mkdirp": "^1.0.4",
     "rimraf": "^5.0.0",
-    "typechain": "npm:@owlprotocol/typechain@8.2.0",
+    "typechain": "8.3.0",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/packages/core/src/helpers/types.ts
+++ b/packages/core/src/helpers/types.ts
@@ -28,7 +28,7 @@ export interface CommonTask {
 interface BaseContract {
   address: string;
   provider: Provider;
-  signer: Signer;
+  signer?: Signer;
 }
 
 export interface CommonNetwork extends BaseContract {

--- a/packages/core/src/versions/CoinMachine.ts
+++ b/packages/core/src/versions/CoinMachine.ts
@@ -3,7 +3,7 @@ import type { ColonyVersion } from './IColony.js';
 import { createContractVersionArray } from './utils.js';
 
 // This is the latest CoinMachine version + 1. It's for generating types and compatibility maps
-const COIN_MACHINE_VERSION_NEXT = 8;
+const COIN_MACHINE_VERSION_NEXT = 9;
 
 /** @internal */
 const COIN_MACHINE_VERSIONS = createContractVersionArray(
@@ -24,6 +24,7 @@ export const coinMachineIncompatibilityMap: Record<
   5: [],
   6: [],
   7: [],
+  8: [],
 };
 
 /** @internal */

--- a/packages/core/src/versions/EvaluatedExpenditure.ts
+++ b/packages/core/src/versions/EvaluatedExpenditure.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const EVALUATED_EXPENDITURE_VERSION_NEXT = 4;
+const EVALUATED_EXPENDITURE_VERSION_NEXT = 5;
 
 /** @internal */
 export const EVALUATED_EXPENDITURE_VERSIONS = createContractVersionArray(
@@ -20,6 +20,7 @@ export const evaluatedExpenditureIncompatibilityMap: Record<
   1: [1, 2, 3],
   2: [1, 2, 3],
   3: [1, 2, 3],
+  4: [1, 2, 3],
 };
 
 /** @internal */

--- a/packages/core/src/versions/FundingQueue.ts
+++ b/packages/core/src/versions/FundingQueue.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const FUNDING_QUEUE_VERSION_NEXT = 5;
+const FUNDING_QUEUE_VERSION_NEXT = 6;
 
 /** @internal */
 export const FUNDING_QUEUE_VERSIONS = createContractVersionArray(
@@ -20,6 +20,7 @@ export const fundingQueueIncompatibilityMap: Record<
   2: [],
   3: [],
   4: [],
+  5: [],
 };
 
 /** @internal */

--- a/packages/core/src/versions/IColony.ts
+++ b/packages/core/src/versions/IColony.ts
@@ -1,7 +1,7 @@
 import { createContractVersionArray } from './utils.js';
 
 // This is the latest IColony version + 1. It's for generating types and compatibility maps
-const COLONY_VERSION_NEXT = 13;
+const COLONY_VERSION_NEXT = 14;
 
 /** @internal */
 export const COLONY_VERSIONS = createContractVersionArray(COLONY_VERSION_NEXT);

--- a/packages/core/src/versions/OneTxPayment.ts
+++ b/packages/core/src/versions/OneTxPayment.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const ONE_TX_PAYMENT_VERSION_NEXT = 5;
+const ONE_TX_PAYMENT_VERSION_NEXT = 6;
 
 /** @internal */
 export const ONE_TX_PAYMENT_VERSIONS = createContractVersionArray(
@@ -20,6 +20,7 @@ export const oneTxPaymentIncompatibilityMap: Record<
   2: [],
   3: [],
   4: [],
+  5: [],
 };
 
 /** @internal */

--- a/packages/core/src/versions/ReputationBootstrapper.ts
+++ b/packages/core/src/versions/ReputationBootstrapper.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const REPUTATION_BOOTSTRAPPER_VERSION_NEXT = 2;
+const REPUTATION_BOOTSTRAPPER_VERSION_NEXT = 3;
 
 /** @internal */
 export const REPUTATION_BOOTSTRAPPER_VERSIONS = createContractVersionArray(
@@ -18,6 +18,7 @@ export const reputationBootstrapperIncompatibilityMap: Record<
   Array<ColonyVersion>
 > = {
   1: [],
+  2: [],
 };
 
 /** @internal */

--- a/packages/core/src/versions/StakedExpenditure.ts
+++ b/packages/core/src/versions/StakedExpenditure.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const STAKED_EXPENDITURE_VERSION_NEXT = 3;
+const STAKED_EXPENDITURE_VERSION_NEXT = 4;
 
 /** @internal */
 export const STAKED_EXPENDITURE_VERSIONS = createContractVersionArray(
@@ -19,6 +19,7 @@ export const stakedExpenditureIncompatibilityMap: Record<
 > = {
   1: [1, 2, 3],
   2: [1, 2, 3],
+  3: [1, 2, 3],
 };
 
 /** @internal */

--- a/packages/core/src/versions/TokenSupplier.ts
+++ b/packages/core/src/versions/TokenSupplier.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const TOKEN_SUPPLIER_VERSION_NEXT = 5;
+const TOKEN_SUPPLIER_VERSION_NEXT = 6;
 
 /** @internal */
 export const TOKEN_SUPPLIER_VERSIONS = createContractVersionArray(
@@ -20,6 +20,7 @@ export const tokenSupplierIncompatibilityMap: Record<
   2: [],
   3: [],
   4: [],
+  5: [],
 };
 
 /** @internal */

--- a/packages/core/src/versions/VotingReputation.ts
+++ b/packages/core/src/versions/VotingReputation.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const VOTING_REPUTATION_VERSION_NEXT = 9;
+const VOTING_REPUTATION_VERSION_NEXT = 10;
 
 /** @internal */
 export const VOTING_REPUTATION_VERSIONS = createContractVersionArray(
@@ -25,6 +25,7 @@ export const votingReputationIncompatibilityMap: Record<
   6: [1, 2, 3, 4, 5, 6],
   7: [1, 2, 3, 4, 5, 6],
   8: [1, 2, 3, 4, 5, 6],
+  9: [1, 2, 3, 4, 5, 6],
 };
 
 /** @internal */

--- a/packages/core/src/versions/Whitelist.ts
+++ b/packages/core/src/versions/Whitelist.ts
@@ -2,7 +2,7 @@ import type { ColonyVersion } from './IColony.js';
 
 import { createContractVersionArray } from './utils.js';
 
-const WHITELIST_VERSION_NEXT = 4;
+const WHITELIST_VERSION_NEXT = 5;
 
 /** @internal */
 export const WHITELIST_VERSIONS = createContractVersionArray(
@@ -19,6 +19,7 @@ export const whitelistIncompatibilityMap: Record<
   1: [],
   2: [],
   3: [],
+  4: [],
 };
 
 /** @internal */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -19,6 +19,7 @@
       "skipLibCheck": true,
       "strictNullChecks": true,
       "strict": true,
+      "target": "es2022",
       "traceResolution": false
     },
     "include": [

--- a/packages/sdk/docs/api/README.md
+++ b/packages/sdk/docs/api/README.md
@@ -103,7 +103,7 @@ ___
 
 ### Motion
 
-Ƭ **Motion**: `VotingReputationDataTypes7.MotionStructOutput` \| `VotingReputationDataTypes8.MotionStructOutput`
+Ƭ **Motion**: `VotingReputationDataTypes7.MotionStructOutput` \| `VotingReputationDataTypes8.MotionStructOutput` \| `VotingReputationDataTypes9.MotionStructOutput`
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 ### SupportedColonyContract
 
-Ƭ **SupportedColonyContract**: `ColonyContract10` \| `ColonyContract11` \| `ColonyContract12`
+Ƭ **SupportedColonyContract**: `ColonyContract11` \| `ColonyContract12` \| `ColonyContract13`
 
 ___
 
@@ -153,17 +153,17 @@ Latest versions of all extension contracts
 
 | Name | Type |
 | :------ | :------ |
-| `CoinMachine` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` |
-| `EvaluatedExpenditure` | ``1`` \| ``2`` \| ``3`` |
-| `FundingQueue` | ``1`` \| ``2`` \| ``3`` \| ``4`` |
-| `IVotingReputation` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` |
-| `OneTxPayment` | ``1`` \| ``2`` \| ``3`` \| ``4`` |
-| `ReputationBootstrapper` | ``1`` |
-| `StakedExpenditure` | ``1`` \| ``2`` |
+| `CoinMachine` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` |
+| `EvaluatedExpenditure` | ``1`` \| ``2`` \| ``3`` \| ``4`` |
+| `FundingQueue` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` |
+| `IVotingReputation` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` |
+| `OneTxPayment` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` |
+| `ReputationBootstrapper` | ``1`` \| ``2`` |
+| `StakedExpenditure` | ``1`` \| ``2`` \| ``3`` |
 | `StreamingPayments` | ``1`` \| ``2`` |
-| `TokenSupplier` | ``1`` \| ``2`` \| ``3`` \| ``4`` |
-| `VotingReputation` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` |
-| `Whitelist` | ``1`` \| ``2`` \| ``3`` |
+| `TokenSupplier` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` |
+| `VotingReputation` | ``1`` \| ``2`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` |
+| `Whitelist` | ``1`` \| ``2`` \| ``3`` \| ``4`` |
 
 ___
 
@@ -244,7 +244,7 @@ Returns `true` if an extension version is compatible with the given colony versi
 | :------ | :------ | :------ |
 | `extension` | [`Extension`](enums/Extension.md) | A valid `Extension` contract name |
 | `extensionVersion` | `ExtensionVersion` | The version of the extension to check against the colony |
-| `colonyVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12`` | The version of the colony to check for |
+| `colonyVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12`` \| ``13`` | The version of the colony to check for |
 
 #### Returns
 

--- a/packages/sdk/docs/api/classes/Colony.md
+++ b/packages/sdk/docs/api/classes/Colony.md
@@ -62,7 +62,7 @@ ___
 
 ### version
 
-• **version**: ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12``
+• **version**: ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12`` \| ``13``
 
 Contract version
 
@@ -72,7 +72,7 @@ ___
 
 ### supportedVersions
 
-▪ `Static` **supportedVersions**: ({ `factory`: typeof `IColony__factory` = ColonyFactory10; `version`: `number` = 10 } \| { `factory`: typeof `IColony__factory` = ColonyFactory11; `version`: `number` = 11 })[]
+▪ `Static` **supportedVersions**: { `factory`: typeof `IColony__factory` = ColonyFactory11; `version`: `number` = 11 }[]
 
 The currently supported Colony versions. If a Colony version is not included here it has to be upgraded.
 If this is not an option, Colony SDK might throw errors at certain points. Usage of ColonyJS is advised in these cases
@@ -1178,8 +1178,8 @@ ___
 
 ### getLatestSupportedVersion
 
-▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12``
+▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12`` \| ``13``
 
 #### Returns
 
-``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12``
+``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` \| ``10`` \| ``11`` \| ``12`` \| ``13``

--- a/packages/sdk/docs/api/classes/OneTxPayment.md
+++ b/packages/sdk/docs/api/classes/OneTxPayment.md
@@ -24,7 +24,7 @@ ___
 
 ### version
 
-• **version**: ``2`` \| ``1`` \| ``3`` \| ``4``
+• **version**: ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5``
 
 The extension contract's version
 
@@ -160,8 +160,8 @@ ___
 
 ### getLatestSupportedVersion
 
-▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4``
+▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5``
 
 #### Returns
 
-``2`` \| ``1`` \| ``3`` \| ``4``
+``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5``

--- a/packages/sdk/docs/api/classes/VotingReputation.md
+++ b/packages/sdk/docs/api/classes/VotingReputation.md
@@ -100,7 +100,7 @@ You can - at any point in the lifecycle inspect the current state of a Motion. U
 | :------ | :------ |
 | `colony` | [`Colony`](Colony.md) |
 | `votingReputationContract` | `SupportedVotingReputationContract` |
-| `deployedVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` |
+| `deployedVersion` | ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9`` |
 
 ## Properties
 
@@ -112,7 +112,7 @@ ___
 
 ### version
 
-• **version**: ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8``
+• **version**: ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9``
 
 ___
 
@@ -717,8 +717,8 @@ ___
 
 ### getLatestSupportedVersion
 
-▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8``
+▸ `Static` **getLatestSupportedVersion**(): ``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9``
 
 #### Returns
 
-``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8``
+``2`` \| ``1`` \| ``3`` \| ``4`` \| ``5`` \| ``6`` \| ``7`` \| ``8`` \| ``9``

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "examples:node": "ts-node examples/node/index.ts",
     "examples:browser": "esbuild --bundle examples/browser/src/*.ts --servedir=examples/browser/web",
-    "build-contracts": "contractor colony -t 6 -o ./src/contracts",
+    "build-contracts": "contractor colony -t 7 -o ./src/contracts",
     "build": "npm run clean && npm run compile-cjs && npm run compile-esm && npm run compile-types && npm run create-pkg-json",
     "build-docs": "typedoc",
     "build-examples": "esbuild --bundle examples/browser/src/*.ts --outdir=examples/browser/web --minify",

--- a/packages/sdk/src/ColonyNetwork/Colony.ts
+++ b/packages/sdk/src/ColonyNetwork/Colony.ts
@@ -48,10 +48,6 @@ import type { ColonyDataTypes as ColonyDataTypes12 } from '../contracts/IColony/
 import type { IBasicMetaTransaction } from '../contracts/IBasicMetaTransaction.js';
 
 import {
-  IColony as ColonyContract10,
-  IColony__factory as ColonyFactory10,
-} from '../contracts/IColony/10/index.js';
-import {
   IColony as ColonyContract11,
   IColony__factory as ColonyFactory11,
 } from '../contracts/IColony/11/index.js';
@@ -59,6 +55,10 @@ import {
   IColony as ColonyContract12,
   IColony__factory as ColonyFactory12,
 } from '../contracts/IColony/12/index.js';
+import {
+  IColony as ColonyContract13,
+  IColony__factory as ColonyFactory13,
+} from '../contracts/IColony/13/index.js';
 import {
   PermissionConfig,
   TxConfig,
@@ -71,9 +71,9 @@ import { ERC20Token, Token, getToken } from './tokens/index.js';
 import { VotingReputation } from './VotingReputation.js';
 
 export type SupportedColonyContract =
-  | ColonyContract10
   | ColonyContract11
-  | ColonyContract12;
+  | ColonyContract12
+  | ColonyContract13;
 export type SupportedColonyMethods = SupportedColonyContract['functions'];
 
 export type Domain =
@@ -105,9 +105,9 @@ export class Colony {
    * If this is not an option, Colony SDK might throw errors at certain points. Usage of ColonyJS is advised in these cases
    */
   static supportedVersions = [
-    { version: 10, factory: ColonyFactory10 },
     { version: 11, factory: ColonyFactory11 },
     { version: 12, factory: ColonyFactory12 },
+    { version: 13, factory: ColonyFactory13 },
   ];
 
   /**

--- a/packages/sdk/src/ColonyNetwork/OneTxPayment.ts
+++ b/packages/sdk/src/ColonyNetwork/OneTxPayment.ts
@@ -24,13 +24,18 @@ import {
   OneTxPayment as OneTxPaymentContract4,
   OneTxPayment__factory as OneTxPaymentFactory4,
 } from '../contracts/OneTxPayment/4/index.js';
+import {
+  OneTxPayment as OneTxPaymentContract5,
+  OneTxPayment__factory as OneTxPaymentFactory5,
+} from '../contracts/OneTxPayment/5/index.js';
 import { Colony } from './Colony.js';
 
 const { AddressZero } = constants;
 
 export type SupportedOneTxPaymentContract =
   | OneTxPaymentContract3
-  | OneTxPaymentContract4;
+  | OneTxPaymentContract4
+  | OneTxPaymentContract5;
 
 /**
  * ## `OneTxPayment` (One Transaction Payment)
@@ -52,6 +57,7 @@ export class OneTxPayment {
   static supportedVersions = [
     { version: 3, factory: OneTxPaymentFactory3 },
     { version: 4, factory: OneTxPaymentFactory4 },
+    { version: 5, factory: OneTxPaymentFactory5 },
   ];
 
   static extensionType: Extension.OneTxPayment = Extension.OneTxPayment;

--- a/packages/sdk/src/ColonyNetwork/VotingReputation.ts
+++ b/packages/sdk/src/ColonyNetwork/VotingReputation.ts
@@ -33,6 +33,7 @@ import { DecisionData, MetadataType } from '@colony/event-metadata';
 
 import type { VotingReputationDataTypes as VotingReputationDataTypes7 } from '../contracts/IVotingReputation/7/IVotingReputation.js';
 import type { VotingReputationDataTypes as VotingReputationDataTypes8 } from '../contracts/IVotingReputation/8/IVotingReputation.js';
+import type { VotingReputationDataTypes as VotingReputationDataTypes9 } from '../contracts/IVotingReputation/9/IVotingReputation.js';
 
 import {
   IVotingReputation as VotingReputationContract7,
@@ -42,6 +43,10 @@ import {
   IVotingReputation as VotingReputationContract8,
   IVotingReputation__factory as VotingReputationFactory8,
 } from '../contracts/IVotingReputation/8/index.js';
+import {
+  IVotingReputation as VotingReputationContract9,
+  IVotingReputation__factory as VotingReputationFactory9,
+} from '../contracts/IVotingReputation/9/index.js';
 
 import { extractEvent, extractCustomEvent } from '../utils.js';
 import { Colony } from './Colony.js';
@@ -50,11 +55,13 @@ const { AddressZero } = constants;
 
 export type SupportedVotingReputationContract =
   | VotingReputationContract7
-  | VotingReputationContract8;
+  | VotingReputationContract8
+  | VotingReputationContract9;
 
 export type Motion =
   | VotingReputationDataTypes7.MotionStructOutput
-  | VotingReputationDataTypes8.MotionStructOutput;
+  | VotingReputationDataTypes8.MotionStructOutput
+  | VotingReputationDataTypes9.MotionStructOutput;
 
 export enum Vote {
   Nay,
@@ -161,6 +168,7 @@ export class VotingReputation {
   static supportedVersions = [
     { version: 7, factory: VotingReputationFactory7 },
     { version: 8, factory: VotingReputationFactory8 },
+    { version: 9, factory: VotingReputationFactory9 },
   ];
 
   static extensionType: Extension.VotingReputation = Extension.VotingReputation;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -109,14 +105,14 @@ importers:
   packages/contractor:
     dependencies:
       '@colony/abis':
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^1.0.1
+        version: 1.0.1
       '@typechain/ethers-v5':
-        specifier: ^11.0.0
-        version: 11.0.0(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(@owlprotocol/typechain@8.2.0)(typescript@5.0.4)
+        specifier: ^11.1.0
+        version: 11.1.0(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(typechain@8.3.0)(typescript@5.0.4)
       '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.0(@owlprotocol/typechain@8.2.0)(typescript@5.0.4)
+        specifier: ^0.4.2
+        version: 0.4.2(typechain@8.3.0)(typescript@5.0.4)
       '@types/mkdirp':
         specifier: ^1.0.2
         version: 1.0.2
@@ -130,8 +126,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       typechain:
-        specifier: npm:@owlprotocol/typechain@8.2.0
-        version: /@owlprotocol/typechain@8.2.0(typescript@5.0.4)
+        specifier: 8.3.0
+        version: 8.3.0(typescript@5.0.4)
       yargs:
         specifier: ^17.7.1
         version: 17.7.1
@@ -836,8 +832,8 @@ packages:
       prettier: 2.8.8
     dev: false
 
-  /@colony/abis@0.2.2:
-    resolution: {integrity: sha512-p9zvZ6WYgliSNvpT7BE7X9p/uUidXhwVZ5+Ze0K6l2T2V0pwhxBpMrvJBcZtbw8CYkTGF5Rd/l/rkt5hvXOdKg==}
+  /@colony/abis@1.0.1:
+    resolution: {integrity: sha512-fbEy+PLJu2LXEXAECgj/rBGFJSV0TruI1K7b6kKpTYpZPGx7BlYLWHuYy4MiTf4u8S5sTzsQnIk5y7BfCLnMqA==}
     engines: {node: ^16, npm: ^8}
     dev: false
 
@@ -1576,29 +1572,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@owlprotocol/typechain@8.2.0(typescript@5.0.4):
-    resolution: {integrity: sha512-aPnqqAJ7lkyvr7HgEe650kZ5GY4GFqrf7AxIFqwmb/tLaiUzuXNjdM/HpkxSTEbnin50OkFiYy6wd9gDWjtNUA==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=4.3.0'
-    dependencies:
-      '@types/prettier': 2.7.2
-      debug: 4.3.4
-      fs-extra: 7.0.1
-      glob: 7.1.7
-      js-sha3: 0.8.0
-      lodash: 4.17.21
-      mkdirp: 1.0.4
-      prettier: 2.8.8
-      ts-command-line-args: 2.5.0(typescript@5.0.4)
-      ts-essentials: 7.0.3(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - jasmine
-      - jest
-      - supports-color
-    dev: false
-
   /@picocss/pico@1.5.10:
     resolution: {integrity: sha512-+LafMsrwPxXQMk6sI///TmSInCwwZmq+K7SikyL3N/4GhhwzyPC+TQLUEqmrLyjluR+uIpFFcqjty30Rtr6GxQ==}
     dev: true
@@ -1640,33 +1613,33 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
-  /@typechain/ethers-v5@11.0.0(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(@owlprotocol/typechain@8.2.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-JDAvOjtzGuEQukgArIEseHznS2+v+vG3TpfODjNj4tu1kgmVu66G9gk7THOO04HJ5q+OJSLx9b46lc3GRGPIVA==}
+  /@typechain/ethers-v5@11.1.0(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(typechain@8.3.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-7P+fLol3faUi/WPFwUo9tfo+IHSsvMBvSM/ECNU9mFHcF8eFI84ygauCdwPgP41k8bhsPb29XhwZiYDTUDXU8Q==}
     peerDependencies:
       '@ethersproject/abi': ^5.0.0
       '@ethersproject/providers': ^5.0.0
       ethers: ^5.1.3
-      typechain: ^8.2.0
+      typechain: ^8.3.0
       typescript: '>=4.3.0'
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/providers': 5.7.2
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.0.4)
-      typechain: /@owlprotocol/typechain@8.2.0(typescript@5.0.4)
+      typechain: 8.3.0(typescript@5.0.4)
       typescript: 5.0.4
     dev: false
 
-  /@typechain/ethers-v6@0.4.0(@owlprotocol/typechain@8.2.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-vD3Agzz63Gf2XlU3ed2/y+8dLWQj+wf+4Eq+0JXsyOio/plyV5F6r0yYe+s3XdGI858U3Sr263pl8mliDrUqbw==}
+  /@typechain/ethers-v6@0.4.2(typechain@8.3.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-LPC4BBknGkWGR1TLM0d19zZ9/iXIyp2tf6+TDYMYCSbxoaP0F3jNvKVMboU1gDfr2MHaPB+fE/7ExLQ5t9RDwg==}
     peerDependencies:
       ethers: 6.x
-      typechain: ^8.2.0
+      typechain: ^8.3.0
       typescript: '>=4.7.0'
     dependencies:
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.0.4)
-      typechain: /@owlprotocol/typechain@8.2.0(typescript@5.0.4)
+      typechain: 8.3.0(typescript@5.0.4)
       typescript: 5.0.4
     dev: false
 
@@ -5917,6 +5890,29 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /typechain@8.3.0(typescript@5.0.4):
+    resolution: {integrity: sha512-AxtAYyOA7f2p28/JkcqrF+gnzam94VNTIbXcaUKodkrKzMX6P/XqBaP6d/OPuBZOi0WgOOmkg1zOSojX8uGkOg==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=4.3.0'
+    dependencies:
+      '@types/prettier': 2.7.2
+      debug: 4.3.4
+      fs-extra: 7.0.1
+      glob: 7.1.7
+      js-sha3: 0.8.0
+      lodash: 4.17.21
+      mkdirp: 1.0.4
+      prettier: 2.8.8
+      ts-command-line-args: 2.5.0(typescript@5.0.4)
+      ts-essentials: 7.0.3(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - jasmine
+      - jest
+      - supports-color
+    dev: false
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
@@ -6261,3 +6257,7 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Add support for `glwss4` contracts in Colony SDK. No API changes were necessary.
Contractor was bumped to v1.0.1 of the `@colony/abis` package
In `core`, a guard was added to prevent trying to get permission proofs without an address.
