### PR TITLE
Add git hash to snapshot release name

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -19,18 +19,22 @@ jobs:
         node-version: [20.11.0]
     steps:
       - uses: actions/checkout@v4
+
       - uses: pnpm/action-setup@v4
         with:
           version: 8.15.5
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Set relevant environment variables
         run: |
           if [[ ${{ github.event.inputs.includeNext }} == 'true' ]]; then
             echo "COLONY_CONTRACTOR_INCLUDE_NEXT=true" >> $GITHUB_ENV
           fi
+
       - name: Create .npmrc (to be logged in for publishing)
         run: |
           cat << EOF > "$HOME/.npmrc"
@@ -38,16 +42,25 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - run: pnpm run bootstrap
+
       - run: pnpm run lint
+
       - run: pnpm run build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
+
       - run: pnpm run test
         env:
           CI: true
           NODE_OPTIONS: --max-old-space-size=4096
+
+      - name: Generate git hash of current HEAD
+        run: echo "VERSION_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Version snapshot
-        run: npx changeset version --snapshot snapshot && pnpm install --lockfile-only
+        run: npx changeset version --snapshot snapshot-{{ env.VERSION_HASH }} && pnpm install --lockfile-only
+
       - name: Publish snapshot to npm
         run: npx changeset publish --snapshot --tag snapshot --no-git-tag


### PR DESCRIPTION
## Description

This PR adds the hash of the current git HEAD to the npm release name when creating a snapshot.

E.g. `0.0.0-snapshot-d84f63c-20240626091247`.