### PR TITLE
Fix/643 CLNY on Arbitrum One Address Constant

### DIFF
--- a/.changeset/green-carrots-double.md
+++ b/.changeset/green-carrots-double.md
@@ -1,0 +1,5 @@
+---
+"@colony/core": major
+---
+
+clny token constant fix

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -173,7 +173,7 @@ export namespace Tokens {
     /** ETH on Arbitrum One */
     ETH = '0x0000000000000000000000000000000000000000',
     /** CLNY on Arbitrum One */
-    CLNY = '0xcccccdcc0ccf6c708d860e19353c5f9a49accccc',
+    CLNY = '0xD611b29dc327723269Bd1e53Fe987Ee71A24B234',
     /** USDC on Arbitrum One */
     USDC = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   }


### PR DESCRIPTION
## Description

- [x] Investigated and identified the root cause of the `getBalance` issue.

**Findings** 🔍

- The issue is **not caused by the example implementation** or the `getBalance` function itself, but rather by the `Tokens.ArbitrumOne.CLNY` constant.
- When querying the **native token in the root pool**, `getBalance` works **without any issues**.
- Similarly, querying **other tokens** such as **USDC or ETH** does not cause any errors.
- However, the `0xcccccdcc0ccf6c708d860e19353c5f9a49accccc` address used for **ArbitrumOne CLNY** is **neither a valid token contract nor a Colony Network contract**.
- The correct address for **CLNY Network Token** has been updated to:  
  `0xD611b29dc327723269Bd1e53Fe987Ee71A24B234`.

**Changes** 🏗

- Updated the **CLNY Network Token address** to the correct one.

## Additionally ❓

- Do I need to make any additional improvements to `getBalance` or the example implementation as described in the issue?

## TODO

- [ ] Address any necessary improvements based on feedback.

(Resolves | Contributes to) #31415
