### PR TITLE
Fix: Empty extension incompatibility maps should allow any colony version

### DIFF
--- a/packages/core/src/versions/helpers.ts
+++ b/packages/core/src/versions/helpers.ts
@@ -142,6 +142,10 @@ export const getExtensionLowestCompatibleColonyVersion = (
     );
   }
 
+  if (!map.length) {
+    return COLONY_VERSIONS[0];
+  }
+
   const colonyVersion = COLONY_VERSIONS.find(
     (v) => v === map[map.length - 1] + 1,
   );


### PR DESCRIPTION
## Description

- When an extension incompatibility map is empty it means that any version of colony is compatible. This means that the `getExtensionLowestCompatibleColonyVersion` function should return the oldest possible colony version in this case.

**Changes** 🏗

* Fix the `getExtensionLowestCompatibleColonyVersion` function to handle empty incompatibility maps.
