### PR TITLE
Wait for Metatransaction to be created before trying to fetch it

### DIFF
--- a/.changeset/lovely-wolves-suffer.md
+++ b/.changeset/lovely-wolves-suffer.md
@@ -1,0 +1,5 @@
+---
+"@colony/sdk": patch
+---
+
+Wait for Metatransaction to be created before trying to get it

--- a/packages/sdk/src/TxCreator/TxCreator.ts
+++ b/packages/sdk/src/TxCreator/TxCreator.ts
@@ -280,6 +280,7 @@ export class TxCreator<
         'Could not get transaction hash from broadcaster response',
       );
     }
+    await provider.waitForTransaction(parsed.data.txHash);
 
     return provider.getTransaction(parsed.data.txHash);
   }


### PR DESCRIPTION
## Description

This PR adds a `waitForTransaction` to actually wait for the transaction to exist before trying to fetch it.
