### PR TITLE
Fix ts-node examples and introduce improved typescript eslint rules

### DIFF
--- a/.changeset/little-singers-try.md
+++ b/.changeset/little-singers-try.md
@@ -1,0 +1,9 @@
+---
+"@colony/colony-js": patch
+"@colony/events": patch
+"@colony/tokens": patch
+"@colony/core": patch
+"@colony/sdk": patch
+---
+
+Introduce `tsx` instead of `ts-node` for esm compatibility reasons. This required some changes to how we import and export types from .ts files, so a lint rule was added for this.

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
     "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "sourceType": "module"
+    },
     "extends": [
         "plugin:@typescript-eslint/recommended",
         "@colony/eslint-config-colony"
@@ -22,6 +25,18 @@
         "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-shadow": [
             "error"
+        ],
+        "@typescript-eslint/consistent-type-imports": [
+            "error",
+            {
+                "fixStyle": "inline-type-imports"
+            }
+        ],
+        "@typescript-eslint/consistent-type-exports": [
+            "error",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "import/prefer-default-export": "off",
         "import/no-unresolved": "off",

--- a/packages/colony-js/.eslintrc
+++ b/packages/colony-js/.eslintrc
@@ -1,4 +1,10 @@
 {
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    },
+    "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+    },
     "overrides": [
         {
             "files": [

--- a/packages/colony-js/src/clients/ColonyNetworkClient.ts
+++ b/packages/colony-js/src/clients/ColonyNetworkClient.ts
@@ -1,4 +1,8 @@
-import { ContractTransaction, BigNumber, Overrides } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type Overrides,
+} from 'ethers';
 import {
   type SignerOrProvider,
   ColonyNetworkAddress,
@@ -7,16 +11,16 @@ import {
 } from '@colony/core';
 import {
   getTokenLockingClient,
-  TokenLockingClient,
+  type TokenLockingClient,
   ColonyTokenFactory,
 } from '@colony/tokens';
 
 import {
-  IColonyNetwork,
+  type IColonyNetwork,
   IColonyNetwork__factory as IColonyNetworkFactory,
 } from '../contracts/index.js';
 import { ClientType } from '../constants.js';
-import { AnyColonyClient } from '../clients/Core/exports.js';
+import { type AnyColonyClient } from '../clients/Core/exports.js';
 import { getColonyClient } from './Core/exports.js';
 
 type NetworkEstimate = IColonyNetwork['estimateGas'];

--- a/packages/colony-js/src/clients/Core/ColonyClientV10.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV10.ts
@@ -1,8 +1,8 @@
 import type { SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/10/factories/IColony__factory.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
-import { UnknownIColonyClient } from './augments/commonAugments.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type UnknownIColonyClient } from './augments/commonAugments.js';
 import { addAugments } from './augments/augmentsV7.js';
 import { addAugmentsB as addAddDomainAugments } from './augments/AddDomain.js';
 import { addAugmentsB as addMoveFundsBetweenPotsAugments } from './augments/MoveFundsBetweenPots.js';

--- a/packages/colony-js/src/clients/Core/ColonyClientV11.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV11.ts
@@ -1,8 +1,8 @@
 import type { SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/11/factories/IColony__factory.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
-import { UnknownIColonyClient } from './augments/commonAugments.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type UnknownIColonyClient } from './augments/commonAugments.js';
 import { addAugments } from './augments/augmentsV7.js';
 import { addAugmentsB as addAddDomainAugments } from './augments/AddDomain.js';
 import { addAugmentsB as addMoveFundsBetweenPotsAugments } from './augments/MoveFundsBetweenPots.js';

--- a/packages/colony-js/src/clients/Core/ColonyClientV12.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV12.ts
@@ -1,29 +1,29 @@
 import type { SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/12/factories/IColony__factory.js';
-import { IColony } from '../../contracts/IColony/12/IColony.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type IColony } from '../../contracts/IColony/12/IColony.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import {
-  AugmentedIColony,
-  AugmentedEstimate,
+  type AugmentedIColony,
+  type AugmentedEstimate,
 } from './augments/commonAugments.js';
-import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
-import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
-import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
-import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import { type ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { type ColonyAugmentsV6 } from './augments/augmentsV6.js';
 import {
   addAugments,
-  ColonyAugmentsV7,
-  AugmentedEstimateV7,
+  type ColonyAugmentsV7,
+  type AugmentedEstimateV7,
 } from './augments/augmentsV7.js';
 import {
-  AddDomainAugmentsB,
-  AddDomainEstimateGasB,
+  type AddDomainAugmentsB,
+  type AddDomainEstimateGasB,
   addAugmentsB as addAddDomainAugments,
 } from './augments/AddDomain.js';
 import {
-  MoveFundsBetweenPotsAugmentsB,
-  MoveFundsBetweenPotsEstimateGasB,
+  type MoveFundsBetweenPotsAugmentsB,
+  type MoveFundsBetweenPotsEstimateGasB,
   addAugmentsB as addMoveFundsBetweenPotsAugments,
 } from './augments/MoveFundsBetweenPots.js';
 

--- a/packages/colony-js/src/clients/Core/ColonyClientV13.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV13.ts
@@ -1,29 +1,29 @@
-import { SignerOrProvider } from '@colony/core';
+import { type SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/13/factories/IColony__factory.js';
-import { IColony } from '../../contracts/IColony/13/IColony.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type IColony } from '../../contracts/IColony/13/IColony.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import {
-  AugmentedIColony,
-  AugmentedEstimate,
+  type AugmentedIColony,
+  type AugmentedEstimate,
 } from './augments/commonAugments.js';
-import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
-import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
-import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
-import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import { type ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { type ColonyAugmentsV6 } from './augments/augmentsV6.js';
 import {
   addAugments,
-  ColonyAugmentsV7,
-  AugmentedEstimateV7,
+  type ColonyAugmentsV7,
+  type AugmentedEstimateV7,
 } from './augments/augmentsV7.js';
 import {
-  AddDomainAugmentsB,
-  AddDomainEstimateGasB,
+  type AddDomainAugmentsB,
+  type AddDomainEstimateGasB,
   addAugmentsB as addAddDomainAugments,
 } from './augments/AddDomain.js';
 import {
-  MoveFundsBetweenPotsAugmentsB,
-  MoveFundsBetweenPotsEstimateGasB,
+  type MoveFundsBetweenPotsAugmentsB,
+  type MoveFundsBetweenPotsEstimateGasB,
   addAugmentsB as addMoveFundsBetweenPotsAugments,
 } from './augments/MoveFundsBetweenPots.js';
 

--- a/packages/colony-js/src/clients/Core/ColonyClientV14.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV14.ts
@@ -1,29 +1,29 @@
-import { SignerOrProvider } from '@colony/core';
+import { type SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/14/factories/IColony__factory.js';
-import { IColony } from '../../contracts/IColony/14/IColony.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type IColony } from '../../contracts/IColony/14/IColony.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import {
-  AugmentedIColony,
-  AugmentedEstimate,
+  type AugmentedIColony,
+  type AugmentedEstimate,
 } from './augments/commonAugments.js';
-import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
-import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
-import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
-import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import { type ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { type ColonyAugmentsV6 } from './augments/augmentsV6.js';
 import {
   addAugments,
-  ColonyAugmentsV7,
-  AugmentedEstimateV7,
+  type ColonyAugmentsV7,
+  type AugmentedEstimateV7,
 } from './augments/augmentsV7.js';
 import {
-  AddDomainAugmentsB,
-  AddDomainEstimateGasB,
+  type AddDomainAugmentsB,
+  type AddDomainEstimateGasB,
   addAugmentsB as addAddDomainAugments,
 } from './augments/AddDomain.js';
 import {
-  MoveFundsBetweenPotsAugmentsB,
-  MoveFundsBetweenPotsEstimateGasB,
+  type MoveFundsBetweenPotsAugmentsB,
+  type MoveFundsBetweenPotsEstimateGasB,
   addAugmentsB as addMoveFundsBetweenPotsAugments,
 } from './augments/MoveFundsBetweenPots.js';
 

--- a/packages/colony-js/src/clients/Core/ColonyClientV15.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV15.ts
@@ -1,29 +1,29 @@
-import { SignerOrProvider } from '@colony/core';
+import { type SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/15/factories/IColony__factory.js';
-import { IColony } from '../../contracts/IColony/15/IColony.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type IColony } from '../../contracts/IColony/15/IColony.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import {
-  AugmentedIColony,
-  AugmentedEstimate,
+  type AugmentedIColony,
+  type AugmentedEstimate,
 } from './augments/commonAugments.js';
-import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
-import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
-import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
-import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import { type ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { type ColonyAugmentsV6 } from './augments/augmentsV6.js';
 import {
   addAugments,
-  ColonyAugmentsV7,
-  AugmentedEstimateV7,
+  type ColonyAugmentsV7,
+  type AugmentedEstimateV7,
 } from './augments/augmentsV7.js';
 import {
-  AddDomainAugmentsB,
-  AddDomainEstimateGasB,
+  type AddDomainAugmentsB,
+  type AddDomainEstimateGasB,
   addAugmentsB as addAddDomainAugments,
 } from './augments/AddDomain.js';
 import {
-  MoveFundsBetweenPotsAugmentsB,
-  MoveFundsBetweenPotsEstimateGasB,
+  type MoveFundsBetweenPotsAugmentsB,
+  type MoveFundsBetweenPotsEstimateGasB,
   addAugmentsB as addMoveFundsBetweenPotsAugments,
 } from './augments/MoveFundsBetweenPots.js';
 

--- a/packages/colony-js/src/clients/Core/ColonyClientV16.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV16.ts
@@ -1,29 +1,29 @@
-import { SignerOrProvider } from '@colony/core';
+import { type SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/16/factories/IColony__factory.js';
-import { IColony } from '../../contracts/IColony/16/IColony.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type IColony } from '../../contracts/IColony/16/IColony.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import {
-  AugmentedIColony,
-  AugmentedEstimate,
+  type AugmentedIColony,
+  type AugmentedEstimate,
 } from './augments/commonAugments.js';
-import { ColonyAugmentsV3 } from './augments/augmentsV3.js';
-import { ColonyAugmentsV4 } from './augments/augmentsV4.js';
-import { ColonyAugmentsV5 } from './augments/augmentsV5.js';
-import { ColonyAugmentsV6 } from './augments/augmentsV6.js';
+import { type ColonyAugmentsV3 } from './augments/augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augments/augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augments/augmentsV5.js';
+import { type ColonyAugmentsV6 } from './augments/augmentsV6.js';
 import {
   addAugments,
-  ColonyAugmentsV7,
-  AugmentedEstimateV7,
+  type ColonyAugmentsV7,
+  type AugmentedEstimateV7,
 } from './augments/augmentsV7.js';
 import {
-  AddDomainAugmentsB,
-  AddDomainEstimateGasB,
+  type AddDomainAugmentsB,
+  type AddDomainEstimateGasB,
   addAugmentsB as addAddDomainAugments,
 } from './augments/AddDomain.js';
 import {
-  MoveFundsBetweenPotsAugmentsB,
-  MoveFundsBetweenPotsEstimateGasB,
+  type MoveFundsBetweenPotsAugmentsB,
+  type MoveFundsBetweenPotsEstimateGasB,
   addAugmentsB as addMoveFundsBetweenPotsAugments,
 } from './augments/MoveFundsBetweenPots.js';
 

--- a/packages/colony-js/src/clients/Core/ColonyClientV8.ts
+++ b/packages/colony-js/src/clients/Core/ColonyClientV8.ts
@@ -1,8 +1,8 @@
 import type { SignerOrProvider } from '@colony/core';
 
 import { IColony__factory as IColonyFactory } from '../../contracts/IColony/8/factories/IColony__factory.js';
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
-import { UnknownIColonyClient } from './augments/commonAugments.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type UnknownIColonyClient } from './augments/commonAugments.js';
 import { addAugments } from './augments/augmentsV5.js';
 import { addAugmentsB as addAddDomainAugments } from './augments/AddDomain.js';
 import { addAugmentsB as addMoveFundsBetweenPotsAugments } from './augments/MoveFundsBetweenPots.js';

--- a/packages/colony-js/src/clients/Core/ColonyVersionClient.ts
+++ b/packages/colony-js/src/clients/Core/ColonyVersionClient.ts
@@ -1,5 +1,5 @@
 // A minimal version of the ColonyClient contract that only supports the `version` method
-import { BigNumber, Contract } from 'ethers';
+import { type BigNumber, Contract } from 'ethers';
 import type { SignerOrProvider } from '@colony/core';
 
 interface ColonyVersionClient extends Contract {

--- a/packages/colony-js/src/clients/Core/augments/AddDomain.ts
+++ b/packages/colony-js/src/clients/Core/augments/AddDomain.ts
@@ -1,4 +1,8 @@
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import {
+  type BigNumber,
+  type BigNumberish,
+  type ContractTransaction,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
@@ -6,12 +10,12 @@ import {
 } from '@colony/core';
 
 import {
-  IColonyV4,
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV4,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
 import type {
   AugmentedIColony,

--- a/packages/colony-js/src/clients/Core/augments/MoveFundsBetweenPots.ts
+++ b/packages/colony-js/src/clients/Core/augments/MoveFundsBetweenPots.ts
@@ -1,4 +1,8 @@
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import {
+  type BigNumber,
+  type BigNumberish,
+  type ContractTransaction,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
@@ -9,14 +13,17 @@ import {
 } from '@colony/core';
 
 import {
-  IColonyV6,
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV6,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
-import { AugmentedIColony, UnknownIColonyClient } from './commonAugments.js';
+import {
+  type AugmentedIColony,
+  type UnknownIColonyClient,
+} from './commonAugments.js';
 
 // Colonies that support the earlier (not-overloaded) method
 type ValidColonyA = IColonyV6;

--- a/packages/colony-js/src/clients/Core/augments/SetExpenditureClaimDelay.ts
+++ b/packages/colony-js/src/clients/Core/augments/SetExpenditureClaimDelay.ts
@@ -1,4 +1,8 @@
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import {
+  type BigNumber,
+  type BigNumberish,
+  type ContractTransaction,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,

--- a/packages/colony-js/src/clients/Core/augments/SetExpenditurePayoutModifier.ts
+++ b/packages/colony-js/src/clients/Core/augments/SetExpenditurePayoutModifier.ts
@@ -1,4 +1,8 @@
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import {
+  type BigNumber,
+  type BigNumberish,
+  type ContractTransaction,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,

--- a/packages/colony-js/src/clients/Core/augments/SetPaymentDomain.ts
+++ b/packages/colony-js/src/clients/Core/augments/SetPaymentDomain.ts
@@ -1,4 +1,8 @@
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import {
+  type BigNumber,
+  type BigNumberish,
+  type ContractTransaction,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,

--- a/packages/colony-js/src/clients/Core/augments/augmentsV3.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV3.ts
@@ -1,21 +1,25 @@
-import { ContractTransaction, BigNumber, BigNumberish } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
   getPermissionProofs,
 } from '@colony/core';
 
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
 import {
   addAugments as addCommonAugments,
-  AugmentedIColony,
+  type AugmentedIColony,
 } from './commonAugments.js';
 
 type ValidColony =

--- a/packages/colony-js/src/clients/Core/augments/augmentsV4.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV4.ts
@@ -1,23 +1,27 @@
-import { ContractTransaction, BigNumber, BigNumberish } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
   getPermissionProofs,
 } from '@colony/core';
 
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
-import { AugmentedIColony } from './commonAugments.js';
+import { type AugmentedIColony } from './commonAugments.js';
 import {
   addAugments as addAugmentsV3,
-  ColonyAugmentsV3,
-  AugmentedEstimateV3,
+  type ColonyAugmentsV3,
+  type AugmentedEstimateV3,
 } from './augmentsV3.js';
 
 type ValidColony =

--- a/packages/colony-js/src/clients/Core/augments/augmentsV5.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV5.ts
@@ -1,14 +1,14 @@
 import {
-  ContractTransaction,
+  type ContractTransaction,
   BigNumber,
-  BigNumberish,
-  BytesLike,
+  type BigNumberish,
+  type BytesLike,
 } from 'ethers';
 import {
   type ExtensionVersion,
   type TxOverrides,
   ColonyRole,
-  Extension,
+  type Extension,
   ExtensionVersions,
   Id,
   colonyRoles2Hex,
@@ -17,20 +17,20 @@ import {
   isExtensionCompatible,
 } from '@colony/core';
 
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
-import { AugmentedIColony } from './commonAugments.js';
-import { ColonyAugmentsV3 } from './augmentsV3.js';
+import { type AugmentedIColony } from './commonAugments.js';
+import { type ColonyAugmentsV3 } from './augmentsV3.js';
 import {
   addAugments as addAugmentsV4,
-  ColonyAugmentsV4,
-  AugmentedEstimateV4,
+  type ColonyAugmentsV4,
+  type AugmentedEstimateV4,
 } from './augmentsV4.js';
 
 type ValidColony =

--- a/packages/colony-js/src/clients/Core/augments/augmentsV6.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV6.ts
@@ -1,25 +1,29 @@
-import { ContractTransaction, BigNumber, BigNumberish } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
   getPermissionProofs,
 } from '@colony/core';
 
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
-import { AugmentedIColony } from './commonAugments.js';
-import { ColonyAugmentsV3 } from './augmentsV3.js';
-import { ColonyAugmentsV4 } from './augmentsV4.js';
+import { type AugmentedIColony } from './commonAugments.js';
+import { type ColonyAugmentsV3 } from './augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augmentsV4.js';
 import {
   addAugments as addAugmentsV5,
-  ColonyAugmentsV5,
-  AugmentedEstimateV5,
+  type ColonyAugmentsV5,
+  type AugmentedEstimateV5,
 } from './augmentsV5.js';
 
 type ValidColony =

--- a/packages/colony-js/src/clients/Core/augments/augmentsV7.ts
+++ b/packages/colony-js/src/clients/Core/augments/augmentsV7.ts
@@ -1,26 +1,30 @@
-import { ContractTransaction, BigNumber, BigNumberish } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
   getPermissionProofs,
 } from '@colony/core';
 
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../contracts.js';
-import { AugmentedIColony } from './commonAugments.js';
-import { ColonyAugmentsV3 } from './augmentsV3.js';
-import { ColonyAugmentsV4 } from './augmentsV4.js';
-import { ColonyAugmentsV5 } from './augmentsV5.js';
+import { type AugmentedIColony } from './commonAugments.js';
+import { type ColonyAugmentsV3 } from './augmentsV3.js';
+import { type ColonyAugmentsV4 } from './augmentsV4.js';
+import { type ColonyAugmentsV5 } from './augmentsV5.js';
 import {
   addAugments as addAugmentsV6,
-  ColonyAugmentsV6,
-  AugmentedEstimateV6,
+  type ColonyAugmentsV6,
+  type AugmentedEstimateV6,
 } from './augmentsV6.js';
 
 type ValidColony =

--- a/packages/colony-js/src/clients/Core/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Core/augments/commonAugments.ts
@@ -1,30 +1,30 @@
 import {
-  ContractTransaction,
-  BytesLike,
-  BigNumber,
-  BigNumberish,
+  type ContractTransaction,
+  type BytesLike,
+  type BigNumber,
+  type BigNumberish,
 } from 'ethers';
 import {
   type ColonyEvents,
   IColonyEvents__factory as ColonyEventsFactory,
 } from '@colony/events';
-import { TokenClient } from '@colony/tokens';
+import { type TokenClient } from '@colony/tokens';
 
 import {
   type ColonyVersion,
   type TxOverrides,
   ColonyRole,
-  Extension,
+  type Extension,
   getPermissionProofs,
   ReputationClient,
 } from '@colony/core';
 import { ClientType } from '../../../constants.js';
 import {
   getExtensionClient,
-  GetExtensionClientReturns,
+  type GetExtensionClientReturns,
 } from '../../Extensions/exports.js';
-import { ColonyNetworkClient } from '../../ColonyNetworkClient.js';
-import { AnyIColony } from '../contracts.js';
+import { type ColonyNetworkClient } from '../../ColonyNetworkClient.js';
+import { type AnyIColony } from '../contracts.js';
 
 export type AugmentedEstimate<T extends AnyIColony = AnyIColony> =
   T['estimateGas'] & {

--- a/packages/colony-js/src/clients/Core/exports.ts
+++ b/packages/colony-js/src/clients/Core/exports.ts
@@ -1,7 +1,7 @@
 import type { ColonyVersion } from '@colony/core';
 import { getTokenClient } from '@colony/tokens';
 
-import { ColonyNetworkClient } from '../ColonyNetworkClient.js';
+import { type ColonyNetworkClient } from '../ColonyNetworkClient.js';
 import getColonyVersionClient from './ColonyVersionClient.js';
 
 import getColonyClientV1 from './ColonyClientV1.js';
@@ -15,17 +15,17 @@ import getColonyClientV8 from './ColonyClientV8.js';
 import getColonyClientV9 from './ColonyClientV9.js';
 import getColonyClientV10 from './ColonyClientV10.js';
 import getColonyClientV11 from './ColonyClientV11.js';
-import getColonyClientV12, { ColonyClientV12 } from './ColonyClientV12.js';
-import getColonyClientV13, { ColonyClientV13 } from './ColonyClientV13.js';
-import getColonyClientV14, { ColonyClientV14 } from './ColonyClientV14.js';
-import getColonyClientV15, { ColonyClientV15 } from './ColonyClientV15.js';
-import getColonyClientV16, { ColonyClientV16 } from './ColonyClientV16.js';
+import getColonyClientV12, { type ColonyClientV12 } from './ColonyClientV12.js';
+import getColonyClientV13, { type ColonyClientV13 } from './ColonyClientV13.js';
+import getColonyClientV14, { type ColonyClientV14 } from './ColonyClientV14.js';
+import getColonyClientV15, { type ColonyClientV15 } from './ColonyClientV15.js';
+import getColonyClientV16, { type ColonyClientV16 } from './ColonyClientV16.js';
 
-export { ColonyClientV12 } from './ColonyClientV12.js';
-export { ColonyClientV13 } from './ColonyClientV13.js';
-export { ColonyClientV14 } from './ColonyClientV14.js';
-export { ColonyClientV15 } from './ColonyClientV15.js';
-export { ColonyClientV16 } from './ColonyClientV16.js';
+export type { ColonyClientV12 } from './ColonyClientV12.js';
+export type { ColonyClientV13 } from './ColonyClientV13.js';
+export type { ColonyClientV14 } from './ColonyClientV14.js';
+export type { ColonyClientV15 } from './ColonyClientV15.js';
+export type { ColonyClientV16 } from './ColonyClientV16.js';
 
 export type AnyColonyClient =
   | ColonyClientV12

--- a/packages/colony-js/src/clients/Extensions/ExtensionVersionClient.ts
+++ b/packages/colony-js/src/clients/Extensions/ExtensionVersionClient.ts
@@ -2,7 +2,7 @@
 
 import type { SignerOrProvider } from '@colony/core';
 
-import { Contract, BigNumber } from 'ethers';
+import { Contract, type BigNumber } from 'ethers';
 
 interface ExtensionVersionClient extends Contract {
   version(): Promise<BigNumber>;

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV1.ts
@@ -5,7 +5,7 @@ import { ClientType } from '../../../constants.js';
 import {
   type UnkonwnFundingQueueClient,
   addAugments,
-  ValidColony,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export default function getFundingQueueClient(

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV2.ts
@@ -4,8 +4,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  UnkonwnFundingQueueClient,
-  ValidColony,
+  type UnkonwnFundingQueueClient,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export default function getFundingQueueClient(

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV3.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV3

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV4.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV4

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV5.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV5

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV6.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV6.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV6

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV7.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV7.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV7

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV8.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/FundingQueueClientV8.ts
@@ -5,8 +5,8 @@ import { FundingQueue__factory as FundingQueueFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedFundingQueue,
-  ValidColony,
+  type AugmentedFundingQueue,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface FundingQueueClientV8

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/augments/commonAugments.ts
@@ -6,10 +6,10 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
 
-import { AnyFundingQueue } from '../contracts.js';
-import { AnyIColony } from '../../../Core/contracts.js';
+import { type AnyFundingQueue } from '../contracts.js';
+import { type AnyIColony } from '../../../Core/contracts.js';
 
 export type ValidColony = AnyIColony;
 

--- a/packages/colony-js/src/clients/Extensions/FundingQueue/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/FundingQueue/exports.ts
@@ -2,35 +2,35 @@ import type { FundingQueueVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import getFundingQueueClientV1 from './FundingQueueClientV1.js';
 import getFundingQueueClientV2 from './FundingQueueClientV2.js';
 import getFundingQueueClientV3, {
-  FundingQueueClientV3,
+  type FundingQueueClientV3,
 } from './FundingQueueClientV3.js';
 import getFundingQueueClientV4, {
-  FundingQueueClientV4,
+  type FundingQueueClientV4,
 } from './FundingQueueClientV4.js';
 import getFundingQueueClientV5, {
-  FundingQueueClientV5,
+  type FundingQueueClientV5,
 } from './FundingQueueClientV5.js';
 import getFundingQueueClientV6, {
-  FundingQueueClientV6,
+  type FundingQueueClientV6,
 } from './FundingQueueClientV6.js';
 import getFundingQueueClientV7, {
-  FundingQueueClientV7,
+  type FundingQueueClientV7,
 } from './FundingQueueClientV7.js';
 import getFundingQueueClientV8, {
-  FundingQueueClientV8,
+  type FundingQueueClientV8,
 } from './FundingQueueClientV8.js';
 
-export { FundingQueueClientV3 } from './FundingQueueClientV3.js';
-export { FundingQueueClientV4 } from './FundingQueueClientV4.js';
-export { FundingQueueClientV5 } from './FundingQueueClientV5.js';
-export { FundingQueueClientV6 } from './FundingQueueClientV6.js';
-export { FundingQueueClientV7 } from './FundingQueueClientV7.js';
-export { FundingQueueClientV8 } from './FundingQueueClientV8.js';
+export type { FundingQueueClientV3 } from './FundingQueueClientV3.js';
+export type { FundingQueueClientV4 } from './FundingQueueClientV4.js';
+export type { FundingQueueClientV5 } from './FundingQueueClientV5.js';
+export type { FundingQueueClientV6 } from './FundingQueueClientV6.js';
+export type { FundingQueueClientV7 } from './FundingQueueClientV7.js';
+export type { FundingQueueClientV8 } from './FundingQueueClientV8.js';
 
 export type AnyFundingQueueClient =
   | FundingQueueClientV3

--- a/packages/colony-js/src/clients/Extensions/MultisigPermissions/MultisigPermissionsClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/MultisigPermissions/MultisigPermissionsClientV1.ts
@@ -5,8 +5,8 @@ import { MultisigPermissions__factory as MultisigPermissionsFactory } from '../.
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedMultisigPermissions,
-  ValidColony,
+  type AugmentedMultisigPermissions,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface MultisigPermissionsClientV1

--- a/packages/colony-js/src/clients/Extensions/MultisigPermissions/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/MultisigPermissions/augments/commonAugments.ts
@@ -5,9 +5,13 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { IColonyV14, IColonyV15, IColonyV16 } from '../../../Core/contracts.js';
-import { AnyMultisigPermissions } from '../contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import {
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
+} from '../../../Core/contracts.js';
+import { type AnyMultisigPermissions } from '../contracts.js';
 
 export type ValidColony = IColonyV14 | IColonyV15 | IColonyV16;
 

--- a/packages/colony-js/src/clients/Extensions/MultisigPermissions/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/MultisigPermissions/exports.ts
@@ -2,14 +2,14 @@ import type { MultisigPermissionsVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
-import { ValidColony } from './augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type ValidColony } from './augments/commonAugments.js';
 
 import getMultisigPermissionsClientV1, {
-  MultisigPermissionsClientV1,
+  type MultisigPermissionsClientV1,
 } from './MultisigPermissionsClientV1.js';
 
-export { MultisigPermissionsClientV1 } from './MultisigPermissionsClientV1.js';
+export type { MultisigPermissionsClientV1 } from './MultisigPermissionsClientV1.js';
 
 export type AnyMultisigPermissionsClient = MultisigPermissionsClientV1;
 

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV1.ts
@@ -5,7 +5,7 @@ import { ClientType } from '../../../constants.js';
 import {
   type UnkonwnOneTxPaymentClient,
   addAugments,
-  ValidColony,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export default function getOneTxPaymentClient(

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV2.ts
@@ -4,8 +4,8 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  UnkonwnOneTxPaymentClient,
-  ValidColony,
+  type UnkonwnOneTxPaymentClient,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export default function getOneTxPaymentClient(

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV3.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV4.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV5.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV6.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV6.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV7.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV7.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV8.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/OneTxPaymentClientV8.ts
@@ -5,9 +5,9 @@ import { OneTxPayment__factory as OneTxPaymentFactory } from '../../../contracts
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedEstimate,
-  AugmentedOneTxPayment,
-  ValidColony,
+  type AugmentedEstimate,
+  type AugmentedOneTxPayment,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 type OneTxPaymentEstimate = AugmentedEstimate<OneTxPayment>;

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/augments/commonAugments.ts
@@ -5,16 +5,20 @@ import {
   getPermissionProofs,
 } from '@colony/core';
 
-import { ContractTransaction, BigNumberish, BigNumber } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumberish,
+  type BigNumber,
+} from 'ethers';
 import {
   type OneTxPaymentEvents,
   OneTxPaymentEvents__factory as OneTxPaymentEventsFactory,
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { AnyOneTxPayment } from '../contracts.js';
-import { AnyIColony } from '../../../Core/contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AnyOneTxPayment } from '../contracts.js';
+import { type AnyIColony } from '../../../Core/contracts.js';
 
 export type ValidColony = AnyIColony;
 

--- a/packages/colony-js/src/clients/Extensions/OneTxPayment/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/OneTxPayment/exports.ts
@@ -2,35 +2,35 @@ import type { OneTxPaymentVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import getOneTxPaymentClientV1 from './OneTxPaymentClientV1.js';
 import getOneTxPaymentClientV2 from './OneTxPaymentClientV2.js';
 import getOneTxPaymentClientV3, {
-  OneTxPaymentClientV3,
+  type OneTxPaymentClientV3,
 } from './OneTxPaymentClientV3.js';
 import getOneTxPaymentClientV4, {
-  OneTxPaymentClientV4,
+  type OneTxPaymentClientV4,
 } from './OneTxPaymentClientV4.js';
 import getOneTxPaymentClientV5, {
-  OneTxPaymentClientV5,
+  type OneTxPaymentClientV5,
 } from './OneTxPaymentClientV5.js';
 import getOneTxPaymentClientV6, {
-  OneTxPaymentClientV6,
+  type OneTxPaymentClientV6,
 } from './OneTxPaymentClientV6.js';
 import getOneTxPaymentClientV7, {
-  OneTxPaymentClientV7,
+  type OneTxPaymentClientV7,
 } from './OneTxPaymentClientV7.js';
 import getOneTxPaymentClientV8, {
-  OneTxPaymentClientV8,
+  type OneTxPaymentClientV8,
 } from './OneTxPaymentClientV8.js';
 
-export { OneTxPaymentClientV3 } from './OneTxPaymentClientV3.js';
-export { OneTxPaymentClientV4 } from './OneTxPaymentClientV4.js';
-export { OneTxPaymentClientV5 } from './OneTxPaymentClientV5.js';
-export { OneTxPaymentClientV6 } from './OneTxPaymentClientV6.js';
-export { OneTxPaymentClientV7 } from './OneTxPaymentClientV7.js';
-export { OneTxPaymentClientV8 } from './OneTxPaymentClientV8.js';
+export type { OneTxPaymentClientV3 } from './OneTxPaymentClientV3.js';
+export type { OneTxPaymentClientV4 } from './OneTxPaymentClientV4.js';
+export type { OneTxPaymentClientV5 } from './OneTxPaymentClientV5.js';
+export type { OneTxPaymentClientV6 } from './OneTxPaymentClientV6.js';
+export type { OneTxPaymentClientV7 } from './OneTxPaymentClientV7.js';
+export type { OneTxPaymentClientV8 } from './OneTxPaymentClientV8.js';
 
 export type AnyOneTxPaymentClient =
   | OneTxPaymentClientV3

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV1.ts
@@ -5,8 +5,8 @@ import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedReputationBootstrapper,
-  ValidColony,
+  type AugmentedReputationBootstrapper,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface ReputationBootstrapperClientV1

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV2.ts
@@ -5,8 +5,8 @@ import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedReputationBootstrapper,
-  ValidColony,
+  type AugmentedReputationBootstrapper,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface ReputationBootstrapperClientV2

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV3.ts
@@ -5,8 +5,8 @@ import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedReputationBootstrapper,
-  ValidColony,
+  type AugmentedReputationBootstrapper,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface ReputationBootstrapperClientV3

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV4.ts
@@ -5,8 +5,8 @@ import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedReputationBootstrapper,
-  ValidColony,
+  type AugmentedReputationBootstrapper,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface ReputationBootstrapperClientV4

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/ReputationBootstrapperClientV5.ts
@@ -5,8 +5,8 @@ import { ReputationBootstrapper__factory as ReputationBootstrapperFactory } from
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedReputationBootstrapper,
-  ValidColony,
+  type AugmentedReputationBootstrapper,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface ReputationBootstrapperClientV5

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/augments/commonAugments.ts
@@ -6,9 +6,9 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { AnyReputationBootstrapper } from '../contracts.js';
-import { AnyIColony } from '../../../Core/contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AnyReputationBootstrapper } from '../contracts.js';
+import { type AnyIColony } from '../../../Core/contracts.js';
 
 export type ValidColony = AnyIColony;
 

--- a/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/ReputationBootstrapper/exports.ts
@@ -2,29 +2,29 @@ import type { ReputationBootstrapperVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import getReputationBootstrapperClientV1, {
-  ReputationBootstrapperClientV1,
+  type ReputationBootstrapperClientV1,
 } from './ReputationBootstrapperClientV1.js';
 import getReputationBootstrapperClientV2, {
-  ReputationBootstrapperClientV2,
+  type ReputationBootstrapperClientV2,
 } from './ReputationBootstrapperClientV2.js';
 import getReputationBootstrapperClientV3, {
-  ReputationBootstrapperClientV3,
+  type ReputationBootstrapperClientV3,
 } from './ReputationBootstrapperClientV3.js';
 import getReputationBootstrapperClientV4, {
-  ReputationBootstrapperClientV4,
+  type ReputationBootstrapperClientV4,
 } from './ReputationBootstrapperClientV4.js';
 import getReputationBootstrapperClientV5, {
-  ReputationBootstrapperClientV5,
+  type ReputationBootstrapperClientV5,
 } from './ReputationBootstrapperClientV5.js';
 
-export { ReputationBootstrapperClientV1 } from './ReputationBootstrapperClientV1.js';
-export { ReputationBootstrapperClientV2 } from './ReputationBootstrapperClientV2.js';
-export { ReputationBootstrapperClientV3 } from './ReputationBootstrapperClientV3.js';
-export { ReputationBootstrapperClientV4 } from './ReputationBootstrapperClientV4.js';
-export { ReputationBootstrapperClientV5 } from './ReputationBootstrapperClientV5.js';
+export type { ReputationBootstrapperClientV1 } from './ReputationBootstrapperClientV1.js';
+export type { ReputationBootstrapperClientV2 } from './ReputationBootstrapperClientV2.js';
+export type { ReputationBootstrapperClientV3 } from './ReputationBootstrapperClientV3.js';
+export type { ReputationBootstrapperClientV4 } from './ReputationBootstrapperClientV4.js';
+export type { ReputationBootstrapperClientV5 } from './ReputationBootstrapperClientV5.js';
 
 export type AnyReputationBootstrapperClient =
   | ReputationBootstrapperClientV1

--- a/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV1.ts
@@ -5,8 +5,8 @@ import { StagedExpenditure__factory as StagedExpenditureFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStagedExpenditure,
-  ValidColony,
+  type AugmentedStagedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StagedExpenditureClientV1

--- a/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV2.ts
@@ -5,8 +5,8 @@ import { StagedExpenditure__factory as StagedExpenditureFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStagedExpenditure,
-  ValidColony,
+  type AugmentedStagedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StagedExpenditureClientV2

--- a/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/StagedExpenditure/StagedExpenditureClientV3.ts
@@ -5,8 +5,8 @@ import { StagedExpenditure__factory as StagedExpenditureFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStagedExpenditure,
-  ValidColony,
+  type AugmentedStagedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StagedExpenditureClientV3

--- a/packages/colony-js/src/clients/Extensions/StagedExpenditure/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/StagedExpenditure/augments/commonAugments.ts
@@ -5,9 +5,13 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { IColonyV14, IColonyV15, IColonyV16 } from '../../../Core/contracts.js';
-import { AnyStagedExpenditure } from '../contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import {
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
+} from '../../../Core/contracts.js';
+import { type AnyStagedExpenditure } from '../contracts.js';
 
 export type ValidColony = IColonyV14 | IColonyV15 | IColonyV16;
 

--- a/packages/colony-js/src/clients/Extensions/StagedExpenditure/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/StagedExpenditure/exports.ts
@@ -2,22 +2,22 @@ import type { StagedExpenditureVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
-import { ValidColony } from './augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type ValidColony } from './augments/commonAugments.js';
 
 import getStagedExpenditureClientV1, {
-  StagedExpenditureClientV1,
+  type StagedExpenditureClientV1,
 } from './StagedExpenditureClientV1.js';
 import getStagedExpenditureClientV2, {
-  StagedExpenditureClientV2,
+  type StagedExpenditureClientV2,
 } from './StagedExpenditureClientV2.js';
 import getStagedExpenditureClientV3, {
-  StagedExpenditureClientV3,
+  type StagedExpenditureClientV3,
 } from './StagedExpenditureClientV3.js';
 
-export { StagedExpenditureClientV1 } from './StagedExpenditureClientV1.js';
-export { StagedExpenditureClientV2 } from './StagedExpenditureClientV2.js';
-export { StagedExpenditureClientV3 } from './StagedExpenditureClientV3.js';
+export type { StagedExpenditureClientV1 } from './StagedExpenditureClientV1.js';
+export type { StagedExpenditureClientV2 } from './StagedExpenditureClientV2.js';
+export type { StagedExpenditureClientV3 } from './StagedExpenditureClientV3.js';
 
 export type AnyStagedExpenditureClient =
   | StagedExpenditureClientV1

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV1.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV1.ts
@@ -5,8 +5,8 @@ import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StakedExpenditureClientV1

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV2.ts
@@ -5,8 +5,8 @@ import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StakedExpenditureClientV2

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV3.ts
@@ -4,8 +4,8 @@ import type { StakedExpenditure } from '../../../contracts/StakedExpenditure/3/i
 import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/3/factories/StakedExpenditure__factory.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 import { ClientType } from '../../../constants.js';
 

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV4.ts
@@ -4,8 +4,8 @@ import type { StakedExpenditure } from '../../../contracts/StakedExpenditure/4/i
 import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/4/factories/StakedExpenditure__factory.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 import { ClientType } from '../../../constants.js';
 

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV5.ts
@@ -4,8 +4,8 @@ import type { StakedExpenditure } from '../../../contracts/StakedExpenditure/5/i
 import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/5/factories/StakedExpenditure__factory.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 import { ClientType } from '../../../constants.js';
 

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV6.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/StakedExpenditureClientV6.ts
@@ -4,8 +4,8 @@ import type { StakedExpenditure } from '../../../contracts/StakedExpenditure/6/i
 import { StakedExpenditure__factory as StakedExpenditureFactory } from '../../../contracts/StakedExpenditure/6/factories/StakedExpenditure__factory.js';
 import {
   addAugments,
-  AugmentedStakedExpenditure,
-  ValidColony,
+  type AugmentedStakedExpenditure,
+  type ValidColony,
 } from './augments/commonAugments.js';
 import { ClientType } from '../../../constants.js';
 

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/augments/commonAugments.ts
@@ -1,8 +1,8 @@
 import {
-  BigNumberish,
-  BigNumber,
-  ContractTransaction,
-  BytesLike,
+  type BigNumberish,
+  type BigNumber,
+  type ContractTransaction,
+  type BytesLike,
 } from 'ethers';
 import {
   type StakedExpenditureVersion,
@@ -16,15 +16,15 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../../../Core/contracts.js';
-import { AnyStakedExpenditure } from '../contracts.js';
+import { type AnyStakedExpenditure } from '../contracts.js';
 
 export type ValidColony =
   | IColonyV12

--- a/packages/colony-js/src/clients/Extensions/StakedExpenditure/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/StakedExpenditure/exports.ts
@@ -2,34 +2,34 @@ import type { StakedExpenditureVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
-import { ValidColony } from './augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type ValidColony } from './augments/commonAugments.js';
 
 import getStakedExpenditureClientV1, {
-  StakedExpenditureClientV1,
+  type StakedExpenditureClientV1,
 } from './StakedExpenditureClientV1.js';
 import getStakedExpenditureClientV2, {
-  StakedExpenditureClientV2,
+  type StakedExpenditureClientV2,
 } from './StakedExpenditureClientV2.js';
 import getStakedExpenditureClientV3, {
-  StakedExpenditureClientV3,
+  type StakedExpenditureClientV3,
 } from './StakedExpenditureClientV3.js';
 import getStakedExpenditureClientV4, {
-  StakedExpenditureClientV4,
+  type StakedExpenditureClientV4,
 } from './StakedExpenditureClientV4.js';
 import getStakedExpenditureClientV5, {
-  StakedExpenditureClientV5,
+  type StakedExpenditureClientV5,
 } from './StakedExpenditureClientV5.js';
 import getStakedExpenditureClientV6, {
-  StakedExpenditureClientV6,
+  type StakedExpenditureClientV6,
 } from './StakedExpenditureClientV6.js';
 
-export { StakedExpenditureClientV1 } from './StakedExpenditureClientV1.js';
-export { StakedExpenditureClientV2 } from './StakedExpenditureClientV2.js';
-export { StakedExpenditureClientV3 } from './StakedExpenditureClientV3.js';
-export { StakedExpenditureClientV4 } from './StakedExpenditureClientV4.js';
-export { StakedExpenditureClientV5 } from './StakedExpenditureClientV5.js';
-export { StakedExpenditureClientV6 } from './StakedExpenditureClientV6.js';
+export type { StakedExpenditureClientV1 } from './StakedExpenditureClientV1.js';
+export type { StakedExpenditureClientV2 } from './StakedExpenditureClientV2.js';
+export type { StakedExpenditureClientV3 } from './StakedExpenditureClientV3.js';
+export type { StakedExpenditureClientV4 } from './StakedExpenditureClientV4.js';
+export type { StakedExpenditureClientV5 } from './StakedExpenditureClientV5.js';
+export type { StakedExpenditureClientV6 } from './StakedExpenditureClientV6.js';
 
 export type AnyStakedExpenditureClient =
   | StakedExpenditureClientV1

--- a/packages/colony-js/src/clients/Extensions/StreamingPayments/StreamingPaymentsClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/StreamingPayments/StreamingPaymentsClientV5.ts
@@ -5,8 +5,8 @@ import { StreamingPayments__factory as StreamingPaymentsFactory } from '../../..
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedStreamingPayments,
-  ValidColony,
+  type AugmentedStreamingPayments,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface StreamingPaymentsClientV5

--- a/packages/colony-js/src/clients/Extensions/StreamingPayments/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/StreamingPayments/augments/commonAugments.ts
@@ -1,7 +1,7 @@
 import {
-  BigNumberish,
-  BigNumber,
-  ContractTransaction,
+  type BigNumberish,
+  type BigNumber,
+  type ContractTransaction,
   constants,
 } from 'ethers';
 import {
@@ -11,20 +11,20 @@ import {
   getPermissionProofs,
 } from '@colony/core';
 import {
-  StreamingPaymentsEvents,
+  type StreamingPaymentsEvents,
   StreamingPaymentsEvents__factory as StreamingPaymentsEventsFactory,
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
 import {
-  IColonyV12,
-  IColonyV13,
-  IColonyV14,
-  IColonyV15,
-  IColonyV16,
+  type IColonyV12,
+  type IColonyV13,
+  type IColonyV14,
+  type IColonyV15,
+  type IColonyV16,
 } from '../../../Core/contracts.js';
-import { AnyStreamingPayments } from '../contracts.js';
+import { type AnyStreamingPayments } from '../contracts.js';
 
 const { MaxUint256 } = constants;
 

--- a/packages/colony-js/src/clients/Extensions/StreamingPayments/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/StreamingPayments/exports.ts
@@ -2,14 +2,14 @@ import type { StreamingPaymentsVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
-import { ValidColony } from './augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type ValidColony } from './augments/commonAugments.js';
 
 import getStreamingPaymentsClientV5, {
-  StreamingPaymentsClientV5,
+  type StreamingPaymentsClientV5,
 } from './StreamingPaymentsClientV5.js';
 
-export { StreamingPaymentsClientV5 } from './StreamingPaymentsClientV5.js';
+export type { StreamingPaymentsClientV5 } from './StreamingPaymentsClientV5.js';
 
 export type AnyStreamingPaymentsClient = StreamingPaymentsClientV5;
 

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV2.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV2.ts
@@ -3,7 +3,7 @@ import type { AugmentedIColony } from '../../Core/augments/commonAugments.js';
 import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contracts/TokenSupplier/2/factories/TokenSupplier__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  UnkonwnTokenSupplierClient,
+  type UnkonwnTokenSupplierClient,
   addAugments,
 } from './augments/commonAugments.js';
 

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV3.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV3.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV3

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV4.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV4.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV4

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV5.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV5

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV6.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV6.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV6

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV7.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV7.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV7

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV8.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/TokenSupplierClientV8.ts
@@ -5,8 +5,8 @@ import { TokenSupplier__factory as TokenSupplierFactory } from '../../../contrac
 import { ClientType } from '../../../constants.js';
 import {
   addAugments,
-  AugmentedTokenSupplier,
-  ValidColony,
+  type AugmentedTokenSupplier,
+  type ValidColony,
 } from './augments/commonAugments.js';
 
 export interface TokenSupplierClientV8

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/augments/commonAugments.ts
@@ -6,9 +6,9 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { AnyTokenSupplier } from '../contracts.js';
-import { AnyIColony } from '../../../Core/contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AnyTokenSupplier } from '../contracts.js';
+import { type AnyIColony } from '../../../Core/contracts.js';
 
 export type ValidColony = AnyIColony;
 

--- a/packages/colony-js/src/clients/Extensions/TokenSupplier/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/TokenSupplier/exports.ts
@@ -2,35 +2,35 @@ import type { TokenSupplierVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import getTokenSupplierClientV1 from './TokenSupplierClientV1.js';
 import getTokenSupplierClientV2 from './TokenSupplierClientV2.js';
 import getTokenSupplierClientV3, {
-  TokenSupplierClientV3,
+  type TokenSupplierClientV3,
 } from './TokenSupplierClientV3.js';
 import getTokenSupplierClientV4, {
-  TokenSupplierClientV4,
+  type TokenSupplierClientV4,
 } from './TokenSupplierClientV4.js';
 import getTokenSupplierClientV5, {
-  TokenSupplierClientV5,
+  type TokenSupplierClientV5,
 } from './TokenSupplierClientV5.js';
 import getTokenSupplierClientV6, {
-  TokenSupplierClientV6,
+  type TokenSupplierClientV6,
 } from './TokenSupplierClientV6.js';
 import getTokenSupplierClientV7, {
-  TokenSupplierClientV7,
+  type TokenSupplierClientV7,
 } from './TokenSupplierClientV7.js';
 import getTokenSupplierClientV8, {
-  TokenSupplierClientV8,
+  type TokenSupplierClientV8,
 } from './TokenSupplierClientV8.js';
 
-export { TokenSupplierClientV3 } from './TokenSupplierClientV3.js';
-export { TokenSupplierClientV4 } from './TokenSupplierClientV4.js';
-export { TokenSupplierClientV5 } from './TokenSupplierClientV5.js';
-export { TokenSupplierClientV6 } from './TokenSupplierClientV6.js';
-export { TokenSupplierClientV7 } from './TokenSupplierClientV7.js';
-export { TokenSupplierClientV8 } from './TokenSupplierClientV8.js';
+export type { TokenSupplierClientV3 } from './TokenSupplierClientV3.js';
+export type { TokenSupplierClientV4 } from './TokenSupplierClientV4.js';
+export type { TokenSupplierClientV5 } from './TokenSupplierClientV5.js';
+export type { TokenSupplierClientV6 } from './TokenSupplierClientV6.js';
+export type { TokenSupplierClientV7 } from './TokenSupplierClientV7.js';
+export type { TokenSupplierClientV8 } from './TokenSupplierClientV8.js';
 
 export type AnyTokenSupplierClient =
   | TokenSupplierClientV3

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV10.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV10.ts
@@ -4,14 +4,17 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/10/
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/10/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments as addAugmentsV3,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV11.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV11.ts
@@ -4,14 +4,17 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/11/
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/11/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments as addAugmentsV3,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV12.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV12.ts
@@ -4,14 +4,17 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/12/
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/12/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments as addAugmentsV3,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV5.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV5.ts
@@ -2,7 +2,7 @@ import type { AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import { VotingReputation__factory as VotingReputationFactory } from '../../../contracts/VotingReputation/5/factories/VotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
-import { UnkonwnVotingReputationClient } from './augments/commonAugments.js';
+import { type UnkonwnVotingReputationClient } from './augments/commonAugments.js';
 import { addAugments } from './augments/augmentsV2.js';
 import { addAugments as addCreateDomainMotionAugments } from './augments/CreateDomainMotion.js';
 

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV6.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV6.ts
@@ -2,7 +2,7 @@ import type { AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/6/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
-import { UnkonwnVotingReputationClient } from './augments/commonAugments.js';
+import { type UnkonwnVotingReputationClient } from './augments/commonAugments.js';
 import { addAugments } from './augments/augmentsV2.js';
 import { addAugments as addCreateDomainMotionAugments } from './augments/CreateDomainMotion.js';
 

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV7.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV7.ts
@@ -4,19 +4,22 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/7/I
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/7/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 import {
   addAugments as addCreateDomainMotionAugments,
-  CreateDomainMotionAugments,
-  CreateDomainMotionEstimateGas,
+  type CreateDomainMotionAugments,
+  type CreateDomainMotionEstimateGas,
 } from './augments/CreateDomainMotion.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV8.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV8.ts
@@ -4,14 +4,17 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/8/I
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/8/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments as addAugmentsV3,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV9.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/VotingReputationClientV9.ts
@@ -4,14 +4,17 @@ import type { IVotingReputation } from '../../../contracts/IVotingReputation/9/I
 import { IVotingReputation__factory as VotingReputationFactory } from '../../../contracts/IVotingReputation/9/factories/IVotingReputation__factory.js';
 import { ClientType } from '../../../constants.js';
 import {
-  AugmentedEstimate,
-  AugmentedVotingReputation,
+  type AugmentedEstimate,
+  type AugmentedVotingReputation,
 } from './augments/commonAugments.js';
-import { AugmentedEstimateV2, AugmentsV2 } from './augments/augmentsV2.js';
+import {
+  type AugmentedEstimateV2,
+  type AugmentsV2,
+} from './augments/augmentsV2.js';
 import {
   addAugments as addAugmentsV3,
-  AugmentedEstimateV3,
-  AugmentsV3,
+  type AugmentedEstimateV3,
+  type AugmentsV3,
 } from './augments/augmentsV3.js';
 
 interface VotingReputationEstimate

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/augments/CreateDomainMotion.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/augments/CreateDomainMotion.ts
@@ -1,8 +1,8 @@
 import {
   BigNumber,
-  BigNumberish,
-  BytesLike,
-  ContractTransaction,
+  type BigNumberish,
+  type BytesLike,
+  type ContractTransaction,
   constants,
 } from 'ethers';
 import {
@@ -11,8 +11,8 @@ import {
   parsePermissionedAction,
 } from '@colony/core';
 
-import { VotingReputationV7 } from '../contracts.js';
-import { AugmentedVotingReputation } from './commonAugments.js';
+import { type VotingReputationV7 } from '../contracts.js';
+import { type AugmentedVotingReputation } from './commonAugments.js';
 
 // VotingReputation versions that support this method
 type ValidVotingReputation = VotingReputationV7;

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/augments/augmentsV2.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/augments/augmentsV2.ts
@@ -1,24 +1,24 @@
 import {
-  ContractTransaction,
-  BigNumber,
-  BigNumberish,
-  BytesLike,
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+  type BytesLike,
 } from 'ethers';
 import { type TxOverrides, getCreateMotionProofs } from '@colony/core';
 
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
 import {
-  VotingReputationV7,
-  VotingReputationV8,
-  VotingReputationV9,
-  VotingReputationV10,
-  VotingReputationV11,
-  VotingReputationV12,
+  type VotingReputationV7,
+  type VotingReputationV8,
+  type VotingReputationV9,
+  type VotingReputationV10,
+  type VotingReputationV11,
+  type VotingReputationV12,
 } from '../contracts.js';
-import { AnyVotingReputationClient } from '../exports.js';
+import { type AnyVotingReputationClient } from '../exports.js';
 import {
   addAugments as addCommonAugments,
-  AugmentedVotingReputation,
+  type AugmentedVotingReputation,
 } from './commonAugments.js';
 
 type ValidVotingReputation =

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/augments/augmentsV3.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/augments/augmentsV3.ts
@@ -1,21 +1,25 @@
-import { ContractTransaction, BigNumber, BigNumberish } from 'ethers';
+import {
+  type ContractTransaction,
+  type BigNumber,
+  type BigNumberish,
+} from 'ethers';
 import {
   type TxOverrides,
   ColonyRole,
   getPermissionProofs,
 } from '@colony/core';
 
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
 import {
-  VotingReputationV7,
-  VotingReputationV8,
-  VotingReputationV9,
-  VotingReputationV10,
-  VotingReputationV11,
-  VotingReputationV12,
+  type VotingReputationV7,
+  type VotingReputationV8,
+  type VotingReputationV9,
+  type VotingReputationV10,
+  type VotingReputationV11,
+  type VotingReputationV12,
 } from '../contracts.js';
-import { AugmentedVotingReputation } from './commonAugments.js';
-import { addAugments as addAugmentsV2, AugmentsV2 } from './augmentsV2.js';
+import { type AugmentedVotingReputation } from './commonAugments.js';
+import { addAugments as addAugmentsV2, type AugmentsV2 } from './augmentsV2.js';
 
 type ValidVotingReputation =
   | VotingReputationV7

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/augments/commonAugments.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/augments/commonAugments.ts
@@ -1,4 +1,4 @@
-import { ContractTransaction, BigNumberish, BigNumber } from 'ethers';
+import { type ContractTransaction, type BigNumberish, BigNumber } from 'ethers';
 import {
   type TxOverrides,
   type VotingReputationVersion,
@@ -12,8 +12,8 @@ import {
 } from '@colony/events';
 
 import { ClientType } from '../../../../constants.js';
-import { AugmentedIColony } from '../../../Core/augments/commonAugments.js';
-import { AnyVotingReputation } from '../contracts.js';
+import { type AugmentedIColony } from '../../../Core/augments/commonAugments.js';
+import { type AnyVotingReputation } from '../contracts.js';
 
 export type AugmentedEstimate<
   T extends AnyVotingReputation = AnyVotingReputation,

--- a/packages/colony-js/src/clients/Extensions/VotingReputation/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/VotingReputation/exports.ts
@@ -2,7 +2,7 @@ import type { VotingReputationVersion } from '@colony/core';
 
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../../Core/augments/commonAugments.js';
 
 import getVotingReputationClientV1 from './VotingReputationClientV1.js';
 import getVotingReputationClientV2 from './VotingReputationClientV2.js';
@@ -11,30 +11,30 @@ import getVotingReputationClientV4 from './VotingReputationClientV4.js';
 import getVotingReputationClientV5 from './VotingReputationClientV5.js';
 import getVotingReputationClientV6 from './VotingReputationClientV6.js';
 import getVotingReputationClientV7, {
-  VotingReputationClientV7,
+  type VotingReputationClientV7,
 } from './VotingReputationClientV7.js';
 import getVotingReputationClientV8, {
-  VotingReputationClientV8,
+  type VotingReputationClientV8,
 } from './VotingReputationClientV8.js';
 import getVotingReputationClientV9, {
-  VotingReputationClientV9,
+  type VotingReputationClientV9,
 } from './VotingReputationClientV9.js';
 import getVotingReputationClientV10, {
-  VotingReputationClientV10,
+  type VotingReputationClientV10,
 } from './VotingReputationClientV10.js';
 import getVotingReputationClientV11, {
-  VotingReputationClientV11,
+  type VotingReputationClientV11,
 } from './VotingReputationClientV11.js';
 import getVotingReputationClientV12, {
-  VotingReputationClientV12,
+  type VotingReputationClientV12,
 } from './VotingReputationClientV12.js';
 
-export { VotingReputationClientV7 } from './VotingReputationClientV7.js';
-export { VotingReputationClientV8 } from './VotingReputationClientV8.js';
-export { VotingReputationClientV9 } from './VotingReputationClientV9.js';
-export { VotingReputationClientV10 } from './VotingReputationClientV10.js';
-export { VotingReputationClientV11 } from './VotingReputationClientV11.js';
-export { VotingReputationClientV12 } from './VotingReputationClientV12.js';
+export type { VotingReputationClientV7 } from './VotingReputationClientV7.js';
+export type { VotingReputationClientV8 } from './VotingReputationClientV8.js';
+export type { VotingReputationClientV9 } from './VotingReputationClientV9.js';
+export type { VotingReputationClientV10 } from './VotingReputationClientV10.js';
+export type { VotingReputationClientV11 } from './VotingReputationClientV11.js';
+export type { VotingReputationClientV12 } from './VotingReputationClientV12.js';
 
 export type AnyVotingReputationClient =
   | VotingReputationClientV7

--- a/packages/colony-js/src/clients/Extensions/exports.ts
+++ b/packages/colony-js/src/clients/Extensions/exports.ts
@@ -16,44 +16,44 @@ import {
 } from '@colony/core';
 import { assertExhaustiveSwitch } from '@colony/core/utils';
 
-import { AugmentedIColony } from '../Core/augments/commonAugments.js';
+import { type AugmentedIColony } from '../Core/augments/commonAugments.js';
 
 import {
   getMultisigPermissionsClient,
-  AnyMultisigPermissionsClient,
+  type AnyMultisigPermissionsClient,
 } from './MultisigPermissions/exports.js';
 import {
   getOneTxPaymentClient,
-  AnyOneTxPaymentClient,
+  type AnyOneTxPaymentClient,
 } from './OneTxPayment/exports.js';
 import {
   getReputationBootstrapperClient,
-  AnyReputationBootstrapperClient,
+  type AnyReputationBootstrapperClient,
 } from './ReputationBootstrapper/exports.js';
 import {
   getVotingReputationClient,
-  AnyVotingReputationClient,
+  type AnyVotingReputationClient,
 } from './VotingReputation/exports.js';
 import {
   getStagedExpenditureClient,
-  AnyStagedExpenditureClient,
+  type AnyStagedExpenditureClient,
 } from './StagedExpenditure/exports.js';
 import {
   getStakedExpenditureClient,
-  AnyStakedExpenditureClient,
+  type AnyStakedExpenditureClient,
 } from './StakedExpenditure/exports.js';
 import {
   getStreamingPaymentsClient,
-  AnyStreamingPaymentsClient,
+  type AnyStreamingPaymentsClient,
 } from './StreamingPayments/exports.js';
 import {
   getTokenSupplierClient,
-  AnyTokenSupplierClient,
+  type AnyTokenSupplierClient,
 } from './TokenSupplier/exports.js';
 
 import getExtensionVersionClient from './ExtensionVersionClient.js';
 import {
-  AnyFundingQueueClient,
+  type AnyFundingQueueClient,
   getFundingQueueClient,
 } from './FundingQueue/exports.js';
 

--- a/packages/colony-js/src/helpers.ts
+++ b/packages/colony-js/src/helpers.ts
@@ -1,11 +1,11 @@
 import type { Filter, Log } from '@ethersproject/abstract-provider';
 import type { LogDescription, Result } from '@ethersproject/abi';
 
-import { EventFilter, BigNumber } from 'ethers';
+import { type EventFilter, type BigNumber } from 'ethers';
 import { ColonyRole, Id } from '@colony/core';
 
-import { AnyColonyClient } from './clients/Core/exports.js';
-import { ContractClient, ColonyRoles } from './types.js';
+import { type AnyColonyClient } from './clients/Core/exports.js';
+import { type ContractClient, type ColonyRoles } from './types.js';
 
 interface LogOptions {
   fromBlock?: number;

--- a/packages/colony-js/src/types.ts
+++ b/packages/colony-js/src/types.ts
@@ -16,9 +16,9 @@ import type {
 } from '@colony/tokens';
 import type { ColonyRole } from '@colony/core';
 
-import { AnyColonyClient } from './clients/Core/exports.js';
-import { ExtensionClient } from './clients/Extensions/exports.js';
-import { ColonyNetworkClient } from './clients/ColonyNetworkClient.js';
+import { type AnyColonyClient } from './clients/Core/exports.js';
+import { type ExtensionClient } from './clients/Extensions/exports.js';
+import { type ColonyNetworkClient } from './clients/ColonyNetworkClient.js';
 
 export type EventsClient =
   | EvaluatedExpenditureEvents.EvaluatedExpenditureEvents

--- a/packages/contractor/.eslintrc
+++ b/packages/contractor/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    }
+}

--- a/packages/core/.eslintrc
+++ b/packages/core/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    },
     "rules": {
         "camelcase": [
             "error",

--- a/packages/core/src/helpers/motions.ts
+++ b/packages/core/src/helpers/motions.ts
@@ -1,18 +1,24 @@
-import { BigNumber, BigNumberish, BytesLike, constants, utils } from 'ethers';
+import {
+  BigNumber,
+  type BigNumberish,
+  type BytesLike,
+  constants,
+  utils,
+} from 'ethers';
 
 import { ColonyRole, Id } from '../constants.js';
 import {
   MotionTarget__factory as MotionTargetFactory,
-  MotionTarget,
+  type MotionTarget,
 } from '../contracts/index.js';
 
 import { parsePermissionedAction } from './permissions.js';
 import {
-  CommonColony,
-  CommonNetwork,
-  CommonVotingReputation,
+  type CommonColony,
+  type CommonNetwork,
+  type CommonVotingReputation,
 } from './types.js';
-import { ReputationClient } from './reputation.js';
+import { type ReputationClient } from './reputation.js';
 import { hex2ColonyRoles } from './network.js';
 
 const { MaxUint256 } = constants;

--- a/packages/core/src/helpers/network.ts
+++ b/packages/core/src/helpers/network.ts
@@ -1,18 +1,18 @@
 import type { Log, Provider } from '@ethersproject/abstract-provider';
 import type { Interface } from '@ethersproject/abi';
 
-import { BigNumber, BigNumberish, constants, utils } from 'ethers';
+import { BigNumber, type BigNumberish, constants, utils } from 'ethers';
 
 import {
   ColonyRole,
-  Extension,
+  type Extension,
   FundingPotAssociatedType,
   Id,
 } from '../constants.js';
-import { CommonColony, CommonNetwork } from './types.js';
+import { type CommonColony, type CommonNetwork } from './types.js';
 import { nonNullable } from '../utils/index.js';
-import { ContractVersion } from '../versions/index.js';
-import { SignerOrProvider } from '../types.js';
+import { type ContractVersion } from '../versions/index.js';
+import { type SignerOrProvider } from '../types.js';
 import { Versioned__factory as VersionedFactory } from '../contracts/index.js';
 
 const { keccak256, toUtf8Bytes } = utils;

--- a/packages/core/src/helpers/permissions.ts
+++ b/packages/core/src/helpers/permissions.ts
@@ -1,7 +1,13 @@
-import { BigNumber, BigNumberish, BytesLike, constants, utils } from 'ethers';
+import {
+  BigNumber,
+  type BigNumberish,
+  type BytesLike,
+  constants,
+  utils,
+} from 'ethers';
 
-import { ColonyRole, Id } from '../constants.js';
-import { CommonColony, CommonNetwork } from './types.js';
+import { type ColonyRole, Id } from '../constants.js';
+import { type CommonColony, type CommonNetwork } from './types.js';
 import { getChildIndex } from './network.js';
 
 const { hexDataSlice } = utils;

--- a/packages/core/src/helpers/reputation.ts
+++ b/packages/core/src/helpers/reputation.ts
@@ -1,7 +1,7 @@
-import { BigNumber, BigNumberish, constants } from 'ethers';
+import { BigNumber, type BigNumberish, constants } from 'ethers';
 
 import { Network, ReputationOracleEndpoint } from '../constants.js';
-import { CommonColony, CommonNetwork } from './types.js';
+import { type CommonColony, type CommonNetwork } from './types.js';
 
 interface ReputationClientOptions {
   customEndpointUrl?: string;

--- a/packages/core/src/helpers/types.ts
+++ b/packages/core/src/helpers/types.ts
@@ -1,6 +1,6 @@
 import type { Provider } from '@ethersproject/abstract-provider';
 
-import { BigNumber, BigNumberish, Signer } from 'ethers';
+import { type BigNumber, type BigNumberish, type Signer } from 'ethers';
 
 export interface CommonDomain {
   skillId: BigNumber;

--- a/packages/core/src/versions/helpers.ts
+++ b/packages/core/src/versions/helpers.ts
@@ -1,41 +1,41 @@
 import { COLONY_VERSIONS } from './IColony.js';
-import { ColonyVersion, ExtensionVersion } from './index.js';
+import { type ColonyVersion, type ExtensionVersion } from './index.js';
 import { assertExhaustiveSwitch } from '../utils/index.js';
 import {
   fundingQueueIncompatibilityMap,
-  FundingQueueVersion,
+  type FundingQueueVersion,
 } from './FundingQueue.js';
 import {
   multisigPermissionsIncompatibilityMap,
-  MultisigPermissionsVersion,
+  type MultisigPermissionsVersion,
 } from './MultisigPermissions.js';
 import {
   oneTxPaymentIncompatibilityMap,
-  OneTxPaymentVersion,
+  type OneTxPaymentVersion,
 } from './OneTxPayment.js';
 import {
   reputationBootstrapperIncompatibilityMap,
-  ReputationBootstrapperVersion,
+  type ReputationBootstrapperVersion,
 } from './ReputationBootstrapper.js';
 import {
   stagedExpenditureIncompatibilityMap,
-  StagedExpenditureVersion,
+  type StagedExpenditureVersion,
 } from './StagedExpenditure.js';
 import {
   stakedExpenditureIncompatibilityMap,
-  StakedExpenditureVersion,
+  type StakedExpenditureVersion,
 } from './StakedExpenditure.js';
 import {
   streamingPaymentsIncompatibilityMap,
-  StreamingPaymentsVersion,
+  type StreamingPaymentsVersion,
 } from './StreamingPayments.js';
 import {
   tokenSupplierIncompatibilityMap,
-  TokenSupplierVersion,
+  type TokenSupplierVersion,
 } from './TokenSupplier.js';
 import {
   votingReputationIncompatibilityMap,
-  VotingReputationVersion,
+  type VotingReputationVersion,
 } from './VotingReputation.js';
 import { Extension } from '../constants.js';
 

--- a/packages/core/src/versions/index.ts
+++ b/packages/core/src/versions/index.ts
@@ -1,40 +1,40 @@
 import { Extension } from '../constants.js';
-import { ColonyVersion } from './IColony.js';
+import { type ColonyVersion } from './IColony.js';
 import {
   FUNDING_QUEUE_VERSION_LATEST,
-  FundingQueueVersion,
+  type FundingQueueVersion,
 } from './FundingQueue.js';
 import {
   MULTISIG_PERMISSIONS_VERSION_LATEST,
-  MultisigPermissionsVersion,
+  type MultisigPermissionsVersion,
 } from './MultisigPermissions.js';
 import {
   ONE_TX_PAYMENT_VERSION_LATEST,
-  OneTxPaymentVersion,
+  type OneTxPaymentVersion,
 } from './OneTxPayment.js';
 import {
   REPUTATION_BOOTSTRAPPER_VERSION_LATEST,
-  ReputationBootstrapperVersion,
+  type ReputationBootstrapperVersion,
 } from './ReputationBootstrapper.js';
 import {
   STAKED_EXPENDITURE_VERSION_LATEST,
-  StakedExpenditureVersion,
+  type StakedExpenditureVersion,
 } from './StakedExpenditure.js';
 import {
   STAGED_EXPENDITURE_VERSION_LATEST,
-  StagedExpenditureVersion,
+  type StagedExpenditureVersion,
 } from './StagedExpenditure.js';
 import {
   STREAMING_PAYMENTS_VERSION_LATEST,
-  StreamingPaymentsVersion,
+  type StreamingPaymentsVersion,
 } from './StreamingPayments.js';
 import {
   TOKEN_SUPPLIER_VERSION_LATEST,
-  TokenSupplierVersion,
+  type TokenSupplierVersion,
 } from './TokenSupplier.js';
 import {
   VOTING_REPUTATION_VERSION_LATEST,
-  VotingReputationVersion,
+  type VotingReputationVersion,
 } from './VotingReputation.js';
 
 export * from './helpers.js';
@@ -77,40 +77,40 @@ export type ContractVersion = ExtensionVersion | ColonyVersion;
 /**
  * All possible Colony versions
  */
-export { ColonyVersion } from './IColony.js';
+export type { ColonyVersion } from './IColony.js';
 /**
  * All possible FundingQueue versions
  */
-export { FundingQueueVersion } from './FundingQueue.js';
+export type { FundingQueueVersion } from './FundingQueue.js';
 /**
  * All possible MultisigPermissions versions
  */
-export { MultisigPermissionsVersion } from './MultisigPermissions.js';
+export type { MultisigPermissionsVersion } from './MultisigPermissions.js';
 /**
  * All possible OneTxPayment versions
  */
-export { OneTxPaymentVersion } from './OneTxPayment.js';
+export type { OneTxPaymentVersion } from './OneTxPayment.js';
 /**
  * All possible ReputationBootstrapper versions
  */
-export { ReputationBootstrapperVersion } from './ReputationBootstrapper.js';
+export type { ReputationBootstrapperVersion } from './ReputationBootstrapper.js';
 /**
  * All possible StagedExpenditure versions
  */
-export { StagedExpenditureVersion } from './StagedExpenditure.js';
+export type { StagedExpenditureVersion } from './StagedExpenditure.js';
 /**
  * All possible StakedExpenditure versions
  */
-export { StakedExpenditureVersion } from './StakedExpenditure.js';
+export type { StakedExpenditureVersion } from './StakedExpenditure.js';
 /**
  * All possible StreamingPayments versions
  */
-export { StreamingPaymentsVersion } from './StreamingPayments.js';
+export type { StreamingPaymentsVersion } from './StreamingPayments.js';
 /**
  * All possible TokenSupplier versions
  */
-export { TokenSupplierVersion } from './TokenSupplier.js';
+export type { TokenSupplierVersion } from './TokenSupplier.js';
 /**
  * All possible VotingReputation versions
  */
-export { VotingReputationVersion } from './VotingReputation.js';
+export type { VotingReputationVersion } from './VotingReputation.js';

--- a/packages/events/.eslintrc
+++ b/packages/events/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    },
     "rules": {
         "camelcase": [
             "error",

--- a/packages/events/src/ColonyEventManager.ts
+++ b/packages/events/src/ColonyEventManager.ts
@@ -1,15 +1,20 @@
 import type { Result } from '@ethersproject/abi';
 import type { BlockTag } from '@ethersproject/abstract-provider';
 
-import { constants, providers, EventFilter, BaseContract } from 'ethers';
-import { addressesAreEqual, SignerOrProvider } from '@colony/core';
+import {
+  constants,
+  type providers,
+  type EventFilter,
+  type BaseContract,
+} from 'ethers';
+import { addressesAreEqual, type SignerOrProvider } from '@colony/core';
 
 import {
   type IpfsAdapter,
   type MetadataEvent,
   type MetadataTypeMap,
   IpfsMetadata,
-  MetadataType,
+  type MetadataType,
 } from './ipfs/index.js';
 import type { Ethers6Filter } from './types.js';
 import { getLogs, nonNullable } from './utils.js';

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,10 +1,10 @@
 export {
-  ColonyEvent,
+  type ColonyEvent,
   ColonyEventManager,
-  ColonyEventManagerOptions,
-  ColonyTopic,
-  ColonyFilter,
-  ColonyMultiFilter,
+  type ColonyEventManagerOptions,
+  type ColonyTopic,
+  type ColonyFilter,
+  type ColonyMultiFilter,
   type EventSource,
 } from './ColonyEventManager.js';
 

--- a/packages/events/src/ipfs/IpfsMetadata.ts
+++ b/packages/events/src/ipfs/IpfsMetadata.ts
@@ -1,10 +1,14 @@
 import wrapFetch from 'fetch-retry';
 
 import { createMetadataFor, parseEventMetadata } from './metadata.js';
-import IpfsAdapter from './IpfsAdapter.js';
+import type IpfsAdapter from './IpfsAdapter.js';
 import CloudflareReadonlyAdapter from './CloudflareReadonlyAdapter.js';
 import { MetadataType } from './constants.js';
-import { DataTypeMap, Metadata, MetadataTypeMap } from './types.js';
+import {
+  type DataTypeMap,
+  type Metadata,
+  type MetadataTypeMap,
+} from './types.js';
 
 const fetchRetry = wrapFetch(fetch, {
   headers: {

--- a/packages/events/src/ipfs/index.ts
+++ b/packages/events/src/ipfs/index.ts
@@ -1,7 +1,7 @@
 export {
   IpfsMetadata,
   IpfsMetadataEvents,
-  MetadataEvent,
+  type MetadataEvent,
 } from './IpfsMetadata.js';
 
 export { default as PinataAdapter } from './PinataAdapter.js';

--- a/packages/events/src/ipfs/types.ts
+++ b/packages/events/src/ipfs/types.ts
@@ -1,4 +1,4 @@
-import { MetadataType, TeamColor } from './constants.js';
+import { type MetadataType, type TeamColor } from './constants.js';
 
 interface BaseMetadata {
   name: MetadataType;

--- a/packages/events/src/utils.ts
+++ b/packages/events/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Log } from '@ethersproject/abstract-provider';
 import type { JsonRpcProvider } from '@ethersproject/providers';
 
-import { Ethers6Filter, Ethers6FilterByBlockHash } from './types.js';
+import { type Ethers6Filter, type Ethers6FilterByBlockHash } from './types.js';
 
 /** Version of `getLogs` that also supports filtering for multiple addresses */
 export const getLogs = async (

--- a/packages/sdk/.eslintrc
+++ b/packages/sdk/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    },
     "rules": {
         "camelcase": [
             "error",

--- a/packages/sdk/examples/browser/src/advanced.ts
+++ b/packages/sdk/examples/browser/src/advanced.ts
@@ -1,7 +1,13 @@
-import { providers, utils, Signer, ContractReceipt, BigNumber } from 'ethers';
+import {
+  providers,
+  utils,
+  type Signer,
+  type ContractReceipt,
+  type BigNumber,
+} from 'ethers';
 
 import {
-  Colony,
+  type Colony,
   ColonyNetwork,
   PinataAdapter,
   toEth,

--- a/packages/sdk/examples/browser/src/local-motions.ts
+++ b/packages/sdk/examples/browser/src/local-motions.ts
@@ -1,7 +1,7 @@
-import { BigNumber, BigNumberish, providers, utils, Wallet } from 'ethers';
+import { BigNumber, type BigNumberish, providers, utils, Wallet } from 'ethers';
 
 import {
-  Colony,
+  type Colony,
   ColonyNetwork,
   MotionState,
   toEth,

--- a/packages/sdk/examples/browser/src/local-reputation.ts
+++ b/packages/sdk/examples/browser/src/local-reputation.ts
@@ -1,6 +1,12 @@
 import { providers, utils, Wallet } from 'ethers';
 
-import { Colony, ColonyNetwork, toEth, toWei, w } from '../../../src/index.js';
+import {
+  type Colony,
+  ColonyNetwork,
+  toEth,
+  toWei,
+  w,
+} from '../../../src/index.js';
 import { setupOneTxPaymentExtension } from '../../helpers.js';
 
 const { isAddress } = utils;

--- a/packages/sdk/examples/browser/src/metamask.ts
+++ b/packages/sdk/examples/browser/src/metamask.ts
@@ -1,4 +1,4 @@
-import { providers, Signer } from 'ethers';
+import { providers, type Signer } from 'ethers';
 
 import { ColonyNetwork } from '../../../src/index.js';
 

--- a/packages/sdk/examples/browser/src/motions.ts
+++ b/packages/sdk/examples/browser/src/motions.ts
@@ -1,7 +1,7 @@
-import { BigNumber, BigNumberish, providers, utils } from 'ethers';
+import { BigNumber, type BigNumberish, providers, utils } from 'ethers';
 
 import {
-  Colony,
+  type Colony,
   ColonyNetwork,
   MotionState,
   toEth,

--- a/packages/sdk/examples/helpers.ts
+++ b/packages/sdk/examples/helpers.ts
@@ -1,8 +1,8 @@
 import {
-  Colony,
-  OneTxPayment,
+  type Colony,
+  type OneTxPayment,
   SupportedExtension,
-  VotingReputation,
+  type VotingReputation,
 } from '../src/ColonyNetwork/index.js';
 import {
   ColonyRole,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,7 +31,7 @@
   },
   "license": "GPL-3.0-only",
   "scripts": {
-    "examples:node": "ts-node examples/node/index.ts",
+    "examples:node": "tsx examples/node/index.ts",
     "examples:browser": "esbuild --bundle examples/browser/src/*.ts --servedir=examples/browser/web",
     "build-contracts": "contractor colony -t 10 -o ./src/contracts",
     "build": "npm run clean && npm run compile-cjs && npm run compile-esm && npm run compile-prod && npm run compile-types && npm run create-pkg-json",
@@ -69,7 +69,7 @@
     "fast-glob": "^3.2.11",
     "inquirer": "^8.2.4",
     "prettier": "^2.6.1",
-    "ts-node": "^10.9.1",
+    "tsx": "^4.19.1",
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^3.15.3",
     "wonka": "^4.0.15",

--- a/packages/sdk/src/ColonyNetwork/Colony.ts
+++ b/packages/sdk/src/ColonyNetwork/Colony.ts
@@ -1,4 +1,9 @@
-import { BigNumber, BigNumberish, BytesLike, ContractReceipt } from 'ethers';
+import {
+  BigNumber,
+  type BigNumberish,
+  type BytesLike,
+  type ContractReceipt,
+} from 'ethers';
 import {
   type ColonyVersion,
   Id,
@@ -28,26 +33,26 @@ import type { ColonyDataTypes as ColonyDataTypes12 } from '../contracts/IColony/
 import type { IBasicMetaTransaction } from '../contracts/IBasicMetaTransaction.js';
 
 import {
-  IColony as ColonyContract11,
+  type IColony as ColonyContract11,
   IColony__factory as ColonyFactory11,
 } from '../contracts/IColony/11/index.js';
 import {
-  IColony as ColonyContract12,
+  type IColony as ColonyContract12,
   IColony__factory as ColonyFactory12,
 } from '../contracts/IColony/12/index.js';
 import {
-  IColony as ColonyContract13,
+  type IColony as ColonyContract13,
   IColony__factory as ColonyFactory13,
 } from '../contracts/IColony/13/index.js';
 import {
-  PermissionConfig,
-  TxConfig,
+  type PermissionConfig,
+  type TxConfig,
   ColonyTxCreator,
 } from '../TxCreator/index.js';
 import { extractEvent, extractCustomEvent } from '../utils.js';
-import { ColonyNetwork } from './ColonyNetwork.js';
+import { type ColonyNetwork } from './ColonyNetwork.js';
 import { OneTxPayment } from './OneTxPayment.js';
-import { ERC20Token, Token, getToken } from './tokens/index.js';
+import { ERC20Token, type Token, getToken } from './tokens/index.js';
 import { VotingReputation } from './VotingReputation.js';
 
 export type SupportedColonyContract =

--- a/packages/sdk/src/ColonyNetwork/ColonyNetwork.ts
+++ b/packages/sdk/src/ColonyNetwork/ColonyNetwork.ts
@@ -1,6 +1,6 @@
 import {
-  BigNumberish,
-  ContractReceipt,
+  type BigNumberish,
+  type ContractReceipt,
   constants,
   utils,
   Signer,
@@ -25,18 +25,18 @@ import {
 } from '@colony/events';
 
 import {
-  IColonyNetwork,
+  type IColonyNetwork,
   IColonyNetwork__factory as IColonyNetworkFactory,
-  IBasicMetaTransaction,
+  type IBasicMetaTransaction,
 } from '../contracts/index.js';
 import {
-  BaseContract,
-  TxConfig,
+  type BaseContract,
+  type TxConfig,
   TxCreator,
   MetaTxCreator,
 } from '../TxCreator/index.js';
 import { Colony } from './Colony.js';
-import { Expand, Parameters } from '../types.js';
+import { type Expand, type Parameters } from '../types.js';
 import { extractEvent } from '../utils.js';
 import { EIP2612TxCreator } from '../TxCreator/EIP2612TxCreator.js';
 import { TokenLocking } from './TokenLocking.js';
@@ -59,7 +59,7 @@ export interface ColonyNetworkOptions {
 }
 
 /** @internal */
-interface ColonyNetworkConfig {
+export interface ColonyNetworkConfig {
   metaTxBroadcasterEndpoint: string;
   reputationOracleEndpoint: string;
 }

--- a/packages/sdk/src/ColonyNetwork/OneTxPayment.ts
+++ b/packages/sdk/src/ColonyNetwork/OneTxPayment.ts
@@ -10,22 +10,22 @@ import {
   getPermissionProofs,
   isExtensionCompatible,
 } from '@colony/core';
-import { BigNumber, BigNumberish, constants } from 'ethers';
+import { type BigNumber, type BigNumberish, constants } from 'ethers';
 
 import { extractEvent } from '../utils.js';
 import {
-  OneTxPayment as OneTxPaymentContract3,
+  type OneTxPayment as OneTxPaymentContract3,
   OneTxPayment__factory as OneTxPaymentFactory3,
 } from '../contracts/OneTxPayment/3/index.js';
 import {
-  OneTxPayment as OneTxPaymentContract4,
+  type OneTxPayment as OneTxPaymentContract4,
   OneTxPayment__factory as OneTxPaymentFactory4,
 } from '../contracts/OneTxPayment/4/index.js';
 import {
-  OneTxPayment as OneTxPaymentContract5,
+  type OneTxPayment as OneTxPaymentContract5,
   OneTxPayment__factory as OneTxPaymentFactory5,
 } from '../contracts/OneTxPayment/5/index.js';
-import { Colony } from './Colony.js';
+import { type Colony } from './Colony.js';
 
 const { AddressZero } = constants;
 

--- a/packages/sdk/src/ColonyNetwork/TokenLocking.ts
+++ b/packages/sdk/src/ColonyNetwork/TokenLocking.ts
@@ -1,10 +1,10 @@
 import type { TokenLockingEvents } from '@colony/events';
 
-import { BigNumberish } from 'ethers';
+import { type BigNumberish } from 'ethers';
 import { type TokenLockingClient, getTokenLockingClient } from '@colony/tokens';
 
 import { extractEvent } from '../utils.js';
-import { ColonyNetwork } from './ColonyNetwork.js';
+import { type ColonyNetwork } from './ColonyNetwork.js';
 
 export class TokenLocking {
   address: string;

--- a/packages/sdk/src/ColonyNetwork/VotingReputation.ts
+++ b/packages/sdk/src/ColonyNetwork/VotingReputation.ts
@@ -1,4 +1,4 @@
-import { constants, BigNumber, BigNumberish, utils } from 'ethers';
+import { constants, BigNumber, type BigNumberish, utils } from 'ethers';
 import {
   type ReputationClient,
   type VotingReputationVersion,
@@ -21,7 +21,7 @@ import {
   type TokenLockingEvents,
   type ColonyNetworkEvents,
   type VotingReputationEvents,
-  DecisionData,
+  type DecisionData,
   MetadataType,
 } from '@colony/events';
 
@@ -30,20 +30,20 @@ import type { VotingReputationDataTypes as VotingReputationDataTypes8 } from '..
 import type { VotingReputationDataTypes as VotingReputationDataTypes9 } from '../contracts/IVotingReputation/9/IVotingReputation.js';
 
 import {
-  IVotingReputation as VotingReputationContract7,
+  type IVotingReputation as VotingReputationContract7,
   IVotingReputation__factory as VotingReputationFactory7,
 } from '../contracts/IVotingReputation/7/index.js';
 import {
-  IVotingReputation as VotingReputationContract8,
+  type IVotingReputation as VotingReputationContract8,
   IVotingReputation__factory as VotingReputationFactory8,
 } from '../contracts/IVotingReputation/8/index.js';
 import {
-  IVotingReputation as VotingReputationContract9,
+  type IVotingReputation as VotingReputationContract9,
   IVotingReputation__factory as VotingReputationFactory9,
 } from '../contracts/IVotingReputation/9/index.js';
 
 import { extractEvent, extractCustomEvent } from '../utils.js';
-import { Colony } from './Colony.js';
+import { type Colony } from './Colony.js';
 
 const { AddressZero } = constants;
 

--- a/packages/sdk/src/ColonyNetwork/index.ts
+++ b/packages/sdk/src/ColonyNetwork/index.ts
@@ -1,16 +1,16 @@
 export {
   ColonyNetwork,
-  ColonyNetworkOptions,
-  TokenData,
+  type ColonyNetworkOptions,
+  type TokenData,
 } from './ColonyNetwork.js';
 export {
   Colony,
-  Domain,
-  SupportedColonyContract,
+  type Domain,
+  type SupportedColonyContract,
   SupportedExtension,
-  SupportedExtensions,
+  type SupportedExtensions,
 } from './Colony.js';
 export { OneTxPayment } from './OneTxPayment.js';
 export { TokenLocking } from './TokenLocking.js';
-export { Motion, VotingReputation, Vote } from './VotingReputation.js';
+export { type Motion, VotingReputation, Vote } from './VotingReputation.js';
 export * from './tokens/index.js';

--- a/packages/sdk/src/ColonyNetwork/tokens/ColonyToken.ts
+++ b/packages/sdk/src/ColonyNetwork/tokens/ColonyToken.ts
@@ -1,7 +1,7 @@
 import type { MetaTxTokenEvents } from '@colony/events';
 
 import {
-  ColonyToken as ColonyTokenType,
+  type ColonyToken as ColonyTokenType,
   ColonyTokenFactory,
 } from '@colony/tokens';
 

--- a/packages/sdk/src/ColonyNetwork/tokens/ERC20Token.ts
+++ b/packages/sdk/src/ColonyNetwork/tokens/ERC20Token.ts
@@ -2,7 +2,7 @@ import type { BigNumber, BigNumberish } from 'ethers';
 import type { TokenEvents } from '@colony/events';
 
 import {
-  ERC20Token as ERC20TokenType,
+  type ERC20Token as ERC20TokenType,
   ERC20TokenFactory,
 } from '@colony/tokens';
 

--- a/packages/sdk/src/ColonyNetwork/tokens/ERC2612Token.ts
+++ b/packages/sdk/src/ColonyNetwork/tokens/ERC2612Token.ts
@@ -1,8 +1,8 @@
 import type { TokenEvents } from '@colony/events';
 
-import { BigNumber, BigNumberish } from 'ethers';
+import { type BigNumber, type BigNumberish } from 'ethers';
 import {
-  ERC2612Token as ERC2612TokenType,
+  type ERC2612Token as ERC2612TokenType,
   ERC2612TokenFactory,
 } from '@colony/tokens';
 

--- a/packages/sdk/src/TxCreator/ColonyTxCreator.ts
+++ b/packages/sdk/src/TxCreator/ColonyTxCreator.ts
@@ -1,23 +1,27 @@
-import { BigNumberish, ContractReceipt, ContractTransaction } from 'ethers';
 import {
-  ColonyRole,
+  type BigNumberish,
+  type ContractReceipt,
+  type ContractTransaction,
+} from 'ethers';
+import {
+  type ColonyRole,
   getPermissionProofs,
   getCreateMotionProofs,
   Id,
 } from '@colony/core';
-import { MetadataType, type VotingReputationEvents } from '@colony/events';
+import { type MetadataType, type VotingReputationEvents } from '@colony/events';
 
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
-import { Colony } from '../ColonyNetwork/index.js';
+import { type Colony } from '../ColonyNetwork/index.js';
 import { extractEvent } from '../utils.js';
 import {
-  TxCreatorConfig,
-  EventData,
-  ColonyTransaction,
-  ColonyMetaTransaction,
+  type TxCreatorConfig,
+  type EventData,
+  type ColonyTransaction,
+  type ColonyMetaTransaction,
 } from './TxCreator.js';
-import { MetaTxBaseContract, MetaTxCreator } from './MetaTxCreator.js';
-import { ParsedLogTransactionReceipt } from '../types.js';
+import { type MetaTxBaseContract, MetaTxCreator } from './MetaTxCreator.js';
+import { type ParsedLogTransactionReceipt } from '../types.js';
 
 export interface PermissionConfig {
   domain: BigNumberish;

--- a/packages/sdk/src/TxCreator/EIP2612TxCreator.ts
+++ b/packages/sdk/src/TxCreator/EIP2612TxCreator.ts
@@ -1,13 +1,17 @@
 import type { TypedDataSigner } from '@ethersproject/abstract-signer';
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
-import { BigNumberish, Signer, utils } from 'ethers';
+import { type BigNumberish, type Signer, utils } from 'ethers';
 import { Network } from '@colony/core';
-import { MetadataType } from '@colony/events';
-import { ERC2612Token as ERC2612TokenType } from '@colony/tokens';
+import { type MetadataType } from '@colony/events';
+import { type ERC2612Token as ERC2612TokenType } from '@colony/tokens';
 
-import { ColonyMetaTransaction, EventData, TxCreator } from './TxCreator.js';
-import { ParsedLogTransactionReceipt } from '../types.js';
+import {
+  type ColonyMetaTransaction,
+  type EventData,
+  TxCreator,
+} from './TxCreator.js';
+import { type ParsedLogTransactionReceipt } from '../types.js';
 
 const { splitSignature } = utils;
 

--- a/packages/sdk/src/TxCreator/MetaTxCreator.ts
+++ b/packages/sdk/src/TxCreator/MetaTxCreator.ts
@@ -1,17 +1,17 @@
 import { utils } from 'ethers';
 import { Network } from '@colony/core';
-import { MetadataType } from '@colony/events';
+import { type MetadataType } from '@colony/events';
 
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
 import type { IBasicMetaTransaction } from '../contracts/index.js';
 
 import {
-  BaseContract,
-  ColonyMetaTransaction,
-  EventData,
+  type BaseContract,
+  type ColonyMetaTransaction,
+  type EventData,
   TxCreator,
 } from './TxCreator.js';
-import { ParsedLogTransactionReceipt } from '../types.js';
+import { type ParsedLogTransactionReceipt } from '../types.js';
 
 const { arrayify, solidityKeccak256, splitSignature } = utils;
 

--- a/packages/sdk/src/TxCreator/TxCreator.ts
+++ b/packages/sdk/src/TxCreator/TxCreator.ts
@@ -1,16 +1,20 @@
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
-import { Contract, ContractReceipt, ContractTransaction } from 'ethers';
+import {
+  type Contract,
+  type ContractReceipt,
+  type ContractTransaction,
+} from 'ethers';
 import { parseLogs } from '@colony/core';
 import {
   type MetadataTypeMap,
   type VotingReputationEvents,
   IpfsMetadataEvents,
-  MetadataType,
+  type MetadataType,
 } from '@colony/events';
 
-import { ParsedLogTransactionReceipt } from '../types.js';
-import { ColonyNetwork } from '../ColonyNetwork/index.js';
+import { type ParsedLogTransactionReceipt } from '../types.js';
+import { type ColonyNetwork } from '../ColonyNetwork/index.js';
 
 export interface TxConfig<M> {
   metadataType?: M;

--- a/packages/sdk/src/TxCreator/index.ts
+++ b/packages/sdk/src/TxCreator/index.ts
@@ -7,5 +7,5 @@ export {
   type TxConfig,
   TxCreator,
 } from './TxCreator.js';
-export { MetaTxBaseContract, MetaTxCreator } from './MetaTxCreator.js';
-export { PermissionConfig, ColonyTxCreator } from './ColonyTxCreator.js';
+export { type MetaTxBaseContract, MetaTxCreator } from './MetaTxCreator.js';
+export { type PermissionConfig, ColonyTxCreator } from './ColonyTxCreator.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,13 +4,13 @@ export type { ContractReceipt, ContractTransaction } from 'ethers';
 export type { TransactionResponse } from '@ethersproject/abstract-provider';
 
 export {
-  AnnotationData,
-  ColonyData,
-  DecisionData,
-  DomainData,
-  Metadata,
+  type AnnotationData,
+  type ColonyData,
+  type DecisionData,
+  type DomainData,
+  type Metadata,
   MetadataType,
-  SafeInfo,
+  type SafeInfo,
   TeamColor,
 } from '@colony/events';
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,8 +1,8 @@
 import type { Interface } from '@ethersproject/abi';
 
-import { ContractReceipt } from 'ethers';
+import { type ContractReceipt } from 'ethers';
 
-import { ParsedLogTransactionReceipt } from './types.js';
+import { type ParsedLogTransactionReceipt } from './types.js';
 
 /** Extract event args from a contract receipt */
 // TODO: Make it possible to retrieve multiple events of the same kind

--- a/packages/tokens/.eslintrc
+++ b/packages/tokens/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    },
     "rules": {
         "camelcase": [
             "error",

--- a/packages/tokens/src/clients/TokenClient.ts
+++ b/packages/tokens/src/clients/TokenClient.ts
@@ -5,13 +5,13 @@ import { constants } from 'ethers';
 import { ClientType, TokenClientType } from '../constants.js';
 import {
   MetaTxToken__factory as MetaTxTokenFactory,
-  MetaTxToken,
+  type MetaTxToken,
 } from '../contracts/index.js';
 import {
   TokenERC20__factory as TokenERC20Factory,
-  TokenERC20,
+  type TokenERC20,
   TokenERC2612__factory as TokenERC2612Factory,
-  TokenERC2612,
+  type TokenERC2612,
 } from '../contracts/static/index.js';
 
 const { AddressZero } = constants;

--- a/packages/tokens/src/clients/TokenLockingClient.ts
+++ b/packages/tokens/src/clients/TokenLockingClient.ts
@@ -3,7 +3,7 @@ import type { SignerOrProvider } from '@colony/core';
 import { ClientType } from '../constants.js';
 
 import {
-  TokenLocking,
+  type TokenLocking,
   TokenLocking__factory as TokenLockingFactory,
 } from '../contracts/index.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,9 +264,9 @@ importers:
       prettier:
         specifier: ^2.6.1
         version: 2.8.0
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.15.11)(typescript@5.1.6)
+      tsx:
+        specifier: ^4.19.1
+        version: 4.19.1
       typedoc:
         specifier: ^0.24.8
         version: 0.24.8(typescript@5.1.6)
@@ -860,9 +860,27 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
+  /@esbuild/aix-ppc64@0.23.1:
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.23.1:
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -878,9 +896,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.23.1:
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.23.1:
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -896,9 +932,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.23.1:
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.23.1:
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -914,9 +968,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.23.1:
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.23.1:
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -932,6 +1004,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.23.1:
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -941,9 +1022,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm@0.23.1:
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.18.20:
     resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.23.1:
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
@@ -968,9 +1067,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64@0.23.1:
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.18.20:
     resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.23.1:
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
@@ -986,9 +1103,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64@0.23.1:
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.18.20:
     resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.23.1:
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -1004,9 +1139,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x@0.23.1:
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64@0.18.20:
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.23.1:
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -1022,9 +1175,36 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.23.1:
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.18.20:
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
@@ -1040,9 +1220,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.23.1:
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.18.20:
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.23.1:
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -1058,9 +1256,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.23.1:
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.23.1:
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -3188,6 +3404,38 @@ packages:
       '@esbuild/win32-x64': 0.18.20
     dev: true
 
+  /esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -3687,6 +3935,14 @@ packages:
     dev: true
     optional: true
 
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
 
@@ -3734,6 +3990,12 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
+
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5507,6 +5769,10 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
@@ -6184,6 +6450,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.0.4
+    dev: true
+
+  /tsx@4.19.1:
+    resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /tty-table@4.2.1:


### PR DESCRIPTION
## Description

`ts-node` seems to be [completely broken](https://stackoverflow.com/questions/62096269/unknown-file-extension-ts-for-a-typescript-file) for esm packages, so I opted to use [tsx](https://www.npmjs.com/package/tsx) instead.

This change required some adjustments to the type imports, specifically mentioning `type` exports or imports explicitly. For that I added an eslint rule that is also able to fix it automatically.